### PR TITLE
Allow passing a weight_list in the form of a text file

### DIFF
--- a/src/spine/bin/cli.py
+++ b/src/spine/bin/cli.py
@@ -24,6 +24,7 @@ def main(
     log_dir: str,
     weight_prefix: str,
     weight_path: str,
+    weight_list: str,
     config_overrides: List[str],
 ):
     """Main driver for training/validation/inference/analysis.
@@ -56,6 +57,9 @@ def main(
         Path to the directory for storing the training weights
     weight_path : str
         Path to a weight file or pattern for multiple weight files to load
+        the model weights
+    weight_list : str
+        Path to a text file containing a list of weight file paths to load
         the model weights
     config_overrides : List[str]
         List of config overrides in the form "key.path=value"
@@ -118,6 +122,8 @@ def main(
     # Override the weight loading path if provided
     if weight_path is not None:
         cfg["model"]["weight_path"] = weight_path
+    if weight_list is not None:
+        cfg["model"]["weight_list"] = weight_list
 
     # Apply any generic config overrides from --set arguments
     if config_overrides:
@@ -194,11 +200,11 @@ For ML training/inference functionality, ensure PyTorch is installed:
     )
 
     # Add mutually exclusive group for source input
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument(
+    source_group = parser.add_mutually_exclusive_group()
+    source_group.add_argument(
         "-s", "--source", nargs="+", type=str, help="List of paths to the input files"
     )
-    group.add_argument(
+    source_group.add_argument(
         "-S",
         "--source-list",
         help="Path to a text file containing a list of data file paths",
@@ -234,10 +240,15 @@ For ML training/inference functionality, ensure PyTorch is installed:
     )
 
     # Add path to weight file or pattern for loading model weights
-    parser.add_argument(
+    weight_group = parser.add_mutually_exclusive_group()
+    weight_group.add_argument(
         "--weight-path",
         help="Path string a weight file or pattern for multiple weight "
         "files to load model weights",
+    )
+    weight_group.add_argument(
+        "--weight-list",
+        help="Path to a text file containing a list of weight file paths",
     )
 
     # Add option to dynamically override any config parameter using dot notation
@@ -280,6 +291,7 @@ For ML training/inference functionality, ensure PyTorch is installed:
         log_dir=args.log_dir,
         weight_prefix=args.weight_prefix,
         weight_path=args.weight_path,
+        weight_list=args.weight_list,
         config_overrides=args.config_overrides,
     )
 

--- a/src/spine/main.py
+++ b/src/spine/main.py
@@ -6,7 +6,6 @@ object(s) used to execute/train ML models, post-processors, analysis
 scripts, writers and profilers.
 """
 
-import glob
 import os
 from typing import Optional, Tuple
 
@@ -131,16 +130,16 @@ def inference_single(cfg: dict) -> None:
 
     # Find the set of weights to run the inference on
     preloaded, weights = False, []
-    if driver.model is not None and driver.model.weight_path is not None:
-        preloaded = os.path.isfile(driver.model.weight_path)
-        weights = sorted(glob.glob(driver.model.weight_path))
-        if not preloaded and len(weights):
+    if driver.model is not None:
+        weights = driver.model.weight_path
+        if weights is None or isinstance(weights, str):
+            preloaded = True
+            weights = [weights]
+        else:
             weight_list = " - " + "\n - ".join(weights)
             logger.info(
                 "Looping over %d set of weights:\n%s", len(weights), weight_list
             )
-    if not weights:
-        weights = [None]
 
     # Loop over the weights, run the inference loop
     for weight in weights:

--- a/src/spine/model/manager.py
+++ b/src/spine/model/manager.py
@@ -25,6 +25,7 @@ class ModelManager:
         network_input,
         loss_input=None,
         weight_path=None,
+        weight_list=None,
         train=None,
         to_numpy=False,
         time_dependent_loss=False,
@@ -49,6 +50,8 @@ class ModelManager:
             List of keys of parsed objects to input into the loss forward
         weight_path : str, optional
             Path to global model weights to load
+        weight_list : str, optional
+            Path to a text file containing a list of weight file paths to load
         to_numpy : int, default False
             Cast model output to numpy ndarray
         time_dependant_loss : bool, default False
@@ -135,9 +138,27 @@ class ModelManager:
         # If requested, freeze some/all the model weights
         self.freeze_weights()
 
-        # If requested, load the some/all the model weights
+        # Parse the list of weight files to consider for loading
         self.weight_path = weight_path
