### PR TITLE
Clean up output writer handling

### DIFF
--- a/src/spine/io/core/write/csv.py
+++ b/src/spine/io/core/write/csv.py
@@ -1,6 +1,8 @@
 """Module to write log files to CSV."""
 
 import os
+from types import TracebackType
+from typing import Any, Dict, Optional, Type
 
 __all__ = ["CSVWriter"]
 
@@ -59,12 +61,12 @@ class CSVWriter:
 
     def __init__(
         self,
-        file_name="output.csv",
-        overwrite=False,
-        append=False,
-        accept_missing=False,
-        buffer_size=1,
-    ):
+        file_name: str = "output.csv",
+        overwrite: bool = False,
+        append: bool = False,
+        accept_missing: bool = False,
+        buffer_size: int = 1,
+    ) -> None:
         """Initialize the basics of the output file.
 
         Parameters
@@ -91,7 +93,7 @@ class CSVWriter:
         self.append_file = append
         self.accept_missing = accept_missing
         self.buffer_size = buffer_size
-        self.result_keys = None
+        self.keys = None
         self.file_handle = None
 
         # If appending, check that the file exists and read the header
@@ -104,9 +106,9 @@ class CSVWriter:
                 )
 
             with open(self.file_name, "r", encoding="utf-8") as out_file:
-                self.result_keys = out_file.readline().strip().split(",")
+                self.keys = out_file.readline().strip().split(",")
 
-    def __enter__(self):
+    def __enter__(self) -> "CSVWriter":
         """Context manager entry. Opens the file handle.
 
         Returns
@@ -117,7 +119,12 @@ class CSVWriter:
         self.open()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> bool:
         """Context manager exit. Closes the file handle.
 
         Parameters
@@ -126,7 +133,7 @@ class CSVWriter:
             Exception type if an exception occurred
         exc_val : Exception
             Exception value if an exception occurred
-        exc_tb : traceback
+        exc_tb : TracebackType
             Exception traceback if an exception occurred
 
         Returns
@@ -137,7 +144,7 @@ class CSVWriter:
         self.close()
         return False
 
-    def open(self):
+    def open(self) -> None:
         """Open the file handle for writing.
 
         If the file handle is already open, this does nothing.
@@ -150,7 +157,7 @@ class CSVWriter:
                 self.file_name, mode, encoding="utf-8", buffering=self.buffer_size
             )
 
-    def close(self):
+    def close(self) -> None:
         """Close the file handle and ensure all data is written.
 
         This flushes any buffered data before closing. After calling
@@ -161,7 +168,7 @@ class CSVWriter:
             self.file_handle.close()
             self.file_handle = None
 
-    def flush(self):
+    def flush(self) -> None:
         """Explicitly flush the file buffer to disk.
 
         This forces any buffered data to be written to disk without
@@ -171,16 +178,16 @@ class CSVWriter:
         if self.file_handle is not None:
             self.file_handle.flush()
 
-    def create(self, result_blob):
+    def create(self, data: Dict[str, Any]) -> None:
         """Initialize the header of the CSV file, record the keys to be stored.
 
         Parameters
         ----------
-        result_blob : dict
+        data : dict
             Dictionary containing the output of the reconstruction chain
         """
         # Save the list of keys to store
-        self.result_keys = list(result_blob.keys())
+        self.keys = list(data.keys())
 
         # Open the file handle if not already open
         self.open()
@@ -189,10 +196,10 @@ class CSVWriter:
         assert self.file_handle is not None
 
         # Create a header and write it to file
-        header_str = ",".join(self.result_keys)
+        header_str = ",".join(self.keys)
         self.file_handle.write(header_str + "\n")
 
-    def append(self, result_blob):
+    def append(self, data: Dict[str, Any]) -> None:
         """Append the CSV file with the output.
 
         Parameters
@@ -201,16 +208,16 @@ class CSVWriter:
             Dictionary containing the output of the reconstruction chain
         """
         # Fetch the values to store
-        if self.result_keys is None:
+        if self.keys is None:
             # If this function has never been called, initialiaze the CSV file
-            self.create(result_blob)
+            self.create(data)
 
         else:
             # If it has, check that the list of keys is identical
-            if list(result_blob.keys()) != self.result_keys:
+            if list(data.keys()) != self.keys:
                 # If it is not identical, check the discrepancies
-                missing = self.array_diff(self.result_keys, result_blob.keys())
-                excess = self.array_diff(result_blob.keys(), self.result_keys)
+                missing = self.array_diff(self.keys, data.keys())
+                excess = self.array_diff(data.keys(), self.keys)
                 if len(excess):
                     raise AssertionError(
                         "There are keys in this entry which were not "
@@ -225,10 +232,10 @@ class CSVWriter:
                         f"Missing keys: {list(missing)}"
                     )
 
-                new_result_blob = {k: -1 for k in self.result_keys}
-                for k, v in result_blob.items():
-                    new_result_blob[k] = v
-                result_blob = new_result_blob
+                new_data = {k: -1 for k in self.keys}
+                for k, v in data.items():
+                    new_data[k] = v
+                data = new_data
 
         # Ensure file is open
         if self.file_handle is None:
