### PR TITLE
Add joint overlay dataset

### DIFF
--- a/src/spine/io/dataset/__init__.py
+++ b/src/spine/io/dataset/__init__.py
@@ -1,15 +1,18 @@
 """Torch-backed dataset adapters for SPINE IO.
 
-The dataset layer sits between low-level readers and the DataLoader. It is
+The dataset layer sits between low-level readers and PyTorch DataLoaders. It is
 responsible for:
 
 - exposing ``__len__`` and ``__getitem__`` for torch
 - converting raw reader outputs into parser products
 - attaching augmentation, collate-type, and overlay metadata
+- composing source datasets when training needs aligned cache products
+  (``MixedDataset``) or unaligned overlay pairs (``JointDataset``)
 """
 
 from .hdf5 import HDF5Dataset
+from .joint import JointDataset
 from .larcv import LArCVDataset
 from .mixed import MixedDataset
 
-__all__ = ["HDF5Dataset", "LArCVDataset", "MixedDataset"]
+__all__ = ["HDF5Dataset", "JointDataset", "LArCVDataset", "MixedDataset"]

--- a/src/spine/io/dataset/hdf5.py
+++ b/src/spine/io/dataset/hdf5.py
@@ -76,8 +76,11 @@ class HDF5Dataset(BaseDataset):
             Reader-specific keyword arguments forwarded to the selected HDF5
             backend reader
         """
+        # Initialize parent class
         super().__init__()
 
+        # Validate the configuration and prepare reader arguments before
+        # instantiating the backend.
         if not TORCH_AVAILABLE:
             raise ImportError("PyTorch is required to use HDF5Dataset.")
         if keys is not None and skip_keys is not None:
@@ -94,6 +97,9 @@ class HDF5Dataset(BaseDataset):
         )
         reader_stage_map: dict[str, str] = {}
 
+        # If a parser schema is provided, instantiate the parsers and collect
+        # the raw HDF5 products they require. In staged mode, also validate
+        # schema-level stage assignments and build the reader key-to-stage map.
         if schema is not None:
             if dtype is None:
                 raise ValueError("An explicit `dtype` is required when using `schema`.")
@@ -125,7 +131,7 @@ class HDF5Dataset(BaseDataset):
             else:
                 self.keys.update(inferred_keys)
 
-        self.build_augmenter(augment)
+        # Initialize the appropriate reader backend
         if staged:
             self.reader = StageHDF5Reader(
                 stage=stage,
@@ -135,6 +141,9 @@ class HDF5Dataset(BaseDataset):
             )
         else:
             self.reader = HDF5Reader(**kwargs)
+
+        # Initialize the augmenter
+        self.build_augmenter(augment)
 
     def __len__(self) -> int:
         """Return the number of entries exposed by the backend reader."""

--- a/src/spine/io/dataset/joint.py
+++ b/src/spine/io/dataset/joint.py
@@ -1,0 +1,245 @@
+"""Dataset wrapper for overlaying events from two independent sources."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, ClassVar
+
+from ..overlay import Overlayer
+from .base import BaseDataset, DataDict
+
+__all__ = ["JointDataset"]
+
+
+class JointDataset(BaseDataset):
+    """Torch dataset that overlays unaligned primary/secondary events.
+
+    This class is intentionally different from :class:`MixedDataset`:
+
+    - ``MixedDataset`` is an aligned merge of products that describe the same
+      event across backends.
+    - ``JointDataset`` is an unaligned merge of products that describe
+      different events and should be overlaid for training.
+
+    ``JointDataset`` does not decide which secondary event to use. A joint
+    sampler provides indexes of the form ``(primary_idx, secondary_idx)``. If
+    ``secondary_idx`` is ``None`` or if a scalar primary index is provided, the
+    dataset returns the primary sample unchanged. This keeps pairing policy and
+    pair probability in the sampler, while this class only instantiates source
+    datasets and applies the existing :class:`spine.io.overlay.Overlayer`.
+
+    The first implementation supports one primary event plus at most one
+    secondary event per sample. Both sources must expose the same data keys,
+    collate types, and overlay methods so that the overlayer can operate on a
+    common product schema.
+    """
+
+    name: ClassVar[str] = "joint"
+    joint: ClassVar[bool] = True
+    primary: BaseDataset
+    secondary: BaseDataset
+    reader: Any
+
+    def __init__(
+        self,
+        primary: Mapping[str, Any] | str | BaseDataset,
+        secondary: Mapping[str, Any] | str | BaseDataset,
+        base: Mapping[str, Any] | str | None = None,
+        dtype: str | None = None,
+        augment: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Instantiate the joint overlay dataset.
+
+        Parameters
+        ----------
+        primary : mapping, str or BaseDataset
+            Primary dataset configuration, overrides to a shared ``base``
+            configuration, or already-instantiated dataset. The primary
+            controls the length and primary index order.
+        secondary : mapping, str or BaseDataset
+            Secondary dataset configuration, overrides to a shared ``base``
+            configuration, or already-instantiated dataset.
+        base : mapping or str, optional
+            Shared dataset configuration merged into both source configs before
+            instantiation. Source blocks override values from ``base``. Use
+            this for common schema/parser options, and put source-specific
+            values such as file paths or entry filters in ``primary`` and
+            ``secondary``.
+        dtype : str, optional
+            Floating-point dtype forwarded when instantiating configured
+            datasets.
+        augment : mapping, optional
+            Augmentation applied after the primary sample is returned or after
+            the primary/secondary samples are overlaid.
+        """
+        # Initialize parent class
+        super().__init__()
+
+        # Instantiate the source datasets. The optional `base` block lets users
+        # define a common schema once while keeping paths and filters local to
+        # each source block.
+        self.primary = self.build_dataset(
+            self.resolve_source_config(base, primary),
+            dtype,
+        )
+        self.secondary = self.build_dataset(
+            self.resolve_source_config(base, secondary), dtype
+        )
+
+        # Expose the primary reader for compatibility with code that inspects
+        # the dataset's main source. Secondary access is internal to overlays.
+        self.reader = getattr(self.primary, "reader", None)
+        if len(self.primary) < 1:
+            raise ValueError("The primary dataset must expose at least one entry.")
+        if len(self.secondary) < 1:
+            raise ValueError("The secondary dataset must expose at least one entry.")
+
+        # The overlayer expects the same logical products on both sides. It uses
+        # the primary metadata after compatibility is validated.
+        self.validate_metadata(
+            "data type", self.primary.data_types, self.secondary.data_types
+        )
+        self.validate_metadata(
+            "overlay", self.primary.overlay_methods, self.secondary.overlay_methods
+        )
+
+        self.overlayer = Overlayer(
+            multiplicity=2,
+            mode="constant",
+            data_types=self.primary.data_types,
+            methods=self.primary.overlay_methods,
+        )
+
+        # Initialize the augmenter
+        self.build_augmenter(augment)
+
+    @staticmethod
+    def resolve_source_config(
+        base: Mapping[str, Any] | str | None,
+        source: Mapping[str, Any] | str | BaseDataset,
+    ) -> Mapping[str, Any] | str | BaseDataset:
+        """Merge one source override block into the shared base config.
+
+        Already-instantiated datasets are returned unchanged. String configs
+        cannot be merged with ``base`` because there is no mapping to update.
+        """
+        if base is None or not isinstance(source, Mapping):
+            return source
+        if not isinstance(base, Mapping):
+            raise ValueError(
+                "A shared `base` config can only be merged with source "
+                "override mappings."
+            )
+
+        return {**dict(base), **dict(source)}
+
+    @staticmethod
+    def build_dataset(
+        source: Mapping[str, Any] | str | BaseDataset,
+        dtype: str | None,
+    ) -> BaseDataset:
+        """Instantiate one source dataset unless an object is already provided.
+
+        Source-specific options, including entry filters, must be present in
+        the source config itself before this method is called.
+        """
+        if isinstance(source, (Mapping, str)):
+            from ..factories import dataset_factory
+
+            return dataset_factory(source, dtype=dtype)
+
+        return source
+
+    def __len__(self) -> int:
+        """Return the number of primary entries.
+
+        Joint samplers iterate over the primary source and independently choose
+        secondary indexes to pair with those primary entries.
+        """
+        return len(self.primary)
+
+    def __getitem__(self, idx: int | tuple[int, int | None]) -> DataDict:
+        """Return one primary sample or one primary/secondary overlay.
+
+        Parameters
+        ----------
+        idx : int or tuple[int, int or None]
+            A scalar index returns the corresponding primary sample without an
+            overlay. A tuple ``(primary_idx, secondary_idx)`` overlays the two
+            source samples. A tuple ``(primary_idx, None)`` returns the primary
+            sample without touching the secondary source.
+        """
+        primary_idx, secondary_idx = self.resolve_pair_index(idx)
+        primary = self.primary[primary_idx]
+        if secondary_idx is None:
+            return self.apply_augmenter(primary)
+
+        overlaid = self.overlayer([primary, self.secondary[secondary_idx]])
+        assert len(overlaid) == 1, "Joint overlays should produce one sample."
+        return self.apply_augmenter(overlaid[0])
+
+    def resolve_pair_index(
+        self, idx: int | tuple[int, int | None]
+    ) -> tuple[int, int | None]:
+        """Resolve the primary and optional secondary indexes for one sample."""
+        if isinstance(idx, tuple):
+            if len(idx) != 2:
+                raise ValueError("JointDataset tuple indexes must have length 2.")
+            primary_idx, secondary_idx = idx
+            if secondary_idx is not None:
+                secondary_idx = self.validate_secondary_index(int(secondary_idx))
+            return int(primary_idx), secondary_idx
+
+        return idx, None
+
+    def validate_secondary_index(self, secondary_idx: int) -> int:
+        """Validate one secondary index produced by a joint sampler."""
+        if secondary_idx < 0 or secondary_idx >= len(self.secondary):
+            raise ValueError("Secondary index is outside of bounds.")
+
+        return secondary_idx
+
+    @staticmethod
+    def validate_metadata(
+        label: str,
+        primary: Mapping[str, str | None],
+        secondary: Mapping[str, str | None],
+    ) -> None:
+        """Ensure both datasets expose compatible metadata for overlaying.
+
+        The current joint overlay implementation is schema-preserving: every
+        product emitted by the primary must also be emitted by the secondary
+        with the same collate type and overlay method.
+        """
+        primary_keys = set(primary)
+        secondary_keys = set(secondary)
+        if primary_keys != secondary_keys:
+            missing = sorted(primary_keys - secondary_keys)
+            extra = sorted(secondary_keys - primary_keys)
+            raise ValueError(
+                f"JointDataset {label} keys must match between primary and "
+                f"secondary datasets. Missing in secondary: {missing}. "
+                f"Extra in secondary: {extra}."
+            )
+
+        for key in primary:
+            if primary[key] != secondary[key]:
+                raise ValueError(
+                    f"JointDataset {label} mismatch for '{key}': "
+                    f"{primary[key]!r} vs {secondary[key]!r}."
+                )
+
+    @property
+    def data_types(self) -> dict[str, str]:
+        """Return the collate type for each joint output product."""
+        return dict(self.primary.data_types)
+
+    @property
+    def overlay_methods(self) -> dict[str, str | None]:
+        """Return overlay methods for any downstream batch-level overlay."""
+        return dict(self.primary.overlay_methods)
+
+    @property
+    def data_keys(self) -> tuple[str, ...]:
+        """Return the names of all products emitted by joint samples."""
+        return tuple(self.data_types.keys())

--- a/src/spine/io/dataset/larcv.py
+++ b/src/spine/io/dataset/larcv.py
@@ -18,7 +18,19 @@ __all__ = ["LArCVDataset"]
 
 
 class LArCVDataset(BaseDataset):
-    """Torch dataset that parses LArCV entries into SPINE parser products."""
+    """Torch dataset that parses LArCV entries into SPINE products.
+
+    The dataset wraps :class:`spine.io.read.LArCVReader` and a parser schema.
+    The schema maps output product names to parser configurations from
+    :mod:`spine.io.parse.larcv`. During initialization, the dataset
+    instantiates each parser, collects every LArCV tree key required by those
+    parsers, and passes the union of those tree keys to the reader.
+
+    Each loaded entry is returned as a dictionary containing standard dataset
+    metadata, such as ``index`` and source-file provenance fields, plus one
+    parsed product per schema entry. Optional augmentation is applied after all
+    parser products are produced.
+    """
 
     name: ClassVar[str] = "larcv"
     parsers: dict[str, Any]
@@ -31,9 +43,29 @@ class LArCVDataset(BaseDataset):
         augment: Mapping[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """Instantiate the LArCV-backed dataset."""
+        """Instantiate the LArCV-backed dataset.
+
+        Parameters
+        ----------
+        schema : mapping
+            Mapping from output product name to parser configuration. Each
+            parser configuration must identify a parser from
+            :mod:`spine.io.parse.larcv` using ``parser`` or ``name`` and
+            provide any parser-specific LArCV product names.
+        dtype : str
+            Floating-point dtype forwarded to parser factories.
+        augment : mapping, optional
+            Augmentation configuration applied to each parsed sample.
+        **kwargs : Any
+            Reader-specific keyword arguments forwarded to
+            :class:`spine.io.read.LArCVReader`, such as ``file_keys`` and
+            entry-list filters.
+        """
+        # Initialize the parent class
         super().__init__()
 
+        # Instantiate the configured parsers and collect the LArCV tree keys
+        # needed by any parser.
         self.parsers = {}
         tree_keys: list[str] = []
         for data_product, parser_cfg in schema.items():
@@ -46,15 +78,30 @@ class LArCVDataset(BaseDataset):
                 if key not in tree_keys:
                     tree_keys.append(key)
 
-        self.build_augmenter(augment)
+        # Initialize the backend reader with the collected tree keys
         self.reader = LArCVReader(tree_keys=tree_keys, **kwargs)
 
+        # Initialize the augmenter
+        self.build_augmenter(augment)
+
     def __len__(self) -> int:
-        """Return the number of dataset entries."""
+        """Return the number of entries exposed by the LArCV reader."""
         return len(self.reader)
 
     def __getitem__(self, idx: int) -> DataDict:
-        """Return one parsed dataset entry."""
+        """Return one parsed LArCV entry.
+
+        Parameters
+        ----------
+        idx : int
+            Dataset entry index after any reader-level filtering.
+
+        Returns
+        -------
+        dict
+            Standard metadata fields plus one parser output for each product
+            declared in ``schema``.
+        """
         data_dict = self.reader[idx]
         result = self.metadata_dict(data_dict)
 
@@ -69,7 +116,11 @@ class LArCVDataset(BaseDataset):
 
     @property
     def data_types(self) -> dict[str, str]:
-        """Return the collate type of each parsed data product."""
+        """Return the collate type for metadata and parsed products.
+
+        Parser return types are consumed by :class:`spine.io.collate.CollateAll`
+        to batch products consistently.
+        """
         data_types = self.index_data_types()
         for name, parser in self.parsers.items():
             data_types[name] = parser.returns
@@ -78,7 +129,11 @@ class LArCVDataset(BaseDataset):
 
     @property
     def overlay_methods(self) -> dict[str, str]:
-        """Return the overlay method of each parsed data product."""
+        """Return overlay methods for metadata and parsed products.
+
+        Parser overlay metadata is consumed by :class:`spine.io.overlay.Overlayer`
+        when multiple entries are combined into one training sample.
+        """
         overlay_methods = self.index_overlay_methods()
         for name, parser in self.parsers.items():
             overlay_methods[name] = parser.overlay
@@ -87,10 +142,21 @@ class LArCVDataset(BaseDataset):
 
     @property
     def data_keys(self) -> tuple[str, ...]:
-        """Return the names of all data products produced by this dataset."""
+        """Return metadata and parser-product keys exposed by this dataset."""
         return (*self._index_keys, *self._source_keys, *self.parsers.keys())
 
     @staticmethod
     def list_data(file_path: str) -> dict[str, list[str]]:
-        """List top-level products available in an input LArCV file."""
+        """List top-level products available in an input LArCV file.
+
+        Parameters
+        ----------
+        file_path : str
+            Path to one LArCV input file.
+
+        Returns
+        -------
+        dict
+            Mapping from product category to available product names.
+        """
         return LArCVReader.list_data(file_path)

--- a/src/spine/io/dataset/mixed.py
+++ b/src/spine/io/dataset/mixed.py
@@ -66,13 +66,18 @@ class MixedDataset(BaseDataset):
             constructors. This is primarily used for reader-level options such
             as entry-list filtering that must remain aligned across sources.
         """
+        # Initialize the parent class
         super().__init__()
 
+        # Store the alignment and merge configuration for use when samples are
+        # fetched.
         self.align_keys = tuple(align_keys)
         self.hdf5_align_keys = dict(hdf5_align_keys or {})
         self.hdf5_key_map = dict(hdf5_key_map or {})
         self.allow_overwrite = allow_overwrite
 
+        # Initialize the aligned sources. Shared keyword arguments are forwarded
+        # to both datasets so reader-level filters preserve one-to-one ordering.
         self.primary = LArCVDataset(**larcv, dtype=dtype, augment=None, **kwargs)
         self.cache = HDF5Dataset(**hdf5, dtype=dtype, augment=None, **kwargs)
         self.reader = self.primary.reader
@@ -82,6 +87,7 @@ class MixedDataset(BaseDataset):
                 f"to be mixed safely. Got {len(self.primary)} and {len(self.cache)}."
             )
 