-        self.load_weights(weight_path)
+        if weight_path is not None:
+            # If a path is provided, check if it is an simple path or a wildcard pattern
+            if weight_list is not None:
+                raise ValueError("Cannot specify both `weight_path` and `weight_list`.")
+            if not os.path.isfile(weight_path):
+                if self.train or not glob.glob(weight_path):
+                    raise ValueError(f"Weight file not found: {weight_path}")
+                self.weight_path = glob.glob(weight_path)
+
+        elif weight_list is not None:
+            with open(weight_list, "r", encoding="utf-8") as f:
+                self.weight_path = [line.strip() for line in f if line.strip()]
+                if not self.weight_path:
+                    raise ValueError(f"No weight paths found in {weight_list}.")
+
+        # Load the weights only if a single weight file is provided. If multiple weight
+        # files are provided, the loading will be handled in a loop in the main driver.
+        if self.weight_path is None or isinstance(self.weight_path, str):
+            self.load_weights(self.weight_path)
 
         # If the execution is distributed, wrap with DDP
         if self.distributed:

--- a/src/spine/model/manager.py
+++ b/src/spine/model/manager.py
@@ -393,12 +393,8 @@ class ModelManager:
 
         # Loop over provided model paths
         for module, weight_path, model_name in weight_paths:
-            # Check that the requested weight file can be found. If the path
-            # points at > 1 file, skip for now (loaded in a loop later)
+            # Module-level weight paths must resolve to a single checkpoint.
             if not os.path.isfile(weight_path):
-                if not self.train and glob.glob(weight_path):
-                    continue
-
                 raise ValueError(
                     "Weight file not found for module " f"{module}: {weight_path}"
                 )


### PR DESCRIPTION
## Description
This PR adds support for providing a list of inference checkpoints, either through a wildcard-expanded `weight_path` or through a new `weight_list` text file input.

It updates the CLI, model manager, and inference driver so that:
- a single checkpoint is still preloaded once and used normally
- multiple checkpoints can be iterated over cleanly during inference
- `--weight-path` and `--weight-list` are treated as mutually exclusive inputs
- module-level `weight_path` values are validated more strictly and must resolve to a single file

## Motivation and Context
This change is required to support running inference over multiple saved checkpoints in a controlled way without manually editing the config between runs.

It fixes an issue where inference weight handling was too rigid and could not cleanly consume a list of checkpoints. It also fixes a bug introduced while adding that support, where passing a single `weight_path` could be mishandled and lead to repeated processing behavior.

Fixes #115

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code quality improvement (refactoring, type hints, etc.)
- [ ] Performance improvement

## How Has This Been Tested?
I tested the different weight-loading modes and reviewed the normalization flow from CLI input through model initialization and inference execution.

- [x] Verified that a single `weight_path` is treated as one checkpoint and no longer causes repeated iteration behavior
- [x] Verified that multiple checkpoints can be provided and iterated over during inference
- [x] Verified that `--weight-path` and `--weight-list` are mutually exclusive at the CLI level
- [x] Verified that module-level `weight_path` validation now fails cleanly if the path is not a single file
- [x] Ran formatting/lint hooks during commit (`black`, `isort`, `flake8`, pre-commit checks)

**Test Configuration**:
- OS: macOS
- Python version: local development environment
- SPINE version: `feature/weight_list`, commit `ca4495b9`

To reproduce:
1. Run inference with a single checkpoint using `--weight-path /path/to/model.ckpt`.
2. Run inference with multiple checkpoints using either:
   - `--weight-path "/path/to/snapshots/*.ckpt"`
   - `--weight-list /path/to/weights.txt`
3. Confirm that the single-checkpoint case runs once with a preloaded model.
4. Confirm that the multi-checkpoint case loops over the resolved checkpoint list and reloads weights between runs.
5. Confirm that specifying both `--weight-path` and `--weight-list` raises an error.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots / Event Displays (if applicable)
None included.

## Additional Notes
A few implementation details are worth calling out for reviewers:

- The normalization of inference weights now happens in `ModelManager`, which stores either:
  - `None`
  - a single checkpoint path as a string
  - a list of checkpoint paths
- `inference_single` now branches on that normalized representation, so single-checkpoint and multi-checkpoint inference follow different but explicit paths.
- The new `weight_list` option is intended for inference workflows where checkpoint ordering should be controlled manually rather than through a filesystem pattern.
- Module-level `weight_path` entries are now required to point to a single file; wildcard-style multi-file behavior is only supported for the top-level inference checkpoint selection.