@@ -236,10 +243,10 @@ class CSVWriter:
 
         # File handle is guaranteed to be open here
         assert self.file_handle is not None
-        assert self.result_keys is not None
+        assert self.keys is not None
 
         # Append to file (no open/close overhead!)
-        result_str = ",".join([str(result_blob[k]) for k in self.result_keys])
+        result_str = ",".join([str(data[k]) for k in self.keys])
         self.file_handle.write(result_str + "\n")
 
     @staticmethod

--- a/src/spine/io/core/write/hdf5.py
+++ b/src/spine/io/core/write/hdf5.py
@@ -2,6 +2,7 @@
 
 import os
 from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import h5py
 import numpy as np
@@ -39,22 +40,29 @@ class HDF5Writer:
 
     def __init__(
         self,
-        file_name=None,
-        keys=None,
-        skip_keys=None,
-        dummy_ds=None,
-        overwrite=False,
-        append=False,
-        prefix=None,
-        split=False,
-        lite=False,
-    ):
+        file_name: Optional[str] = None,
+        prefix: Optional[Union[str, List[str]]] = None,
+        suffix: str = "spine",
+        keys: Optional[List[str]] = None,
+        skip_keys: Optional[List[str]] = None,
+        dummy_ds: Optional[Dict[str, str]] = None,
+        overwrite: bool = False,
+        append: bool = False,
+        split: bool = False,
+        lite: bool = False,
+    ) -> None:
         """Initializes the basics of the output file.
 
         Parameters
         ----------
         file_name : str, optional
             Name of the output HDF5 file
+        prefix : str or List[str], optional
+            Input file prefix. It will be use to form the output file name,
+            provided that no file_name is explicitly provided. Must be a list
+            with one prefix per input file when `split` is `True`.
+        suffix : str, default "spine"
+            Suffix to add to the output file name if it is built from the input
         keys : List[str], optional
             List of data product keys to store. If not specified, store everything
         skip_keys: List[str], optionl
@@ -66,67 +74,107 @@ class HDF5Writer:
             If `True`, overwrite the output file if it already exists
         append : bool, default False
             If `True`, add new values to the end of an existing file
-        prefix : str, optional
-            Input file prefix. It will be use to form the output file name,
-            provided that no file_name is explicitely provided
         split : bool, default False
             If `True`, split the output to produce one file per input file
         lite : bool, default False
             If `True`, the lite version of objects is stored (drop point indexes)
         """
-        # If the output file name is not provided, use the input file prefix(es)
-        if not file_name:
-            assert prefix is not None, (
-                "If the output `file_name` is not provided, must provide"
-                "the input file `prefix` to build it from."
-            )
-            if not split:
-                file_name = f"{prefix}_spine.h5"
-            else:
-                file_name = [f"{pre}_spine.h5" for pre in prefix]
-
-        elif split:
-            dir_name = os.path.dirname(file_name)
-            if dir_name:
-                dir_name += "/"
-            base_name = os.path.splitext(os.path.basename(file_name))[0]
-            if not prefix:
-                file_name = [
-                    f"{dir_name}{base_name}_{i}.h5" for i in range(len(prefix))
-                ]
-            else:
-                file_name = [f"{dir_name}{pre}_{base_name}.h5" for pre in prefix]
+        # Build the output file name(s) from the input prefix(es) if not provided
+        self.file_names = self.get_file_names(file_name, prefix, suffix, split)
 
         # Check that the output file(s) do(es) not already exist, if requested
-        if not overwrite:
-            if not split:
+        if not overwrite and not append:
+            for file_name in self.file_names:
                 if os.path.isfile(file_name):
                     raise FileExistsError(f"File with name {file_name} already exists.")
-            else:
-                for f in file_name:
-                    if os.path.isfile(f):
-                        raise FileExistsError(f"File with name {f} already exists.")
 
-        # Store persistent attributes
-        self.file_name = file_name
+        # Store other persistent attributes
         self.append = append
         self.split = split
         self.lite = lite
-        self.ready = False
-        self.object_dtypes = []  # TODO: make this a set
 
-        self.keys = keys
+        self.keys = set(keys) if keys is not None else None
         self.skip_keys = skip_keys
-        self.dummy_ds = dummy_ds
 
         # Initialize dummy dataset placeholders once
+        self.dummy_ds = dummy_ds
         if self.dummy_ds is not None:
-            for key, class_name in dummy_ds.items():
+            for key, class_name in self.dummy_ds.items():
                 self.dummy_ds[key] = getattr(spine.data, class_name)()
 
         # Initialize attributes to be stored when the output file is created
+        self.ready = False
+        self.object_dtypes = []
         self.type_dict = None
         self.event_dtype = None