+        # Initialize the augmenter
         self.build_augmenter(augment)
 
     def __len__(self) -> int:

--- a/src/spine/io/factories.py
+++ b/src/spine/io/factories.py
@@ -153,6 +153,8 @@ def loader_factory(
     torch_dataset = dataset_factory(dataset, entry_list, dtype)
 
     # Initialize the sampler
+    if sampler is None and getattr(torch_dataset, "joint", False):
+        raise ValueError("JointDataset requires an explicit joint sampler.")
     if sampler is not None:
         sampler = sampler_factory(
             sampler, torch_dataset, batch_size, distributed, world_size, rank
@@ -205,6 +207,14 @@ def dataset_factory(
 
     # Append the entry_list if it is provided independently
     if entry_list is not None:
+        dataset_name = (
+            dataset_cfg if isinstance(dataset_cfg, str) else dataset_cfg.get("name")
+        )
+        if dataset_name in ("joint", "JointDataset"):
+            raise ValueError(
+                "`entry_list` must be configured inside `base`, `primary`, "
+                "or `secondary` for JointDataset."
+            )
         warn(
             "You are manually overwriting the existing `entry_list` "
             "argument provided in the configuration file."
@@ -266,6 +276,18 @@ def sampler_factory(
     sampler_obj = instantiate(
         sampler_dict, sampler_cfg, dataset=dataset, batch_size=minibatch_size
     )
+
+    # Joint datasets consume tuple indexes; standard datasets consume scalars.
+    is_joint_dataset = getattr(dataset, "joint", False)
+    is_joint_sampler = getattr(sampler_obj, "joint", False)
+    if is_joint_dataset != is_joint_sampler:
+        expected = "joint" if is_joint_dataset else "standard"
+        got = "joint" if is_joint_sampler else "standard"
+        raise ValueError(
+            f"Cannot use a {got} sampler with a {expected} dataset. "
+            "Use a joint sampler with JointDataset and a standard sampler "
+            "with standard datasets."
+        )
 
     # If we are working a distributed environment, wrap the sampler
     if distributed:

--- a/src/spine/io/sample.py
+++ b/src/spine/io/sample.py
@@ -33,6 +33,9 @@ __all__ = [
     "SequentialBatchSampler",
     "RandomSequenceBatchSampler",
     "BootstrapBatchSampler",
+    "JointSequentialBatchSampler",
+    "JointRandomSequenceBatchSampler",
+    "JointBootstrapBatchSampler",
 ]
 
 
@@ -44,6 +47,8 @@ class AbstractBatchSampler(Sampler):
     self.num_samples and self.batch_size as well as a self._random
     RNG, if needed.
     """
+
+    joint = False
 
     def __init__(
         self,
@@ -189,6 +194,116 @@ class BootstrapBatchSampler(AbstractBatchSampler):
         return iter(np.concatenate(batches))
 
 
+class _Sized:
+    """Minimal sized proxy used to drive paired secondary samplers."""
+
+    def __init__(self, size: int) -> None:
+        self.size = size
+
+    def __len__(self) -> int:
+        return self.size
+
+
+class AbstractJointBatchSampler(Sampler):
+    """Pair primary sampler indices with independently sampled secondary indices."""
+
+    joint = True
+    sampler_cls: type[AbstractBatchSampler]
+
+    def __init__(
+        self,
+        dataset: Sized,
+        batch_size: int,
+        seed: int | None = None,
+        drop_last: bool = True,
+        pair_probability: float = 1.0,
+    ) -> None:
+        """Build matched primary and secondary index streams.
+
+        Parameters
+        ----------
+        dataset : JointDataset
+            Dataset with a ``secondary`` source to sample from.
+        batch_size : int
+            Number of primary samples to load per iteration.
+        seed : int, optional
+            Seed forwarded to the primary sampler. The secondary sampler uses
+            the next seed so random policies are independent.
+        drop_last : bool, default True
+            Whether the primary sampler should drop incomplete batches.
+        pair_probability : float, default 1.0
+            Probability of pairing a primary index with a secondary index.
+            When the draw fails, the sampler yields ``None`` for the secondary
+            index and the joint dataset returns the primary sample unchanged.
+        """
+        super().__init__(data_source=None)
+
+        if not getattr(dataset, "joint", False) or not hasattr(dataset, "secondary"):
+            raise ValueError("Joint samplers require a JointDataset.")
+        if pair_probability < 0.0 or pair_probability > 1.0:
+            raise ValueError("`pair_probability` must be between 0 and 1.")
+
+        self.primary_sampler = self.sampler_cls(dataset, batch_size, seed, drop_last)
+        secondary_seed = None if seed is None else seed + 1
+        self.secondary_sampler = self.sampler_cls(
+            _Sized(len(self.primary_sampler)),
+            batch_size,
+            secondary_seed,
+            drop_last,
+        )
+        self.secondary_size = len(dataset.secondary)
+        self.batch_size = self.primary_sampler.batch_size
+        self.drop_last = self.primary_sampler.drop_last
+        self.num_samples = len(self.primary_sampler)
+        self.pair_probability = pair_probability
+        rng_seed = int(time.time()) if seed is None else seed + 2
+        self._random = np.random.RandomState(seed=rng_seed)  # pylint: disable=E1101
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def __iter__(self) -> Iterator[tuple[int, int | None]]:
+        primary_indices = list(self.primary_sampler)
+        pair_mask = self._random.random_sample(len(primary_indices))
+        pair_mask = pair_mask < self.pair_probability
+
+        num_pairs = int(np.count_nonzero(pair_mask))
+        paired_indices = np.asarray(list(self.secondary_sampler), dtype=int)
+        paired_indices = paired_indices[:num_pairs] % self.secondary_size
+
+        secondary_indices: list[int | None] = []
+        paired_pos = 0
+        for paired in pair_mask:
+            if paired:
+                secondary_indices.append(int(paired_indices[paired_pos]))
+                paired_pos += 1
+            else:
+                secondary_indices.append(None)
+
+        return iter(zip(primary_indices, secondary_indices))
+
+
+class JointSequentialBatchSampler(AbstractJointBatchSampler):
+    """Sequential primary sampling with paired sequential secondary sampling."""
+
+    name = "joint_sequential"
+    sampler_cls = SequentialBatchSampler
+
+
+class JointRandomSequenceBatchSampler(AbstractJointBatchSampler):
+    """Random-sequence primary sampling with paired random secondary sampling."""
+
+    name = "joint_random_sequence"
+    sampler_cls = RandomSequenceBatchSampler
+
+
+class JointBootstrapBatchSampler(AbstractJointBatchSampler):
+    """Bootstrap primary sampling with paired bootstrap secondary sampling."""
+
+    name = "joint_bootstrap"
+    sampler_cls = BootstrapBatchSampler
+
+
 class DistributedProxySampler(DistributedSampler):
     """Sampler that restricts data loading to a subset of input sampler indices.
 
@@ -261,7 +376,7 @@ class DistributedProxySampler(DistributedSampler):
         minibatch_size = self.batch_size / self.num_replicas
         ranks = (np.arange(self.total_size) // minibatch_size) % self.num_replicas
 
-        indices = np.array(indices, dtype=int)[ranks == self.rank]
+        indices = [indices[i] for i in np.where(ranks == self.rank)[0]]
         assert len(indices) == self.num_samples
 
         return iter(indices)

--- a/test/test_io/test_dataset.py
+++ b/test/test_io/test_dataset.py
@@ -12,8 +12,10 @@ from spine.io.collate import CollateAll
 from spine.io.dataset import *
 from spine.io.dataset import base as dataset_base_module
 from spine.io.dataset import hdf5 as hdf5_dataset_module
+from spine.io.dataset import joint as joint_dataset_module
 from spine.io.dataset import larcv as larcv_dataset_module
 from spine.io.dataset import mixed as mixed_dataset_module
+from spine.io.parse.data import ParserTensor
 from spine.io.write import HDF5Writer
 from spine.utils.conditional import ROOT, ROOT_AVAILABLE, TORCH_AVAILABLE
 
@@ -1496,6 +1498,181 @@ def test_mixed_dataset_overlay_collision_raises(monkeypatch):
 
     with pytest.raises(ValueError, match="overlay collision"):
         _ = dataset.overlay_methods
+
+
+def test_joint_dataset_overlays_primary_and_secondary_pair():
+    """JointDataset should overlay one explicit primary/secondary pair."""
+
+    class DummyDataset:
+        def __init__(self, samples):
+            self.samples = samples
+            self.reader = object()
+
+        def __len__(self):
+            return len(self.samples)
+
+        def __getitem__(self, idx):
+            sample = self.samples[idx]
+            return {
+                "index": sample["index"],
+                "data": ParserTensor(
+                    features=np.asarray(sample["features"], dtype=np.float32),
+                    feats_only=True,
+                ),
+            }
+
+        @property
+        def data_types(self):
+            return {"index": "scalar", "data": "tensor"}
+
+        @property
+        def overlay_methods(self):
+            return {"index": "cat", "data": None}
+
+    primary = DummyDataset(
+        [
+            {"index": 0, "features": [[1.0], [2.0]]},
+            {"index": 1, "features": [[3.0]]},
+        ]
+    )
+    secondary = DummyDataset(
+        [
+            {"index": 10, "features": [[10.0]]},
+            {"index": 11, "features": [[11.0], [12.0]]},
+        ]
+    )
+
+    dataset = joint_dataset_module.JointDataset(
+        primary=primary,
+        secondary=secondary,
+    )
+
+    first = dataset[(0, 0)]
+    np.testing.assert_array_equal(first["index"], np.asarray([0, 10]))
+    np.testing.assert_array_equal(
+        first["data"].features, np.asarray([[1.0], [2.0], [10.0]], dtype=np.float32)
+    )
+    second = dataset[(1, 1)]
+    np.testing.assert_array_equal(second["index"], np.asarray([1, 11]))
+    np.testing.assert_array_equal(
+        second["data"].features, np.asarray([[3.0], [11.0], [12.0]], dtype=np.float32)
+    )
+    assert len(dataset) == 2
+    assert dataset.data_types == {"index": "scalar", "data": "tensor"}
+    assert dataset.overlay_methods == {"index": "cat", "data": None}
+    assert dataset.data_keys == ("index", "data")
+
+
+def test_joint_dataset_rejects_incompatible_sources():
+    """JointDataset should fail clearly when products cannot be overlaid."""
+
+    class DummyDataset:
+        overlay_methods = {"index": "cat"}
+
+        def __init__(self, data_types):
+            self.data_types = data_types
+
+        def __len__(self):
+            return 1
+
+        def __getitem__(self, idx):
+            return {"index": idx}
+
+    with pytest.raises(ValueError, match="data type keys must match"):
+        joint_dataset_module.JointDataset(
+            primary=DummyDataset({"index": "scalar", "data": "tensor"}),
+            secondary=DummyDataset({"index": "scalar"}),
+        )
+
+
+def test_joint_dataset_accepts_explicit_pair_index():
+    """Pair indexes should let an external sampler own secondary pairing."""
+
+    class DummyDataset:
+        data_types = {"index": "scalar"}
+        overlay_methods = {"index": "cat"}
+
+        def __init__(self, indexes):
+            self.indexes = indexes
+
+        def __len__(self):
+            return len(self.indexes)
+
+        def __getitem__(self, idx):
+            return {"index": self.indexes[idx]}
+
+    dataset = joint_dataset_module.JointDataset(
+        primary=DummyDataset([0, 1]),
+        secondary=DummyDataset([10, 11]),
+    )
+
+    assert dataset[0]["index"] == 0
+    np.testing.assert_array_equal(dataset[(0, 1)]["index"], np.asarray([0, 11]))
+    assert dataset[(1, None)]["index"] == 1
+
+
+def test_joint_dataset_merges_shared_dataset_config(monkeypatch):
+    """Shared dataset config should let source blocks override only paths."""
+
+    class DummyDataset:
+        data_types = {"index": "scalar"}
+        overlay_methods = {"index": "cat"}
+
+        def __init__(self, index):
+            self.index = index
+
+        def __len__(self):
+            return 1
+
+        def __getitem__(self, idx):
+            return {"index": self.index}
+
+    seen = []
+
+    def build_dataset(source, dtype):
+        seen.append((source, dtype))
+        return DummyDataset(source["index"])
+
+    monkeypatch.setattr(
+        joint_dataset_module.JointDataset,
+        "build_dataset",
+        staticmethod(build_dataset),
+    )
+
+    dataset = joint_dataset_module.JointDataset(
+        base={
+            "name": "hdf5",
+            "schema": {"data": {"parser": "tensor"}},
+            "entry_list": [2, 3],
+        },
+        primary={"file_keys": "primary.h5", "index": 0, "entry_list": [0]},
+        secondary={"file_keys": "secondary.h5", "index": 10, "entry_list": [1]},
+        dtype="float32",
+    )
+
+    np.testing.assert_array_equal(dataset[(0, 0)]["index"], np.asarray([0, 10]))
+    assert seen == [
+        (
+            {
+                "name": "hdf5",
+                "schema": {"data": {"parser": "tensor"}},
+                "entry_list": [0],
+                "file_keys": "primary.h5",
+                "index": 0,
+            },
+            "float32",
+        ),
+        (
+            {
+                "name": "hdf5",
+                "schema": {"data": {"parser": "tensor"}},
+                "entry_list": [1],
+                "file_keys": "secondary.h5",
+                "index": 10,
+            },
+            "float32",
+        ),
+    ]
 
 
 def test_larcv_dataset_uses_augmenter_and_length(monkeypatch):

--- a/test/test_io/test_dataset.py
+++ b/test/test_io/test_dataset.py
@@ -1585,6 +1585,57 @@ def test_joint_dataset_rejects_incompatible_sources():
         )
 
 
+def test_joint_dataset_rejects_overlay_metadata_mismatch():
+    """JointDataset should reject matching keys with conflicting metadata."""
+
+    class DummyDataset:
+        data_types = {"index": "scalar"}
+
+        def __init__(self, overlay_methods):
+            self.overlay_methods = overlay_methods
+
+        def __len__(self):
+            return 1
+
+        def __getitem__(self, idx):
+            return {"index": idx}
+
+    with pytest.raises(ValueError, match="overlay mismatch"):
+        joint_dataset_module.JointDataset(
+            primary=DummyDataset({"index": "cat"}),
+            secondary=DummyDataset({"index": "first"}),
+        )
+
+
+def test_joint_dataset_rejects_empty_sources():
+    """JointDataset should require both primary and secondary samples."""
+
+    class DummyDataset:
+        data_types = {"index": "scalar"}
+        overlay_methods = {"index": "cat"}
+
+        def __init__(self, size):
+            self.size = size
+
+        def __len__(self):
+            return self.size
+
+        def __getitem__(self, idx):
+            return {"index": idx}
+
+    with pytest.raises(ValueError, match="primary dataset must expose"):
+        joint_dataset_module.JointDataset(
+            primary=DummyDataset(0),
+            secondary=DummyDataset(1),
+        )
+
+    with pytest.raises(ValueError, match="secondary dataset must expose"):
+        joint_dataset_module.JointDataset(
+            primary=DummyDataset(1),
+            secondary=DummyDataset(0),
+        )
+
+
 def test_joint_dataset_accepts_explicit_pair_index():
     """Pair indexes should let an external sampler own secondary pairing."""
 
@@ -1609,6 +1660,34 @@ def test_joint_dataset_accepts_explicit_pair_index():
     assert dataset[0]["index"] == 0
     np.testing.assert_array_equal(dataset[(0, 1)]["index"], np.asarray([0, 11]))
     assert dataset[(1, None)]["index"] == 1
+
+
+def test_joint_dataset_rejects_bad_pair_indexes():
+    """JointDataset should validate tuple shape and secondary bounds."""
+
+    class DummyDataset:
+        data_types = {"index": "scalar"}
+        overlay_methods = {"index": "cat"}
+
+        def __init__(self, indexes):
+            self.indexes = indexes
+
+        def __len__(self):
+            return len(self.indexes)
+
+        def __getitem__(self, idx):
+            return {"index": self.indexes[idx]}
+
+    dataset = joint_dataset_module.JointDataset(
+        primary=DummyDataset([0, 1]),
+        secondary=DummyDataset([10]),
+    )
+
+    with pytest.raises(ValueError, match="length 2"):
+        dataset[(0, 1, 2)]
+
+    with pytest.raises(ValueError, match="outside of bounds"):
+        dataset[(0, 4)]
 
 
 def test_joint_dataset_merges_shared_dataset_config(monkeypatch):
@@ -1672,6 +1751,48 @@ def test_joint_dataset_merges_shared_dataset_config(monkeypatch):
             },
             "float32",
         ),
+    ]
+
+
+def test_joint_dataset_resolve_source_config_rejects_string_base():
+    """A string base cannot be merged into mapping source overrides."""
+    with pytest.raises(ValueError, match="shared `base`"):
+        joint_dataset_module.JointDataset.resolve_source_config(
+            "hdf5", {"file_keys": "input.h5"}
+        )
+
+
+def test_joint_dataset_build_dataset_uses_factory(monkeypatch):
+    """Mapping-based source configs should instantiate through dataset_factory."""
+
+    class DummyDataset:
+        data_types = {"index": "scalar"}
+        overlay_methods = {"index": "cat"}
+
+        def __len__(self):
+            return 1
+
+        def __getitem__(self, idx):
+            return {"index": idx}
+
+    calls = []
+
+    def fake_dataset_factory(source, entry_list=None, dtype=None):
+        calls.append((source, entry_list, dtype))
+        return DummyDataset()
+
+    monkeypatch.setattr("spine.io.factories.dataset_factory", fake_dataset_factory)
+
+    dataset = joint_dataset_module.JointDataset(
+        primary={"name": "hdf5", "file_keys": "a.h5"},
+        secondary={"name": "hdf5", "file_keys": "b.h5"},
+        dtype="float32",
+    )
+
+    assert len(dataset) == 1
+    assert calls == [
+        ({"name": "hdf5", "file_keys": "a.h5"}, None, "float32"),
+        ({"name": "hdf5", "file_keys": "b.h5"}, None, "float32"),
     ]
 
 

--- a/test/test_io/test_factories.py
+++ b/test/test_io/test_factories.py
@@ -113,6 +113,39 @@ def test_dataset_factory_mixed(monkeypatch):
     not TORCH_AVAILABLE,
     reason="PyTorch is required for torch-backed dataset factory tests.",
 )
+def test_dataset_factory_joint():
+    """The generic dataset factory should instantiate the joint dataset."""
+
+    class DummyDataset:
+        data_types = {"index": "scalar"}
+        overlay_methods = {"index": "cat"}
+
+        def __init__(self, indexes):
+            self.indexes = indexes
+
+        def __len__(self):
+            return len(self.indexes)
+
+        def __getitem__(self, idx):
+            return {"index": self.indexes[idx]}
+
+    dataset = dataset_factory(
+        {
+            "name": "joint",
+            "primary": DummyDataset([0]),
+            "secondary": DummyDataset([10]),
+        },
+        dtype="float32",
+    )
+
+    assert dataset.name == "joint"
+    np.testing.assert_array_equal(dataset[(0, 0)]["index"], np.asarray([0, 10]))
+
+
+@pytest.mark.skipif(
+    not TORCH_AVAILABLE,
+    reason="PyTorch is required for torch-backed dataset factory tests.",
+)
 def test_dataset_factory_entry_list_warning(hdf5_data):
     """Providing an external entry list should override the config with a warning."""
     cfg = {
@@ -125,6 +158,16 @@ def test_dataset_factory_entry_list_warning(hdf5_data):
         dataset = dataset_factory(cfg, entry_list=[0], dtype="float32")
 
     assert len(dataset) == 1
+
+
+def test_dataset_factory_rejects_external_joint_entry_list():
+    """JointDataset entry filters should live in source configs."""
+    with pytest.raises(ValueError, match="entry_list"):
+        dataset_factory(
+            {"name": "joint", "primary": "hdf5", "secondary": "hdf5"},
+            entry_list=[0],
+            dtype="float32",
+        )
 
 
 @pytest.mark.skipif(
@@ -371,6 +414,7 @@ def test_sampler_factory_wraps_distributed(monkeypatch):
 
     class DummySampler:
         batch_size = 4
+        joint = False
 
     monkeypatch.setattr(
         factories_module, "instantiate", lambda *args, **kwargs: DummySampler()
@@ -394,6 +438,49 @@ def test_sampler_factory_wraps_distributed(monkeypatch):
 
     assert wrapped["value"][1:] == (2, 1)
     assert result == wrapped["value"]
+
+
+@pytest.mark.skipif(
+    not TORCH_AVAILABLE,
+    reason="PyTorch is required for sampler factory tests.",
+)
+def test_sampler_factory_rejects_standard_sampler_for_joint_dataset(monkeypatch):
+    """Joint datasets should require explicit joint samplers."""
+
+    class DummyDataset:
+        joint = True
+
+    class DummySampler:
+        joint = False
+
+    monkeypatch.setattr(
+        factories_module, "instantiate", lambda *args, **kwargs: DummySampler()
+    )
+
+    with pytest.raises(ValueError, match="standard sampler with a joint dataset"):
+        factories_module.sampler_factory(
+            {"name": "dummy"}, dataset=DummyDataset(), minibatch_size=2
+        )
+
+
+@pytest.mark.skipif(
+    not TORCH_AVAILABLE,
+    reason="PyTorch is required for sampler factory tests.",
+)
+def test_sampler_factory_rejects_joint_sampler_for_standard_dataset(monkeypatch):
+    """Standard datasets should reject joint samplers."""
+
+    class DummySampler:
+        joint = True
+
+    monkeypatch.setattr(
+        factories_module, "instantiate", lambda *args, **kwargs: DummySampler()
+    )
+
+    with pytest.raises(ValueError, match="joint sampler with a standard dataset"):
+        factories_module.sampler_factory(
+            {"name": "dummy"}, dataset=[1, 2], minibatch_size=2
+        )
 
 
 def test_loader_factory_rejects_missing_torch(monkeypatch):

--- a/test/test_io/test_factories.py
+++ b/test/test_io/test_factories.py
@@ -279,6 +279,42 @@ def test_loader_factory_uses_minibatch_and_helpers(monkeypatch):
     assert captured["pin_memory"] is True
 
 
+def test_loader_factory_requires_sampler_for_joint_dataset(monkeypatch):
+    """Joint datasets should fail early when no joint sampler is configured."""
+
+    class DummyDataset:
+        joint = True
+        data_types = {"value": "scalar"}
+        overlay_methods = {"value": "cat"}
+
+    class DummyDataLoader:
+        def __init__(self, dataset, **kwargs):
+            self.dataset = dataset
+            self.kwargs = kwargs
+
+    fake_torch = types.ModuleType("torch")
+    fake_utils = types.ModuleType("torch.utils")
+    fake_data = types.ModuleType("torch.utils.data")
+    fake_data.DataLoader = DummyDataLoader
+    fake_utils.data = fake_data
+    fake_torch.utils = fake_utils
+
+    monkeypatch.setattr(factories_module, "TORCH_AVAILABLE", True)
+    monkeypatch.setattr(
+        factories_module, "dataset_factory", lambda *args, **kwargs: DummyDataset()
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setitem(sys.modules, "torch.utils", fake_utils)
+    monkeypatch.setitem(sys.modules, "torch.utils.data", fake_data)
+
+    with pytest.raises(ValueError, match="explicit joint sampler"):
+        factories_module.loader_factory(
+            dataset={"name": "joint"},
+            dtype="float32",
+            minibatch_size=2,
+        )
+
+
 def test_loader_factory_distributed_requires_explicit_rank(monkeypatch):
     """Distributed loader setup should reject an unspecified process rank."""
 

--- a/test/test_io/test_sample.py
+++ b/test/test_io/test_sample.py
@@ -33,6 +33,21 @@ class DummyDataset:
         return self.size
 
 
+@dataclass
+class DummyJointDataset:
+    """Joint dataset stand-in with primary and secondary sizes."""
+
+    size: int
+    secondary_size: int
+    joint = True
+
+    def __post_init__(self):
+        self.secondary = DummyDataset(self.secondary_size)
+
+    def __len__(self):
+        return self.size
+
+
 @pytest.fixture(name="dataset")
 def fixture_dataset(request):
     """Generates a dummy dataset whith the necessary attributes and
@@ -148,6 +163,61 @@ def test_bootstrap_sampler(dataset, batch_size, seed):
 
             # Make the distributed sampler has half the entries
             assert len(dist_sampler) == len(sampler) / 2
+
+
+def test_joint_sequential_sampler_pairs_primary_and_secondary():
+    """Joint sequential sampling should return primary/secondary index pairs."""
+    dataset = DummyJointDataset(size=5, secondary_size=2)
+    sampler = JointSequentialBatchSampler(dataset, batch_size=2, seed=1)
+
+    assert list(sampler) == [(0, 0), (1, 1), (2, 0), (3, 1)]
+
+
+def test_joint_random_sequence_sampler_pairs_are_bounded():
+    """Joint random-sequence sampling should keep secondary indexes in range."""
+    dataset = DummyJointDataset(size=12, secondary_size=3)
+    sampler = JointRandomSequenceBatchSampler(dataset, batch_size=4, seed=8)
+    samples = list(sampler)
+
+    assert len(samples) == 12
+    assert all(0 <= primary < 12 for primary, _ in samples)
+    assert all(0 <= secondary < 3 for _, secondary in samples)
+
+
+def test_joint_sampler_pair_probability_skips_without_consuming_secondary():
+    """Skipped pairs should not advance the secondary index stream."""
+    dataset = DummyJointDataset(size=4, secondary_size=3)
+    sampler = JointSequentialBatchSampler(
+        dataset, batch_size=2, seed=2, pair_probability=0.8
+    )
+
+    assert list(sampler) == [(0, None), (1, 0), (2, None), (3, 1)]
+
+
+def test_joint_sampler_rejects_invalid_pair_probability():
+    """Joint samplers should validate pair probability."""
+    with pytest.raises(ValueError, match="pair_probability"):
+        JointSequentialBatchSampler(
+            DummyJointDataset(size=4, secondary_size=2),
+            batch_size=2,
+            pair_probability=1.5,
+        )
+
+
+def test_joint_sampler_requires_joint_dataset():
+    """Joint samplers should reject standard datasets."""
+    with pytest.raises(ValueError, match="JointDataset"):
+        JointSequentialBatchSampler(DummyDataset(4), batch_size=2, seed=1)
+
+
+def test_distributed_proxy_sampler_preserves_joint_pairs():
+    """Distributed wrapping should preserve tuple indexes from joint samplers."""
+    sampler = JointSequentialBatchSampler(
+        DummyJointDataset(size=4, secondary_size=2), batch_size=2, seed=1
+    )
+    dist_sampler = DistributedProxySampler(sampler, num_replicas=2, rank=1)
+
+    assert list(dist_sampler) == [(1, 1), (3, 1)]
 
 
 def test_sampler_input_validation():


### PR DESCRIPTION
## Description
Adds a backend-agnostic `JointDataset` for overlay training across two independently sampled datasets.

`JointDataset` composes a primary and secondary dataset, receives `(primary_idx, secondary_idx)` pairs from joint samplers, and uses the existing `Overlayer` mechanics to produce one overlaid training sample. Scalar indexes and `(primary_idx, None)` return the primary sample unchanged.

This also adds joint sampler variants:
- `joint_sequential`
- `joint_random_sequence`
- `joint_bootstrap`

Each joint sampler emits primary/secondary index pairs and supports `pair_probability` to control how often a secondary sample is paired.

## Motivation and Context
Existing overlay support works well when overlaying adjacent or grouped entries from one dataset, but it is awkward when the desired overlay source is a distinct dataset. This adds a clear semantic split:

- `MixedDataset`: aligned merge of the same event across backends
- `JointDataset`: unaligned/sampled merge of different events for overlays

The first implementation supports the narrow useful case of one primary event plus at most one secondary event.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Code quality improvement (refactoring, type hints, etc.)

## How Has This Been Tested?
Ran targeted Docker-backed tests:

- `PYTHONPATH=src:$PYTHONPATH pytest test/test_io/test_sample.py test/test_io/test_dataset.py::test_joint_dataset_overlays_primary_and_secondary_pair test/test_io/test_dataset.py::test_joint_dataset_rejects_incompatible_sources test/test_io/test_dataset.py::test_joint_dataset_accepts_explicit_pair_index test/test_io/test_dataset.py::test_joint_dataset_merges_shared_dataset_config test/test_io/test_factories.py::test_dataset_factory_joint test/test_io/test_factories.py::test_dataset_factory_rejects_external_joint_entry_list test/test_io/test_factories.py::test_sampler_factory_wraps_distributed test/test_io/test_factories.py::test_sampler_factory_rejects_standard_sampler_for_joint_dataset test/test_io/test_factories.py::test_sampler_factory_rejects_joint_sampler_for_standard_dataset -q --tb=short`

Result: `46 passed`

Also ran full dataset tests:

- `PYTHONPATH=src:$PYTHONPATH pytest test/test_io/test_dataset.py -q --tb=short`

Result: `37 passed, 1 skipped`

The skipped test is the existing ROOT-dependent LArCV dataset test.

**Test Configuration**:
- Docker image: `ghcr.io/deeplearnphysics/spine:latest`
- Branch: `feature/joint-dataset`

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots / Event Displays (if applicable)
Not applicable.

## Additional Notes
`JointDataset` requires a joint sampler when used through the loader factory. Standard samplers are rejected for joint datasets, and joint samplers are rejected for standard datasets, because joint datasets consume tuple indexes while standard datasets consume scalar indexes.