### PR TITLE
Various bug fixes

### DIFF
--- a/spine/driver.py
+++ b/spine/driver.py
@@ -335,6 +335,7 @@ class Driver:
 
         # Initialize the data loader/reader
         self.loader = None
+        self.unwrapper = None
         if loader is not None:
             # Initialize the torch data loader
             self.watch.initialize('load')
@@ -534,7 +535,7 @@ class Driver:
             self.watch.update(self.model.watch, 'model')
 
         # 3. Unwrap
-        if self.unwrap:
+        if self.unwrapper is not None:
             self.watch.start('unwrap')
             data = self.unwrapper(data)
             self.watch.stop('unwrap')

--- a/spine/driver.py
+++ b/spine/driver.py
@@ -409,7 +409,10 @@ class Driver:
 
         # If there is only one file, done
         if len(file_names) == 1:
-            return prefix
+            if not split_output:
+                return prefix, prefix
+            else:
+                return prefix, [prefix]
 
         # Otherwise, form the suffix from the first and last file names
         first = os.path.splitext(file_names[0][len(prefix):])

--- a/spine/io/read/base.py
+++ b/spine/io/read/base.py
@@ -93,8 +93,10 @@ class ReaderBase:
             Maximum number of loaded file names to be printed
         """
         # Some basic checks
+        assert file_keys is not None, (
+                "No input `file_keys` provided, abort.")
         assert limit_num_files is None or limit_num_files > 0, (
-                "If `limit_num_files` is provided, it must be larger than 0")
+                "If `limit_num_files` is provided, it must be larger than 0.")
 
         # If the file_keys points to a single text file, it must be a text
         # file containing a list of file paths. Parse it to a list.
@@ -103,7 +105,7 @@ class ReaderBase:
             # If the file list is a text file, extract the list of paths
             assert os.path.isfile(file_keys), (
                     "If the `file_keys` are specified as a single string, "
-                    "it must be the path to a text file with a file list")
+                    "it must be the path to a text file with a file list.")
             with open(file_keys, 'r', encoding='utf-8') as f:
                 file_keys = f.read().splitlines()
 
@@ -114,7 +116,7 @@ class ReaderBase:
         for file_key in file_keys:
             file_paths = glob.glob(file_key)
             assert file_paths, (
-                    f"File key {file_key} yielded no compatible path")
+                    f"File key {file_key} yielded no compatible path.")
             for path in file_paths:
                 if (limit_num_files is not None and
                     len(self.file_paths) > limit_num_files):


### PR DESCRIPTION
Minor bug fixes:
- Passing a single file to the driver used to cause a crash due to the `split_output` feature
- `unwrap: true` would cause a crash when used in a setting where there is no `loader`
- `file_keys: null` would cause a not very explicit crash (now clear to the end user)
- `to_numpy: true` was incompatible with a training process, now compatible