+
+    @staticmethod
+    def get_file_names(
+        file_name: Optional[str] = None,
+        prefix: Optional[Union[str, List[str]]] = None,
+        suffix: str = "spine",
+        split: bool = False,
+    ) -> List[str]:
+        """Build output file name(s) from an explicit name or input prefix(es).
+
+        Logic is as follows:
+        - If `split` is `False` and `file_name` is provided, use `file_name`
+        - If `split` is `False` and `file_name` is not provided, build the file name
+          from the input `prefix` by adding a suffix
+        - If `split` is `True` and `file_name` is not provided, build the file names
+          from the input `prefix` by adding a suffix
+        - If `split` is `True` and `file_name` is provided, build the file names from
+          `file_name` by adding an index, unless there is only one input prefix,
+          in which case use `file_name` as is
+
+        Parameters
+        ----------
+        file_name : str, optional
+            Name of the output HDF5 file. If not provided, it will be built from the
+            input prefix(es).
+        prefix : str or List[str], optional
+            Input file prefix(es).
+        suffix : str, default "spine"
+            Suffix to add to the output file name if it is built from the input
+        split : bool, default False
+            If `True`, split the output to produce one file per input file.
+
+        Returns
+        -------
+        List[str]
+            List of output file names.
+        """
+        # If the output is not split, use the provided file name or build it from the prefix
+        if not split:
+            if file_name:
+                return [file_name]
+
+            assert prefix is not None and isinstance(prefix, str), (
+                "If the output `file_name` is not provided, must provide "
+                "the input file `prefix` to build it from."
+            )
+            return [f"{prefix}_{suffix}.h5"]
+
+        # If the output is split, build the file names from the provided one by
+        # adding an index, unless there is only one prefix per file,
+        # in which case use the provided name as is
+        assert prefix is not None and not isinstance(prefix, str), (
+            "If `split` is enabled, must provide one `prefix` per input file "
+            "to determine the number of output files."
+        )
+
+        if file_name and len(prefix) == 1:
+            return [file_name]
+
+        if not file_name:
+            return [f"{pre}_{suffix}.h5" for pre in prefix]
+
+        # Otherwise, build the file names from the provided one by adding an index
+        dir_name = os.path.dirname(file_name)
+        base_name = os.path.splitext(os.path.basename(file_name))[0]
+        return [
+            os.path.join(dir_name, f"{base_name}_{i}.h5") for i in range(len(prefix))
+        ]
 
     @dataclass
     class DataFormat:
@@ -134,11 +182,11 @@ class HDF5Writer:
 
         Attributes
         ----------
-        dtype : type, optional
+        dtype : Union[type, List[Tuple[str, type]]], optional
             Data type
         class_name : str, optional
             Name of the class the information comes from
-        width : int, defaul t0
+        width : Union[int, List[int]], default 0
             Width of the tensor to store, if it is a tensor
         merge : bool, default False
             Whether to merge lists of arrays into a single dataset
@@ -146,33 +194,47 @@ class HDF5Writer:
             Whether the data is a scalar object or not
         """
 
-        dtype: str = None
-        class_name: str = None
-        width: int = 0
+        dtype: Optional[Union[type, List[Tuple[str, type]]]] = None
+        class_name: Optional[str] = None
+        width: Union[int, List[int]] = 0
         merge: bool = False
         scalar: bool = False
 
-    def create(self, data, cfg=None):
-        """Create the output file structure based on the data dictionary.
+    def create(
+        self,
+        data: Dict[str, Any],
+        cfg: Optional[Dict[str, Any]] = None,
+        append: bool = False,
+    ) -> None:
+        """Initialize the output file structure based on the data dictionary.
 
         Parameters
         ----------
-        data : dict
+        data : Dict[str, Any]
             Dictionary of data products
-        cfg : dict
+        cfg : Dict[str, Any]
             Dictionary containing the complete SPINE configuration
+        append : bool, default False
+            If `True`, load existing files if present and create missing files
         """
-        # Initialize a dictionary to store keys and their properties
-        self.type_dict = {}
-
         # Fetch the required keys to be stored and register them
         self.keys = self.get_stored_keys(data)
-        for key in self.keys:
-            self.register_key(data, key)
+
+        # Fetch the data type information for each key and store it in a dictionary
+        self.type_dict, self.object_dtypes = self.get_data_types(data, self.keys)
 
         # Initialize the output HDF5 file(s)
-        file_names = [self.file_name] if not self.split else self.file_name
-        for file_name in file_names:
+        for file_name in self.file_names:
+            if append and os.path.isfile(file_name):
+                with h5py.File(file_name, "r") as out_file:
+                    event_obj = out_file["events"]
+                    assert isinstance(event_obj, h5py.Dataset), (
+                        "Expected dataset for events to be a Dataset, but got "
+                        f"{type(event_obj)} instead."
+                    )
+                    self.event_dtype = getattr(event_obj, "dtype")
+                continue
+
             with h5py.File(file_name, "w") as out_file:
                 # Initialize the info dataset that stores environment parameters
                 out_file.create_dataset("info", (0,), maxshape=(None,), dtype=None)
@@ -181,26 +243,26 @@ class HDF5Writer:
                     out_file["info"].attrs["cfg"] = yaml.dump(cfg)
 
                 # Initialize the event dataset and their reference array datasets
-                self.initialize_datasets(out_file)
+                self.initialize_datasets(out_file, self.type_dict)
 
         # Mark file(s) as ready for use
         self.ready = True
 
-    def get_stored_keys(self, data):
+    def get_stored_keys(self, data: Dict[str, Any]) -> Set[str]:
         """Get the list of data product keys to store.
 
         Parameters
         ----------
-        data : dict
+        data : Dict[str, Any]
             Dictionary of data products
 
         Returns
         -------
-        keys : list
+        keys : Set[str]
             List of data keys to store to file
         """
         # If the keys were already produced, nothing to do
-        if self.ready:
+        if self.ready and self.keys is not None:
             return self.keys
 
         # Check that the required/ keys make sense,
@@ -208,7 +270,7 @@ class HDF5Writer:
             self.skip_keys is None
         ), "Must not specify both `keys` or `skip_keys`."
 
-        # Translate keys/skip_keys into a single list
+        # Translate keys/skip_keys into a single set
         keys = {"index"}
         if self.keys is None:
             keys.update(data.keys())
@@ -240,44 +302,78 @@ class HDF5Writer:
 
         return keys
 
-    def register_key(self, data, key):
+    def get_data_types(
+        self, data: Dict[str, Any], keys: Set[str]
+    ) -> Tuple[Dict[str, DataFormat], List[List[Tuple[str, type]]]]:
+        """Get the data type information for each key.
+
+        Parameters
+        ----------
+        data : Dict[str, Any]
+            Dictionary of data products
+
+        Returns
+        -------
+        type_dict : Dict[str, DataFormat]
+            Dictionary containing the data type information for each key
+        object_dtypes : List[List[Tuple[str, type]]]
+            List of composite object dtypes found in the data
+        """
+        # Loop over the keys and get the data type information for each of them, store it
+        type_dict = {}
+        object_dtypes = []
+        for key in keys:
+            type_dict[key] = self.get_data_type(data, key)
+            if (
+                type_dict[key].class_name is not None
+                and type_dict[key].dtype not in object_dtypes
+            ):
+                object_dtypes.append(type_dict[key].dtype)
+
+        return type_dict, object_dtypes
+
+    def get_data_type(self, data: Dict[str, Any], key: str) -> DataFormat:
         """Identify the dtype and shape objects to be dealt with.
 
         Parameters
         ----------
-        data : dict
+        data : Dict[str, Any]
             Dictionary containing the information to be stored
-        key : string
+        key : str
             Dictionary key name
+
+        Returns
+        -------
+        DataFormat
+            DataFormat object containing the data type information for the key
         """
         # Initialize a type object for this output key
-        self.type_dict[key] = self.DataFormat()
+        data_format = self.DataFormat()
 
         # Store the necessary information to know how to store a key
         if np.isscalar(data[key]):
             # Single scalar for the entire batch (e.g. accuracy, loss, etc.)
             if isinstance(data[key], str):
-                self.type_dict[key].dtype = h5py.string_dtype()
+                data_format.dtype = h5py.string_dtype()
             else:
-                self.type_dict[key].dtype = type(data[key])
-            self.type_dict[key].scalar = True
+                data_format.dtype = type(data[key])
+            data_format.scalar = True
 
         else:
             if np.isscalar(data[key][0]):
                 # List containing a single scalar per batch ID
                 if isinstance(data[key][0], str):
-                    self.type_dict[key].dtype = h5py.string_dtype()
+                    data_format.dtype = h5py.string_dtype()
                 else:
-                    self.type_dict[key].dtype = type(data[key][0])
-                self.type_dict[key].scalar = True
+                    data_format.dtype = type(data[key][0])
+                data_format.scalar = True
 
             elif not hasattr(data[key][0], "__len__"):
                 # List containing one single non-standard object per batch ID
                 object_dtype = self.get_object_dtype(data[key][0])
-                self.object_dtypes.append(object_dtype)
-                self.type_dict[key].dtype = object_dtype
-                self.type_dict[key].scalar = True
-                self.type_dict[key].class_name = data[key][0].__class__.__name__
+                data_format.dtype = object_dtype
+                data_format.scalar = True
+                data_format.class_name = data[key][0].__class__.__name__
 
             else:
                 # List containing a list/array of objects per batch ID
@@ -299,44 +395,45 @@ class HDF5Writer:
 
                         # If the default value is an array, unwrap as such
                         if isinstance(ref_obj, np.ndarray):
-                            self.type_dict[key].width = [0]
-                            self.type_dict[key].merge = True
+                            data_format.width = [0]
+                            data_format.merge = True
 
                 if not hasattr(ref_obj, "__len__"):
                     # List containing a single list of objects per batch ID
                     object_dtype = self.get_object_dtype(ref_obj)
-                    self.object_dtypes.append(object_dtype)
-                    self.type_dict[key].dtype = object_dtype
-                    self.type_dict[key].class_name = ref_obj.__class__.__name__
+                    data_format.dtype = object_dtype
+                    data_format.class_name = ref_obj.__class__.__name__
 
                 elif not isinstance(ref_obj, list) and not ref_obj.dtype == object:
                     # List containing a single ndarray of scalars per batch ID
-                    self.type_dict[key].dtype = ref_obj.dtype
+                    data_format.dtype = ref_obj.dtype
                     if len(ref_obj.shape) == 2:
-                        self.type_dict[key].width = ref_obj.shape[1]
+                        data_format.width = ref_obj.shape[1]
 
                 elif isinstance(ref_obj, (list, np.ndarray)):
                     # List containing a list/array of ndarrays per batch ID
                     widths = []
+                    same_width = True
                     for el in ref_obj:
-                        width, same_width = 0, 0
-                        same_width = True
+                        width = 0
                         if len(el.shape) == 2:
                             width = el.shape[1]
                         widths.append(width)
                         same_width &= width == widths[0]
 
-                    self.type_dict[key].dtype = ref_obj[0].dtype
-                    self.type_dict[key].width = widths
-                    self.type_dict[key].merge = same_width
+                    data_format.dtype = ref_obj[0].dtype
+                    data_format.width = widths
+                    data_format.merge = same_width
 
                 else:
                     dtype = type(data[key][0])
                     raise TypeError(
-                        f"Cannot store output of type {dtype} " f"in key {key}."
+                        f"Cannot store output of type {dtype} in key {key}."
                     )
 
-    def get_object_dtype(self, obj):
+        return data_format
+
+    def get_object_dtype(self, obj: Any) -> List[Tuple[str, type]]:
         """Loop over the attributes of a class to figure out what to store.
 
         This function assumes that the class only posseses getters that return
@@ -349,7 +446,7 @@ class HDF5Writer:
 
         Returns
         -------
-        list
+        List[Tuple[str, type]]
             List of (key, dtype) pairs
         """
         object_dtype = []
@@ -387,18 +484,22 @@ class HDF5Writer:
 
         return object_dtype
 
-    def initialize_datasets(self, out_file):
+    def initialize_datasets(
+        self, out_file: h5py.File, type_dict: Dict[str, DataFormat]
+    ) -> None:
         """Create place hodlers for all the datasets to be filled.
 
         Parameters
         ----------
         out_file : h5py.File
             HDF5 file instance
+        type_dict : Dict[str, DataFormat]
+            Dictionary containing the data type information for each key
         """
         # Initialize the datasets, store the general type of the event
         self.event_dtype = []
         ref_dtype = h5py.special_dtype(ref=h5py.RegionReference)
-        for key, val in self.type_dict.items():
+        for key, val in type_dict.items():
             # Add a dataset reference for this key to the event dtype
             self.event_dtype.append((key, ref_dtype))
             if not isinstance(val.width, list):
@@ -414,7 +515,7 @@ class HDF5Writer:
             elif not val.merge:
                 # If the elements of the list are of variable widths, refer to
                 # one dataset per element. An index is stored alongside the
-                # dataset to break.
+                # dataset to break it into individual elements.
                 group = out_file.create_group(key)
 
                 n_arrays = len(val.width)
@@ -447,7 +548,9 @@ class HDF5Writer:
             "events", (0,), maxshape=(None,), dtype=self.event_dtype
         )
 
-    def __call__(self, data, cfg=None):
+    def __call__(
+        self, data: Dict[str, Any], cfg: Optional[Dict[str, Any]] = None
+    ) -> None:
         """Append the HDF5 file with the content of a batch.
 
         Parameters
@@ -458,25 +561,25 @@ class HDF5Writer:
             Dictionary containing the complete SPINE configuration
         """
         # Nest data if is not already, fetch batch size
-        # TODO: make this nicer?
         if np.isscalar(data["index"]):
             for k in data:
                 data[k] = [data[k]]
-        batch_size = len(data["index"])
+            batch_size = 1
+        else:
+            batch_size = len(data["index"])
 
         # If needed, add empty data for dummy datasets
         if self.dummy_ds is not None:
             for key, value in self.dummy_ds.items():
                 data[key] = [spine.data.ObjectList([], default=value)] * batch_size
 
-        # If this function has never been called, initialiaze the HDF5 file
-        if not self.ready and (not self.append or os.path.isfile(self.file_name)):
-            self.create(data, cfg)
-            self.ready = True
+        # If this function has never been called, initialiaze the HDF5 file(s)
+        if not self.ready:
+            self.create(data, cfg, append=self.append)
 
         # Append file(s)
-        if not self.split:
-            with h5py.File(self.file_name, "a") as out_file:
+        if not self.split or len(self.file_names) == 1:
+            with h5py.File(self.file_names[0], "a") as out_file:
                 # Loop over batch IDs
                 for batch_id in range(batch_size):
                     self.append_entry(out_file, data, batch_id)
@@ -484,18 +587,20 @@ class HDF5Writer:
         else:
             file_ids = data["file_index"]
             for file_id in np.unique(file_ids):
-                with h5py.File(self.file_name[file_id], "a") as out_file:
+                with h5py.File(self.file_names[file_id], "a") as out_file:
                     for batch_id in np.where(file_ids == file_id)[0]:
                         self.append_entry(out_file, data, batch_id)
 
-    def append_entry(self, out_file, data, batch_id):
+    def append_entry(
+        self, out_file: h5py.File, data: Dict[str, Any], batch_id: int
+    ) -> None:
         """Stores one entry.
 
         Parameters
         ----------
         out_file : h5py.File
             HDF5 file instance
-        data : dict
+        data : Dict[str, Any]
             Dictionary of data products
         batch_id : int
             Batch ID to be stored
@@ -505,24 +610,36 @@ class HDF5Writer:
 
         # Initialize a dictionary of references to be passed to the
         # event dataset and store the input and result keys
+        assert self.keys is not None, "Keys to be stored have not been identified."
         for key in self.keys:
             self.append_key(out_file, event, data, key, batch_id)
 
         # Append event
-        event_id = len(out_file["events"])
         event_ds = out_file["events"]
+        assert isinstance(
+            event_ds, h5py.Dataset
+        ), f"Expected dataset for events to be a Dataset, but got {type(event_ds)} instead."
+
+        event_id = len(event_ds)
         event_ds.resize(event_id + 1, axis=0)  # pylint: disable=E1101
         event_ds[event_id] = event
 
-    def append_key(self, out_file, event, data, key, batch_id):
+    def append_key(
+        self,
+        out_file: h5py.File,
+        event: np.ndarray,
+        data: Dict[str, Any],
+        key: str,
+        batch_id: int,
+    ) -> None:
         """Stores data key in a specific dataset of an HDF5 file.
 
         Parameters
         ----------
         out_file : h5py.File
             HDF5 file instance
-        event : dict
-            Dictionary of objects that make up one event
+        event : np.ndarray
+            Array representing the event to which the data corresponds
         data : dict
             Dictionary of data products
         key : string
@@ -530,21 +647,31 @@ class HDF5Writer:
         batch_id : int
             Batch ID to be stored
         """
+        # Sanity check that the data type information for this key has been initialized
+        assert self.type_dict is not None and self.object_dtypes is not None, (
+            f"Cannot append key {key} to file as the data type information "
+            "has not been initialized."
+        )
+
         # Get the data type and store it
         val = self.type_dict[key]
         if not val.merge and not isinstance(val.width, list):
             # Store single arrays
             if np.isscalar(data[key]):
                 # If a data product is a single scalar, use it for every entry
-                array = [data[key]]
+                array = np.asarray([data[key]])
 
             else:
                 # Otherwise, get the data corresponding to the current entry
                 array = data[key][batch_id]
                 if val.scalar:
-                    array = [array]
+                    array = np.asarray([array])
 
             if val.dtype in self.object_dtypes:
+                assert not isinstance(val.dtype, type), (
+                    f"Expected object dtype for key {key} to be a composite type, but "
+                    f"got {type(val.dtype)} instead."
+                )
                 self.store_objects(out_file, event, key, array, val.dtype, self.lite)
             else:
                 self.store(out_file, event, key, array)
@@ -560,7 +687,9 @@ class HDF5Writer:
             self.store_flat(out_file, event, key, array_list)
 
     @staticmethod
-    def store(out_file, event, key, array):
+    def store(
+        out_file: h5py.File, event: np.ndarray, key: str, array: np.ndarray
+    ) -> None:
         """Stores an `ndarray` in the file and stores its mapping in the event
         dataset.
 
@@ -568,8 +697,8 @@ class HDF5Writer:
         ----------
         out_file : h5py.File
             HDF5 file instance
-        event : dict
-            Dictionary of objects that make up one event
+        event : np.ndarray
+            Array representing the event to which the data corresponds
         key: str
             Name of the dataset in the file
         array : np.ndarray
@@ -577,6 +706,11 @@ class HDF5Writer:
         """
         # Extend the dataset, store array
         dataset = out_file[key]
+        assert isinstance(dataset, h5py.Dataset), (
+            f"Expected dataset for key {key} to be a Dataset, but got "
+            f"{type(dataset)} instead."
+        )
+
         current_id = len(dataset)
         dataset.resize(current_id + len(array), axis=0)
         dataset[current_id : current_id + len(array)] = array
@@ -586,7 +720,12 @@ class HDF5Writer:
         event[key] = region_ref
 
     @staticmethod
-    def store_jagged(out_file, event, key, array_list):
+    def store_jagged(
+        out_file: h5py.File,
+        event: np.ndarray,
+        key: str,
+        array_list: List[np.ndarray],
+    ) -> None:
         """Stores a jagged list of arrays in the file and stores an index
         mapping for each array element in the event dataset.
 
@@ -594,17 +733,31 @@ class HDF5Writer:
         ----------
         out_file : h5py.File
             HDF5 file instance
-        event : dict
-            Dictionary of objects that make up one event
+        event : np.ndarray
+            Array representing the event to which the data corresponds
         key: str
             Name of the dataset in the file
         array_list : list(np.ndarray)
             List of arrays to be stored
         """
+        # Fetch the group corresponding to this key, which contains one dataset per
+        # element in the list, and check that it is indeed a group
+        group = out_file[key]
+        assert isinstance(group, h5py.Group), (
+            f"Expected group for key {key} to be a Group, but got "
+            f"{type(group)} instead."
+        )
+
         # Extend the dataset, store combined array
         region_refs = []
         for i, array in enumerate(array_list):
-            dataset = out_file[key][f"element_{i}"]
+
+            dataset = group[f"element_{i}"]
+            assert isinstance(dataset, h5py.Dataset), (
+                f"Expected dataset for element {i} of key {key} to be a Dataset, "
+                f"but got {type(dataset)} instead."
+            )
+
             current_id = len(dataset)
             dataset.resize(current_id + len(array), axis=0)
             dataset[current_id : current_id + len(array)] = array
@@ -613,8 +766,13 @@ class HDF5Writer:
             region_refs.append(region_ref)
 
         # Define the index which stores a list of region_refs
-        index = out_file[key]["index"]
-        current_id = len(dataset)
+        index = group["index"]
+        assert isinstance(index, h5py.Dataset), (
+            f"Expected dataset for index of key {key} to be a Dataset, but got "
+            f"{type(index)} instead."
+        )
+
+        current_id = len(index)
         index.resize(current_id + 1, axis=0)
         index[current_id] = region_refs
 
@@ -624,7 +782,9 @@ class HDF5Writer:
         event[key] = region_ref
 
     @staticmethod
-    def store_flat(out_file, event, key, array_list):
+    def store_flat(
+        out_file: h5py.File, event: np.ndarray, key: str, array_list: List[np.ndarray]
+    ) -> None:
         """Stores a concatenated list of arrays in the file and stores its
         index mapping in the event dataset to break them.
 
@@ -632,22 +792,41 @@ class HDF5Writer:
         ----------
         out_file : h5py.File
             HDF5 file instance
-        event : dict
-            Dictionary of objects that make up one event
+        event : np.ndarray
+            Array representing the event to which the data corresponds
         key: str
             Name of the dataset in the file
         array_list : list(np.ndarray)
             List of arrays to be stored
         """
+        # Fetch the group corresponding to this key, which contains one dataset for
+        # the elements in the list and one for the index, and check that it is indeed
+        # a group
+        group = out_file[key]
+        assert isinstance(group, h5py.Group), (
+            f"Expected group for key {key} to be a Group, but got "
+            f"{type(group)} instead."
+        )
+
         # Extend the dataset, store combined array
-        array = np.concatenate(array_list) if len(array_list) else []
-        dataset = out_file[key]["elements"]
+        dataset = group["elements"]
+        assert isinstance(dataset, h5py.Dataset), (
+            f"Expected dataset for elements of key {key} to be a Dataset, but got "
+            f"{type(dataset)} instead."
+        )
+
         first_id = len(dataset)
+        array = np.concatenate(array_list) if len(array_list) else []
         dataset.resize(first_id + len(array), axis=0)
         dataset[first_id : first_id + len(array)] = array
 
         # Loop over arrays in the list, create a reference for each
-        index = out_file[key]["index"]
+        index = group["index"]
+        assert isinstance(index, h5py.Dataset), (
+            f"Expected dataset for index of key {key} to be a Dataset, but got "
+            f"{type(index)} instead."
+        )
+
         current_id = len(index)
         index.resize(current_id + len(array_list), axis=0)
         last_id = first_id
@@ -663,7 +842,14 @@ class HDF5Writer:
         event[key] = region_ref
 
     @staticmethod
-    def store_objects(out_file, event, key, array, obj_dtype, lite):
+    def store_objects(
+        out_file: h5py.File,
+        event: np.ndarray,
+        key: str,
+        array: np.ndarray,
+        obj_dtype: List[Tuple[str, type]],
+        lite: bool,
+    ) -> None:
         """Stores a list of objects with understandable attributes in the file
         and stores its mapping in the event dataset.
 
@@ -671,8 +857,8 @@ class HDF5Writer:
         ----------
         out_file : h5py.File
             HDF5 file instance
-        event : dict
-            Dictionary of objects that make up one event
+        event : np.ndarray
+            Array representing the event to which the data corresponds
         key: str
             Name of the dataset in the file
         array : np.ndarray
@@ -689,6 +875,11 @@ class HDF5Writer:
 
         # Extend the dataset, store array
         dataset = out_file[key]
+        assert isinstance(dataset, h5py.Dataset), (
+            f"Expected dataset for key {key} to be a Dataset, but got "
+            f"{type(dataset)} instead."
+        )
+
         current_id = len(dataset)
         dataset.resize(current_id + len(array), axis=0)
         dataset[current_id : current_id + len(array)] = objects

--- a/test/test_io/test_write.py
+++ b/test/test_io/test_write.py
@@ -125,6 +125,60 @@ def test_hdf5_writer(hdf5_output, tensor_list, index_list, edge_index_list):
     writer(data)
 
 
+def test_hdf5_writer_file_name_inferred_from_prefix():
+    """Test HDF5 output file name inference from input prefixes."""
+    assert HDF5Writer.get_file_names(None, "input", split=False) == ["input_spine.h5"]
+    assert HDF5Writer.get_file_names(None, ["a", "b"], split=True) == [
+        "a_spine.h5",
+        "b_spine.h5",
+    ]
+
+
+def test_hdf5_writer_split_explicit_single_file(hdf5_output):
+    """Test split output keeps an explicit name when there is one input file."""
+    assert HDF5Writer.get_file_names(hdf5_output, ["input"], split=True) == [
+        hdf5_output
+    ]
+
+
+def test_hdf5_writer_split_explicit_multiple_files(tmp_path):
+    """Test split output enumerates an explicit name for multiple input files."""
+    file_name = os.path.join(tmp_path, "output.h5")
+
+    assert HDF5Writer.get_file_names(file_name, ["a", "b", "c"], split=True) == [
+        os.path.join(tmp_path, "output_0.h5"),
+        os.path.join(tmp_path, "output_1.h5"),
+        os.path.join(tmp_path, "output_2.h5"),
+    ]
+
+
+def test_hdf5_writer_append_existing_file(hdf5_output):
+    """Test appending a batch to an existing HDF5 output file."""
+    data = {
+        "index": np.arange(2),
+        "dummy_data": [np.random.rand(2, 3), np.random.rand(3, 3)],
+    }
+
+    HDF5Writer(hdf5_output)(data)
+    HDF5Writer(hdf5_output, append=True)(data)
+
+    with h5py.File(hdf5_output, "r") as out_file:
+        assert len(out_file["events"]) == 4
+
+
+def test_hdf5_writer_append_missing_file(hdf5_output):
+    """Test append mode creates a missing HDF5 output file."""
+    data = {
+        "index": np.arange(2),
+        "dummy_data": [np.random.rand(2, 3), np.random.rand(3, 3)],
+    }
+
+    HDF5Writer(hdf5_output, append=True)(data)
+
+    with h5py.File(hdf5_output, "r") as out_file:
+        assert len(out_file["events"]) == 2
+
+
 def generate_object_list(cls, sizes):
     """Generates a dummy list of lists of objects of the request class.
 


### PR DESCRIPTION
## Summary

This PR cleans up the CSV and HDF5 writer implementations, with the main behavioral change focused on HDF5 output filename handling and split-output behavior.

## HDF5 Writer

- Refactors output filename construction into `HDF5Writer.get_file_names`.
- Fixes split-output naming for explicit `file_name`:
  - `split_output: true` with one input file now uses the explicit `file_name` as-is.
  - `split_output: true` with multiple input files enumerates from the explicit base name.
  - inferred names from input prefixes keep the existing `{prefix}_spine.h5` behavior.
- Normalizes internal writer state to a list of output file names.
- Keeps append/create handling in a single `create(..., append=...)` flow.
- Fixes jagged-list index handling in `store_jagged`:
  - the jagged `index` dataset now grows from `len(index)`, not from the length of the last element dataset.
  - this avoids stale/extra rows in jagged index datasets such as `encoder_tensors/index` and `decoder_tensors/index`.
- Adds type hints and clearer runtime assertions around HDF5 groups/datasets.

## CSV Writer

- Cleans up naming and type hints.
- Keeps CSV output behavior unchanged.
- Removes unused state/imports where possible.

## Validation

Ran the standard ICARUS no-flash inference command inside `spine:latest` on both `main` and this feature branch:

```bash
python3 bin/run.py \
  -c icarus_noflash.yaml \
  -s larcv_mc_20240501_233642_899298_89d4af57-47a1-4937-beb3-85c5903b7977.root
```

`h5diff` reports no meaningful content differences between branch outputs. Raw HDF5 files are not byte-identical, which is expected due to HDF5 internal layout/reference metadata and unordered key creation, but dataset contents compare cleanly.

Also validated the writer with all model/loader output keys enabled for one event, with post-processing disabled:

```bash
python3 bin/run.py \
  -c icarus_noflash.yaml \
  -s larcv_mc_20240501_233642_899298_89d4af57-47a1-4937-beb3-85c5903b7977.root \
  -n 1 \
  --set post=null \
  --set io.writer.keys=null
```

Both branches complete successfully. The feature branch differs from `main` for jagged index dataset shapes, specifically `encoder_tensors/index` and `decoder_tensors/index`; this is intentional and reflects the `store_jagged` fix. The actual tensor element datasets compare cleanly.

Empty `/info` and `/crthits` datasets are expected in the validation output:

- `/info` is an empty metadata carrier with `version` and resolved `cfg` attributes.
- `/crthits` is empty because the selected validation event contains zero CRT hits.