### PR TITLE
Refactor post/analysis structure

### DIFF
--- a/src/spine/ana/__init__.py
+++ b/src/spine/ana/__init__.py
@@ -1,36 +1,11 @@
 """Analysis scripts and performance evaluation tools.
 
-This module provides high-level analysis capabilities for neutrino physics
-reconstruction results, building upon the output of the ML reconstruction
-chain and post-processing modules.
+The analysis package runs configurable scripts on reconstruction and
+post-processing outputs, usually to write CSV summaries for diagnostics,
+calibration studies, and reconstruction-quality metrics.
 
-Core analysis management:
-
-- ``AnaManager`` orchestrates configuration-driven analysis workflows.
-
-Analysis categories:
-
-- Reconstruction-performance studies for PID, energy, spatial, angular, and vertex metrics.
-- Physics analyses for topology, interaction type, and selection optimization.
-- Quality-assessment workflows for truth matching, completeness, and systematic studies.
-
-Output products:
-
-- Histograms, resolution studies, efficiency curves, and publication-ready figures.
-
-Example
--------
-
-.. code-block:: python
-
-  from spine.ana import AnaManager
-
-  ana = AnaManager(config_file="analysis.yaml")
-  results = ana.analyze(input_files, output_dir)
-  ana.plot_performance(results)
-
-This module serves as the final step in the SPINE reconstruction pipeline,
-transforming raw ML outputs into physics-ready analysis results.
+``AnaManager`` orchestrates configured analysis modules and handles batched
+input dictionaries in the driver workflow.
 """
 
 from .manager import AnaManager

--- a/src/spine/ana/base.py
+++ b/src/spine/ana/base.py
@@ -1,13 +1,17 @@
 """Base class of all analysis scripts."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from collections.abc import Mapping, MutableMapping, Sequence
+from typing import Any
 from warnings import warn
 
 from spine.io.write.csv import CSVWriter
 
 
 class AnaBase(ABC):
-    """Parent class of all analysis scripts.
+    """Parent class for CSV-writing analysis scripts.
 
     This base class performs the following functions:
     - Ensures that the necessary methods exist
@@ -18,10 +22,8 @@ class AnaBase(ABC):
     ----------
     name : str
         Name of the analysis script (to call it from a configuration file)
-    req_keys : List[str]
-        Data products needed to run the analysis script
-    opt_keys : List[str]
-        Optional data products which will be used only if they are provided
+    keys : dict
+        Data products needed or optionally consumed by the analysis script
     units : str
         Units in which the coordinates are expressed
     """
@@ -62,22 +64,22 @@ class AnaBase(ABC):
 
     def __init__(
         self,
-        obj_type=None,
-        run_mode=None,
-        truth_point_mode=None,
-        truth_index_mode=None,
-        truth_dep_mode=None,
-        append=False,
-        overwrite=False,
-        log_dir=None,
-        prefix=None,
-        buffer_size=1,
-    ):
-        """Initialize default anlysis script object properties.
+        obj_type: str | Sequence[str] | None = None,
+        run_mode: str | None = None,
+        truth_point_mode: str | None = None,
+        truth_index_mode: str | None = None,
+        truth_dep_mode: str | None = None,
+        append: bool = False,
+        overwrite: bool = False,
+        log_dir: str | None = None,
+        prefix: str | None = None,
+        buffer_size: int = 1,
+    ) -> None:
+        """Initialize default analysis script object properties.
 
         Parameters
         ----------
-        obj_type : Union[str, List[str]]
+        obj_type : str or Sequence[str], optional
             Name or list of names of the object types to process
         run_mode : str, optional
             If specified, tells whether the analysis script must run on
@@ -99,7 +101,7 @@ class AnaBase(ABC):
             If True, appends existing CSV files instead of creating new ones
         overwrite : bool, default False
             If True and an output CSV file exists, overwrite it
-        log_dir : str
+        log_dir : str, optional
             Output CSV file directory (shared with driver log)
         prefix : str, default None
             Name to prefix every output CSV file with
@@ -121,54 +123,64 @@ class AnaBase(ABC):
         self.run_mode = run_mode
         if run_mode is not None:
             # Check that the run mode is recognized
-            assert run_mode in self._run_modes, (
-                f"`run_mode` not recognized: {run_mode}. Must be one of "
-                f"{self._run_modes}."
-            )
+            if run_mode not in self._run_modes:
+                raise ValueError(
+                    f"`run_mode` not recognized: {run_mode}. Must be one of "
+                    f"{self._run_modes}."
+                )
 
-        self.prefixes = []
+        self.prefixes: list[str] = []
         if run_mode != "truth":
             self.prefixes.append("reco")
         if run_mode != "reco":
             self.prefixes.append("truth")
 
         # Check that all the object sources are recognized
-        self.obj_type = obj_type
-        if self.obj_type is not None:
-            if isinstance(self.obj_type, str):
-                self.obj_type = [self.obj_type]
-            for obj in self.obj_type:
-                assert obj in self._obj_types, (
-                    f"Object type must be one of {self._obj_types}. Got "
-                    f"`{obj}` instead."
-                )
+        obj_types: list[str] | None = None
+        if obj_type is not None:
+            if isinstance(obj_type, str):
+                obj_types = [obj_type]
+            elif isinstance(obj_type, Sequence):
+                obj_types = list(obj_type)
+            else:
+                raise TypeError("`obj_type` must be a string or sequence of strings.")
+            for obj in obj_types:
+                if obj not in self._obj_types:
+                    raise ValueError(
+                        f"Object type must be one of {self._obj_types}. Got "
+                        f"`{obj}` instead."
+                    )
+        self.obj_type = obj_types
 
         # Make a list of object keys to process
-        self.fragment_keys = []
-        self.particle_keys = []
-        self.interaction_keys = []
+        self.fragment_keys: list[str] = []
+        self.particle_keys: list[str] = []
+        self.interaction_keys: list[str] = []
         for name in self._obj_types:
             # Initialize one list per object type
             setattr(self, f"{name}_keys", [])
 
             # Skip object types which are not requested
-            if self.obj_type is not None and name in self.obj_type:
+            if obj_types is not None and name in obj_types:
                 if run_mode != "truth":
                     getattr(self, f"{name}_keys").append(f"reco_{name}s")
                 if run_mode != "reco":
                     getattr(self, f"{name}_keys").append(f"truth_{name}s")
 
-        self.obj_keys = self.fragment_keys + self.particle_keys + self.interaction_keys
+        self.obj_keys: list[str] = (
+            self.fragment_keys + self.particle_keys + self.interaction_keys
+        )
 
         # Update underlying keys, if needed
         self.update_keys({k: True for k in self.obj_keys})
 
         # If a truth point mode is specified, store it
         if truth_point_mode is not None:
-            assert truth_point_mode in self.point_modes, (
-                "The `truth_point_mode` argument must be one of "
-                f"{self.point_modes.keys()}. Got `{truth_point_mode}` instead."
-            )
+            if truth_point_mode not in self.point_modes:
+                raise ValueError(
+                    "The `truth_point_mode` argument must be one of "
+                    f"{self.point_modes.keys()}. Got `{truth_point_mode}` instead."
+                )
             self.truth_point_mode = truth_point_mode
             self.truth_point_key = self.point_modes[truth_point_mode]
             self.truth_index_mode = truth_point_mode.replace("points", "index")
@@ -179,16 +191,18 @@ class AnaBase(ABC):
 
         # If a truth deposition mode is specified, store it
         if truth_dep_mode is not None:
-            assert truth_dep_mode in self.dep_modes, (
-                "The `truth_dep_mode` argument must be one of "
-                f"{self.dep_modes.keys()}. Got `{truth_dep_mode}` instead."
-            )
+            if truth_dep_mode not in self.dep_modes:
+                raise ValueError(
+                    "The `truth_dep_mode` argument must be one of "
+                    f"{self.dep_modes.keys()}. Got `{truth_dep_mode}` instead."
+                )
             if truth_point_mode is not None:
                 prefix = truth_point_mode.replace("points", "depositions")
-                assert truth_dep_mode.startswith(prefix), (
-                    f"Points mode {truth_point_mode} and deposition mode "
-                    f"{truth_dep_mode} are incompatible."
-                )
+                if not truth_dep_mode.startswith(prefix):
+                    raise ValueError(
+                        f"Points mode {truth_point_mode} and deposition mode "
+                        f"{truth_dep_mode} are incompatible."
+                    )
             self.truth_dep_mode = truth_dep_mode
             self.truth_dep_key = self.dep_modes[truth_dep_mode]
 
@@ -197,13 +211,13 @@ class AnaBase(ABC):
         self.overwrite_file = overwrite
 
         # Initialize a writer dictionary to be filled by the children classes
-        self.base_dict = {}
+        self.base_dict: dict[str, Any] = {}
         self.log_dir = log_dir
         self.output_prefix = prefix
         self.buffer_size = buffer_size
-        self.writers = {}
+        self.writers: dict[str, CSVWriter] = {}
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Destructor to ensure CSV files are closed.
 
         This acts as a safety net in case close_writers() is not called
@@ -211,16 +225,16 @@ class AnaBase(ABC):
         """
         self.close_writers()
 
-    def close_writers(self):
+    def close_writers(self) -> None:
         """Close all CSV writers and flush any remaining data.
 
         This should be called when the analysis is complete to ensure
         all data is written and files are properly closed.
         """
-        for writer in self.writers.values():
+        for writer in getattr(self, "writers", {}).values():
             writer.close()
 
-    def flush_writers(self):
+    def flush_writers(self) -> None:
         """Flush all CSV writer buffers without closing the files.
 
         This forces any buffered data to be written to disk. Useful
@@ -229,7 +243,7 @@ class AnaBase(ABC):
         for writer in self.writers.values():
             writer.flush()
 
-    def initialize_writer(self, name):
+    def initialize_writer(self, name: str) -> None:
         """Adds a CSV writer to the list of writers for this script.
 
         Parameters
@@ -238,7 +252,8 @@ class AnaBase(ABC):
             Name of the writer
         """
         # Define the name of the file to write to
-        assert len(name) > 0, "Must provide a non-empty name."
+        if len(name) == 0:
+            raise ValueError("Must provide a non-empty name.")
         file_name = f"{self.name}_{name}.csv"
         if self.output_prefix:
             file_name = f"{self.output_prefix}_{file_name}"
@@ -254,58 +269,58 @@ class AnaBase(ABC):
         )
 
     @property
-    def keys(self):
+    def keys(self) -> dict[str, bool]:
         """Dictionary of (key, necessity) pairs which determine which data keys
-        are needed/optional for the post-processor to run.
+        are needed or optional for the analysis script to run.
 
         Returns
         -------
-        Dict[str, bool]
+        dict[str, bool]
             Dictionary of (key, necessity) pairs to be used
         """
         return dict(self._keys)
 
     @keys.setter
-    def keys(self, keys):
+    def keys(self, keys: Mapping[str, bool]) -> None:
         """Converts a dictionary of keys to an immutable tuple.
 
         Parameters
         ----------
-        Dict[str, bool]
+        dict[str, bool]
             Dictionary of (key, necessity) pairs to be used
         """
         self._keys = tuple(keys.items())
 
     @property
-    def point_modes(self):
-        """Dictionary which makes the correspondance between the name of a true
+    def point_modes(self) -> dict[str, str]:
+        """Dictionary which maps the name of a true
         object point attribute with the underlying point tensor it points to.
 
         Returns
         -------
-        Dict[str, str]
+        dict[str, str]
             Dictionary of (attribute, key) mapping for point coordinates
         """
         return dict(self._point_modes)
 
     @property
-    def dep_modes(self):
-        """Dictionary which makes the correspondance between the name of a true
+    def dep_modes(self) -> dict[str, str]:
+        """Dictionary which maps the name of a true
         object deposition attribute with the underlying deposition array it points to.
 
         Returns
         -------
-        Dict[str, str]
+        dict[str, str]
             Dictionary of (attribute, key) mapping for point depositions
         """
         return dict(self._dep_modes)
 
-    def update_keys(self, update_dict):
+    def update_keys(self, update_dict: Mapping[str, bool]) -> None:
         """Update the underlying set of keys and their necessity in place.
 
         Parameters
         ----------
-        update_dict : Dict[str, bool]
+        update_dict : Mapping[str, bool]
             Dictionary of (key, necessity) pairs to update the keys with
         """
         if len(update_dict) > 0:
@@ -313,7 +328,7 @@ class AnaBase(ABC):
             keys.update(update_dict)
             self._keys = tuple(keys.items())
 
-    def get_base_dict(self, data):
+    def get_base_dict(self, data: Mapping[str, Any]) -> dict[str, Any]:
         """Builds the entry information dictionary.
 
         Parameters
@@ -337,8 +352,8 @@ class AnaBase(ABC):
 
         return base_dict
 
-    def append(self, name, **kwargs):
-        """Apppend a CSV log file with a set of values.
+    def append(self, name: str, **kwargs: Any) -> None:
+        """Append a row to a CSV log file.
 
         Parameters
         ----------
@@ -349,7 +364,7 @@ class AnaBase(ABC):
         """
         self.writers[name].append({**self.base_dict, **kwargs})
 
-    def __call__(self, data, entry=None):
+    def __call__(self, data: Mapping[str, Any], entry: int | None = None) -> Any:
         """Runs the analysis script on one entry.
 
         Parameters
@@ -366,10 +381,11 @@ class AnaBase(ABC):
         data_filter = {}
         for key, req in self.keys.items():
             # If this key is needed, check that it exists
-            assert not req or key in data, (
-                f"Analysis script `{self.name}` is missing an essential "
-                f"input to be used: `{key}`."
-            )
+            if req and key not in data:
+                raise KeyError(
+                    f"Analysis script `{self.name}` is missing an essential "
+                    f"input to be used: `{key}`."
+                )
 
             # Append
             if key in data:
@@ -383,7 +399,7 @@ class AnaBase(ABC):
         # Run the analysis script
         return self.process(data_filter)
 
-    def get_index(self, obj):
+    def get_index(self, obj: Any) -> Any:
         """Get a certain pre-defined index attribute of an object.
 
         The :class:`TruthFragment`, :class:`TruthParticle` and
@@ -392,7 +408,7 @@ class AnaBase(ABC):
 
         Parameters
         ----------
-        obj : Union[FragmentBase, ParticleBase, InteractionBase]
+        obj : FragmentBase or ParticleBase or InteractionBase
             Fragment, Particle or Interaction object
 
         Results
@@ -405,7 +421,7 @@ class AnaBase(ABC):
         else:
             return getattr(obj, self.truth_index_mode)
 
-    def get_points(self, obj):
+    def get_points(self, obj: Any) -> Any:
         """Get a certain pre-defined point attribute of an object.
 
         The :class:`TruthFragment`, :class:`TruthParticle` and
@@ -414,7 +430,7 @@ class AnaBase(ABC):
 
         Parameters
         ----------
-        obj : Union[FragmentBase, ParticleBase, InteractionBase]
+        obj : FragmentBase or ParticleBase or InteractionBase
             Fragment, Particle or Interaction object
 
         Results
@@ -428,7 +444,7 @@ class AnaBase(ABC):
             return getattr(obj, self.truth_point_mode)
 
     @abstractmethod
-    def process(self, data):
+    def process(self, data: MutableMapping[str, Any]) -> Any:
         """Place-holder method to be defined in each analysis script.
 
         Parameters

--- a/src/spine/ana/calib/__init__.py
+++ b/src/spine/ana/calib/__init__.py
@@ -1,9 +1,12 @@
 """Calibration analysis scripts.
 
-This submodule is used to extract basic calibration constants, such as:
-- Track dE/dx profile
-- Wire transparency map
-- MCS angular resolution calibration
+This submodule contains analysis scripts that extract calibration inputs from
+reconstruction objects. Currently it includes the MCS angular resolution
+calibration workflow.
+
+Other examples of sensible future additions:
+- dE/dx calibration
+- Shower calorimetric energy calibration
 - ...
 """
 

--- a/src/spine/ana/calib/mcs.py
+++ b/src/spine/ana/calib/mcs.py
@@ -5,7 +5,9 @@ of the tracks as a basis to correct the scattering angle spread in the MCS-based
 KE estimation used in SPINE.
 """
 
+from collections.abc import Mapping, Sequence
 from functools import partial
+from typing import Any
 
 import numpy as np
 
@@ -38,33 +40,33 @@ class MCSCalibAna(AnaBase):
 
     def __init__(
         self,
-        min_ke,
-        segment_length,
-        segment_method="bin_pca",
-        anchor_point=True,
-        angle_method="atan2",
-        time_window=None,
-        run_mode="truth",
-        truth_point_mode="points",
-        **kwargs,
-    ):
+        min_ke: float,
+        segment_length: float | Sequence[float],
+        segment_method: str = "bin_pca",
+        anchor_point: bool = True,
+        angle_method: str = "atan2",
+        time_window: Sequence[float] | None = None,
+        run_mode: str = "truth",
+        truth_point_mode: str = "points",
+        **kwargs: Any,
+    ) -> None:
         """Initialize the analysis script.
 
         Parameters
         ----------
         min_ke : float
             Kinetic energy (in MeV) above which a muon is included in the estimate
-        segment_length : Union[float, List[float]]
+        segment_length : float or Sequence[float]
             Segment length in the units that specify the coordinates. If array,
             will produce angular measurements for each segmentation length
         segment_method : str, default 'step_next'
             Method used to segment the track (one of 'step', 'step_next'
             or 'bin_pca')
         anchor_point : bool, default True
-            Weather or not to collapse end point onto the closest track point
+            Whether to collapse the end point onto the closest track point
         angle_method : str, default 'atan2'
             Angular reconstruction method
-        time_window : List[float], optional
+        time_window : Sequence[float], optional
             Time within which the particle must occur to be used for calibration.
             This is only used with true instances to remove out-of-time objects
         **kwargs : dict, optional
@@ -72,16 +74,22 @@ class MCSCalibAna(AnaBase):
         """
         # Initialize the parent class
         super().__init__(
-            "particle", run_mode, truth_point_mode=truth_point_mode, **kwargs
+            obj_type="particle",
+            run_mode=run_mode,
+            truth_point_mode=truth_point_mode,
+            **kwargs,
         )
 
         # Store the kinematic cut
         self.min_ke = min_ke
 
         # Store the segmentation parameters
-        self.segment_length = segment_length
-        if np.isscalar(segment_length):
-            self.segment_length = [segment_length]
+        if isinstance(segment_length, Sequence) and not isinstance(
+            segment_length, (str, bytes)
+        ):
+            self.segment_length = [float(length) for length in segment_length]
+        else:
+            self.segment_length = [float(segment_length)]
 
         # Partially initialize the segmentation algorithm
         self.get_track_segments = partial(
@@ -89,27 +97,33 @@ class MCSCalibAna(AnaBase):
         )
 
         # Store the angle computation parameters
-        assert angle_method in ANGLE_METHODS, (
-            f"Angular reconstruction method not recognized: {angle_method}. "
-            f"Must be one of {ANGLE_METHODS.keys()}"
-        )
+        if angle_method not in ANGLE_METHODS:
+            raise ValueError(
+                f"Angular reconstruction method not recognized: {angle_method}. "
+                f"Must be one of {ANGLE_METHODS.keys()}"
+            )
         self.angle_method = ANGLE_METHODS[angle_method]
 
         # Store the time window, if provided
-        assert (
-            time_window is None or run_mode == "truth"
-        ), "Cannot enforce time window containment on reconstructed objects."
-        assert time_window is None or (
-            not np.isscalar(time_window) and len(time_window) == 2
-        ), "If a time window is provided, it must be a list of two scalars."
-        self.time_window = time_window
+        normalized_time_window: tuple[float, float] | None = None
+        if time_window is not None:
+            if run_mode != "truth":
+                raise ValueError(
+                    "Cannot enforce time window containment on reconstructed objects."
+                )
+            if not isinstance(time_window, Sequence) or len(time_window) != 2:
+                raise ValueError(
+                    "If a time window is provided, it must be a list of two scalars."
+                )
+            normalized_time_window = (time_window[0], time_window[1])
+        self.time_window = normalized_time_window
 
         # Initialize the CSV writer(s) you want (one per segment length)
         for prefix in self.prefixes:
             for sl in self.segment_length:
                 self.initialize_writer(f"{prefix}_mcs_sl{sl}")
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Pass data products corresponding to one entry through the analysis.
 
         Parameters
@@ -125,7 +139,7 @@ class MCSCalibAna(AnaBase):
                 if part.pid != MUON_PID or part.ke < self.min_ke:
                     continue
 
-                # Enfore time, if requested
+                # Enforce time, if requested
                 if self.time_window is not None:
                     if part.t < self.time_window[0] or part.t > self.time_window[1]:
                         continue
@@ -145,7 +159,7 @@ class MCSCalibAna(AnaBase):
                     dirs = (dirs[:-1] + dirs[1:]) / 2
 
                     # Record the size of the smallest of the two segments
-                    counts = np.array([len(seg) for seg in segments])
+                    counts = np.asarray([len(seg) for seg in segments], dtype=np.int64)
                     min_counts = np.min(np.vstack((counts[:-1], counts[1:])), axis=0)
 
                     # Record the distance between two successive segment centers

--- a/src/spine/ana/diag/__init__.py
+++ b/src/spine/ana/diag/__init__.py
@@ -1,10 +1,9 @@
-"""Diagnostic analaysis scripts.
+"""Diagnostic analysis scripts.
 
 This submodule is used to run basic diagnostics analyses, such as:
-- Track energy reconstruction
+- Graph optimal edge-length studies
 - Track completeness
 - Shower start dE/dx
-- ...
 """
 
 from .graph import *

--- a/src/spine/ana/diag/graph.py
+++ b/src/spine/ana/diag/graph.py
@@ -1,11 +1,17 @@
-"""Module with methods to characterize
+"""Diagnostic analysis tools for graph clustering edge lengths.
 
 This script evaluates the expected length between fragments/particles that
 belong to the same group (particle or interaction groups) in order to optimize
-the edge length
+the edge length.
 """
 
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 import numpy as np
+from numpy.typing import NDArray
 
 from spine.ana.base import AnaBase
 from spine.utils.gnn.network import inter_cluster_distance
@@ -14,11 +20,10 @@ __all__ = ["GraphEdgeLengthAna"]
 
 
 class GraphEdgeLengthAna(AnaBase):
-    """Description of what the analysis script is supposed to be doing.
+    """Measure distances between constituents of particle/interaction groups.
 
-    This script evaluates the expected length between fragments/particles that
-    belong to the same group (particle or interaction groups) in order to optimize
-    the edge length
+    The output can be used to tune graph-edge construction thresholds for
+    fragment-to-particle and particle-to-interaction clustering.
     """
 
     # Name of the analysis script (as specified in the configuration)
@@ -26,41 +31,62 @@ class GraphEdgeLengthAna(AnaBase):
 
     def __init__(
         self,
-        time_window=None,
-        obj_type=("particle", "interaction"),
-        run_mode="truth",
-        truth_point_mode="points",
-        **kwargs,
-    ):
+        time_window: Sequence[float] | None = None,
+        obj_type: str | Sequence[str] | None = ("particle", "interaction"),
+        run_mode: str = "truth",
+        truth_point_mode: str = "points",
+        **kwargs: Any,
+    ) -> None:
         """Initialize the analysis script.
 
         Parameters
         ----------
+        time_window : Sequence[float], optional
+            True-object time window to include in the diagnostic.
+        obj_type : str or Sequence[str], default ('particle', 'interaction')
+            Object aggregation levels to evaluate.
+        run_mode : str, default 'truth'
+            Whether to run on reconstructed, truth, or both object collections.
+        truth_point_mode : str, default 'points'
+            Truth point coordinate attribute to use when evaluating truth objects.
+        **kwargs : dict, optional
+            Additional arguments to pass to :class:`AnaBase`.
         """
+        obj_types: list[str]
+        if isinstance(obj_type, str):
+            obj_types = [obj_type]
+        elif obj_type is None:
+            obj_types = []
+        else:
+            obj_types = list(obj_type)
+
         # If particle clustering edges are to be evaluated, must provide fragments
-        if obj_type == "particle":
-            obj_type = ["fragment", "particle"]
-        elif "particle" in obj_type and "fragment" not in obj_type:
-            obj_type.append("fragment")
+        if "particle" in obj_types and "fragment" not in obj_types:
+            obj_types.append("fragment")
 
         # If interaction clustering edges are to be evaluated, must provide particles
-        if obj_type == "interaction":
-            obj_type = ["particle", "interaction"]
-        elif "interaction" in obj_type and "particle" not in obj_type:
-            obj_type.append("particle")
+        if "interaction" in obj_types and "particle" not in obj_types:
+            obj_types.append("particle")
 
         # Initialize the parent class
         super().__init__(
-            obj_type=obj_type,
+            obj_type=obj_types,
             run_mode=run_mode,
             truth_point_mode=truth_point_mode,
             **kwargs,
         )
 
         # Store the parameters
-        self.time_window = time_window
-        if self.time_window is not None and run_mode != "truth":
-            raise ValueError("Cannot restrict timeing of reconstructed particles")
+        normalized_time_window: tuple[float, float] | None = None
+        if time_window is not None:
+            if not isinstance(time_window, Sequence) or len(time_window) != 2:
+                raise ValueError(
+                    "Time window must be specified as an array of two values."
+                )
+            if run_mode != "truth":
+                raise ValueError("Cannot restrict timing of reconstructed particles.")
+            normalized_time_window = (time_window[0], time_window[1])
+        self.time_window = normalized_time_window
 
         # Add necessary point matrices
         if run_mode != "truth":
@@ -72,7 +98,7 @@ class GraphEdgeLengthAna(AnaBase):
         for key in self.particle_keys + self.interaction_keys:
             self.initialize_writer(key)
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Pass data products corresponding to one entry through the analysis.
 
         Parameters
@@ -80,7 +106,7 @@ class GraphEdgeLengthAna(AnaBase):
         data : dict
             Dictionary of data products
         """
-        # Loop over aggregarted objects (reco/truth particles/interactions)
+        # Loop over aggregated objects (reco/truth particles/interactions)
         for key in self.particle_keys + self.interaction_keys:
             # Loop over all objects of that type
             for obj in data[key]:
@@ -93,19 +119,25 @@ class GraphEdgeLengthAna(AnaBase):
                 else:
                     self.store_distances(key, points, obj, obj.particles)
 
-    def store_distances(self, key, points, group, constituents):
-        """Store the pair-wise distances between constituents of an aggregated object.
+    def store_distances(
+        self,
+        key: str,
+        points: NDArray[np.floating],
+        group: Any,
+        constituents: Sequence[Any],
+    ) -> None:
+        """Store pairwise distances between constituents of one aggregate object.
 
         Parameters
         ----------
         key : str
             Name of the aggregated object
         points : np.ndarray
-            Set of point locations for this this of object
+            Set of point locations for this object collection
         group : object
             Aggregated object (particle or interaction)
-        constituents : List[object]
-            List of constiuents that make up the aggregated object (fragment or particle)
+        constituents : Sequence[object]
+            Constituents that make up the aggregated object
         """
         # Skip if there is one or less constituent
         if len(constituents) < 2:
@@ -117,18 +149,23 @@ class GraphEdgeLengthAna(AnaBase):
                 return
 
         # Compute the pair-wise distances constituent-to-constituent
-        dists = inter_cluster_distance(points, [const.index for const in constituents])
+        dists = np.asarray(
+            inter_cluster_distance(points, [const.index for const in constituents]),
+            dtype=np.float64,
+        )
         dists[np.diag_indices_from(dists)] = 1e9
 
         # Compute the minimum distance within each shape pair
-        shapes = np.array([const.shape for const in constituents])
+        shapes = np.asarray([const.shape for const in constituents], dtype=np.int64)
         unique_shapes = np.unique(shapes)
-        shape_indexes = [np.where(shapes == s)[0] for s in unique_shapes]
+        shape_indexes: list[NDArray[np.int64]] = [
+            np.where(shapes == s)[0] for s in unique_shapes
+        ]
         for i, shape_i in enumerate(unique_shapes):
             index_i = shape_indexes[i]
-            for j, shape_j in enumerate(unique_shapes[i:]):
+            for offset, shape_j in enumerate(unique_shapes[i:]):
                 # Skip single shape pairs if there is only one
-                index_j = shape_indexes[j]
+                index_j = shape_indexes[i + offset]
                 if shape_i == shape_j and len(index_i) < 2:
                     continue
 
@@ -136,9 +173,10 @@ class GraphEdgeLengthAna(AnaBase):
                 dists_shape = dists[index_i]
                 argmins = np.argmin(dists_shape[:, index_j], axis=1)
                 for k, argmin in enumerate(argmins):
+                    sink_index = int(index_j[argmin])
                     const_i, const_j = (
                         constituents[index_i[k]],
-                        constituents[index_j[argmin]],
+                        constituents[sink_index],
                     )
                     out = {
                         "id": group.id,
@@ -146,6 +184,6 @@ class GraphEdgeLengthAna(AnaBase):
                         "sink_id": const_j.id,
                         "source_shape": const_i.shape,
                         "sink_shape": const_j.shape,
-                        "length": dists_shape[k, argmin],
+                        "length": dists_shape[k, sink_index],
                     }
                     self.append(key, **out)

--- a/src/spine/ana/diag/shower.py
+++ b/src/spine/ana/diag/shower.py
@@ -1,5 +1,10 @@
 """Module to evaluate diagnostic metrics on showers."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 from spine.ana.base import AnaBase
 
 __all__ = ["ShowerStartDEdxAna"]
@@ -19,29 +24,35 @@ class ShowerStartDEdxAna(AnaBase):
 
     def __init__(
         self,
-        radius,
-        obj_type="particle",
-        run_mode="both",
-        truth_point_mode="points",
-        truth_dep_mode="depositions",
-        **kwargs,
-    ):
+        radius: float | Sequence[float],
+        obj_type: str | Sequence[str] | None = "particle",
+        run_mode: str = "both",
+        truth_point_mode: str = "points",
+        truth_dep_mode: str = "depositions",
+        **kwargs: Any,
+    ) -> None:
         """Initialize the analysis script.
 
         Parameters
         ----------
-        radius : Union[float, List[float]]
-            Radius around the start point for which evaluate dE/dx
+        radius : float or Sequence[float]
+            Radius around the start point within which to evaluate dE/dx
         **kwargs : dict, optional
             Additional arguments to pass to :class:`AnaBase`
         """
         # Initialize the parent class
-        super().__init__(obj_type, run_mode, truth_point_mode, truth_dep_mode, **kwargs)
+        super().__init__(
+            obj_type=obj_type,
+            run_mode=run_mode,
+            truth_point_mode=truth_point_mode,
+            truth_dep_mode=truth_dep_mode,
+            **kwargs,
+        )
 
         # Store parameters
         self.radius = radius
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Evaluate shower start dE/dx for one entry.
 
         Parameters

--- a/src/spine/ana/diag/track.py
+++ b/src/spine/ana/diag/track.py
@@ -1,8 +1,12 @@
 """Module to evaluate diagnostic metrics on tracks."""
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 import numpy as np
+from numpy.typing import NDArray
 
 from spine.ana.base import AnaBase
 from spine.constants import MUON_PID, TRACK_SHP
@@ -12,11 +16,10 @@ __all__ = ["TrackCompletenessAna"]
 
 
 class TrackCompletenessAna(AnaBase):
-    """This analysis script identifies gaps in tracks and measures the
-    cumulative length of these gaps relative to the track length.
+    """Identify gaps in tracks and measure their cumulative missing length.
 
     This is a useful diagnostic tool to evaluate the space-point efficiency
-    on tracks (good standard candal as track should have exactly no gap in
+    on tracks (a good standard candle, as tracks should have no gaps in
     a perfectly efficient detector).
     """
 
@@ -25,37 +28,45 @@ class TrackCompletenessAna(AnaBase):
 
     def __init__(
         self,
-        time_window: Optional[Union[List[float], Tuple[float, float]]] = None,
-        length_threshold: Optional[float] = 10,
-        include_pids: Optional[Union[Tuple[int], List[int]]] = (MUON_PID,),
+        time_window: Sequence[float] | None = None,
+        length_threshold: float | None = 10,
+        include_pids: Sequence[int] | None = (MUON_PID,),
         run_mode: str = "both",
         truth_point_mode: str = "points",
         **kwargs,
-    ):
+    ) -> None:
         """Initialize the analysis script.
 
         Parameters
         ----------
-        time_window : List[float]
+        time_window : Sequence[float], optional
             Time window within which to include particle (only works for `truth`)
         length_threshold : float, optional
             Minimum length of tracks to consider, in cm
-        include_pids : Union[Tuple[int], List[int]], optional
+        include_pids : Sequence[int], optional
             Particle IDs to include in the analysis
         **kwargs : dict, optional
             Additional arguments to pass to :class:`AnaBase`
         """
         # Initialize the parent class
-        super().__init__("particle", run_mode, truth_point_mode, **kwargs)
+        super().__init__(
+            obj_type="particle",
+            run_mode=run_mode,
+            truth_point_mode=truth_point_mode,
+            **kwargs,
+        )
 
         # Store the time window
-        self.time_window = time_window
-        assert (
-            time_window is None or len(time_window) == 2
-        ), "Time window must be specified as an array of two values."
-        assert (
-            time_window is None or run_mode == "truth"
-        ), "Time of reconstructed particle is unknown."
+        normalized_time_window: tuple[float, float] | None = None
+        if time_window is not None:
+            if not isinstance(time_window, Sequence) or len(time_window) != 2:
+                raise ValueError(
+                    "Time window must be specified as an array of two values."
+                )
+            if run_mode != "truth":
+                raise ValueError("Time of reconstructed particle is unknown.")
+            normalized_time_window = (time_window[0], time_window[1])
+        self.time_window = normalized_time_window
 
         # Store the length threshold and included PIDs
         self.length_threshold = length_threshold
@@ -68,18 +79,17 @@ class TrackCompletenessAna(AnaBase):
         for prefix in self.prefixes:
             self.initialize_writer(prefix)
 
-    def process(self, data: Dict[str, Any]) -> None:
+    def process(self, data: Mapping[str, Any]) -> None:
         """Evaluate track completeness for tracks in one entry.
 
         Parameters
         ----------
-        data : Dict[str, Any]
+        data : dict
             Dictionary of data products
         """
         # Fetch the pixel size in this image (assume cubic cells)
-        assert np.all(
-            data["meta"].size[0] == data["meta"].size
-        ), "Non-cubic pixels not supported."
+        if not np.all(data["meta"].size[0] == data["meta"].size):
+            raise ValueError("Non-cubic pixels not supported.")
         pixel_size = data["meta"].size[0]
 
         # Loop over the types of particle data products
@@ -150,10 +160,12 @@ class TrackCompletenessAna(AnaBase):
 
     @staticmethod
     def cluster_track_chunks(
-        points, start_point: np.ndarray, end_point: np.ndarray, pixel_size: float
-    ) -> np.ndarray:
-        """Find point where the track is broken, divide out the track
-        into self-contained chunks which are Linf connect (Moore neighbors).
+        points: NDArray[np.floating],
+        start_point: NDArray[np.floating],
+        end_point: NDArray[np.floating],
+        pixel_size: float,
+    ) -> NDArray[np.integer]:
+        """Split a track into chunks at gaps along its main axis.
 
         Parameters
         ----------
@@ -179,7 +191,7 @@ class TrackCompletenessAna(AnaBase):
         perm = np.argsort(projs)
         seps = projs[perm][1:] - projs[perm][:-1]
         breaks = np.where(seps > min_gap * 1.1)[0] + 1
-        cluster_labels = np.empty(len(projs), dtype=int)
+        cluster_labels = np.empty(len(projs), dtype=np.int64)
         for i, index in enumerate(np.split(np.arange(len(projs)), breaks)):
             cluster_labels[perm[index]] = i
 
@@ -187,8 +199,10 @@ class TrackCompletenessAna(AnaBase):
 
     @staticmethod
     def sequential_cluster_distances(
-        points: np.ndarray, labels: np.ndarray, start_point: np.ndarray
-    ) -> np.ndarray:
+        points: NDArray[np.floating],
+        labels: NDArray[np.integer],
+        start_point: NDArray[np.floating],
+    ) -> NDArray[np.floating]:
         """Order clusters in order of distance from a starting point, compute
         the distances between successive clusters.
 
@@ -204,18 +218,18 @@ class TrackCompletenessAna(AnaBase):
         # If there's only one cluster, nothing to do here
         unique_labels = np.unique(labels)
         if len(unique_labels) < 2:
-            return np.empty(0, dtype=float)
+            return np.empty(0, dtype=np.float64)
 
         # Order clusters
         start_dist = cdist(start_point[None, :], points).flatten()
-        start_clust_dist = np.empty(len(unique_labels))
+        start_clust_dist = np.empty(len(unique_labels), dtype=np.float64)
         for i, c in enumerate(unique_labels):
             start_clust_dist[i] = np.min(start_dist[labels == c])
         ordered_labels = unique_labels[np.argsort(start_clust_dist)]
 
         # Compute the intercluster distance and relative angle
         n_gaps = len(ordered_labels) - 1
-        dists = np.empty(n_gaps, dtype=float)
+        dists = np.empty(n_gaps, dtype=np.float64)
         for i in range(n_gaps):
             points_i = points[labels == ordered_labels[i]]
             points_j = points[labels == ordered_labels[i + 1]]

--- a/src/spine/ana/factories.py
+++ b/src/spine/ana/factories.py
@@ -1,5 +1,10 @@
 """Construct an analysis script module class from its name."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
 from spine.utils.factory import instantiate, module_dict
 
 from . import calib, diag, metric, script
@@ -11,8 +16,13 @@ for module in [calib, diag, metric, script]:
 
 
 def ana_script_factory(
-    name, cfg, overwrite=None, log_dir=None, prefix=None, buffer_size=1
-):
+    name: str,
+    cfg: Mapping[str, Any],
+    overwrite: bool | None = None,
+    log_dir: str | None = None,
+    prefix: str | None = None,
+    buffer_size: int = 1,
+) -> Any:
     """Instantiates an analyzer module from a configuration dictionary.
 
     Parameters
@@ -40,13 +50,14 @@ def ana_script_factory(
          Initialized analyzer object
     """
     # Provide the name to the configuration
-    cfg["name"] = name
+    config = dict(cfg)
+    config["name"] = name
 
     # Instantiate the analysis script module
     if overwrite is not None:
         return instantiate(
             ANA_DICT,
-            cfg,
+            config,
             overwrite=overwrite,
             log_dir=log_dir,
             prefix=prefix,
@@ -54,5 +65,5 @@ def ana_script_factory(
         )
     else:
         return instantiate(
-            ANA_DICT, cfg, log_dir=log_dir, prefix=prefix, buffer_size=buffer_size
+            ANA_DICT, config, log_dir=log_dir, prefix=prefix, buffer_size=buffer_size
         )

--- a/src/spine/ana/manager.py
+++ b/src/spine/ana/manager.py
@@ -4,31 +4,17 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from collections.abc import Mapping
-from typing import Any, Protocol
+from typing import Any
 
 from spine.utils.factory import parse_module_config
 from spine.utils.manager import ModuleManager
 from spine.utils.stopwatch import StopwatchManager
 
+from .base import AnaBase
 from .factories import ana_script_factory
 
 
-class AnaModule(Protocol):
-    """Analysis module interface used by :class:`AnaManager`."""
-
-    def __call__(
-        self, data: dict[str, Any], entry: int | None = None
-    ) -> dict[str, Any] | None:
-        """Process input data and return products to merge into it."""
-
-    def close_writers(self) -> None:
-        """Close all CSV writers owned by the module."""
-
-    def flush_writers(self) -> None:
-        """Flush all CSV writers owned by the module."""
-
-
-class AnaManager(ModuleManager[AnaModule]):
+class AnaManager(ModuleManager[AnaBase]):
     """Manager class to initialize and execute analysis scripts.
 
     Analysis scripts use the output of the reconstruction chain and the
@@ -114,7 +100,7 @@ class AnaManager(ModuleManager[AnaModule]):
 
         # Add the modules to a processor list in decreasing order of priority
         self.watch = StopwatchManager()
-        module_map: OrderedDict[str, AnaModule] = OrderedDict()
+        module_map: OrderedDict[str, AnaBase] = OrderedDict()
         parsed = parse_module_config(
             modules, sort_by_priority=True, priority_descending=True
         )

--- a/src/spine/ana/manager.py
+++ b/src/spine/ana/manager.py
@@ -1,16 +1,34 @@
 """Manages the operation of analysis scripts."""
 
-from collections import OrderedDict, defaultdict
-from copy import deepcopy
+from __future__ import annotations
 
-import numpy as np
+from collections import OrderedDict
+from collections.abc import Mapping
+from typing import Any, Protocol
 
+from spine.utils.factory import parse_module_config
+from spine.utils.manager import ModuleManager
 from spine.utils.stopwatch import StopwatchManager
 
 from .factories import ana_script_factory
 
 
-class AnaManager:
+class AnaModule(Protocol):
+    """Analysis module interface used by :class:`AnaManager`."""
+
+    def __call__(
+        self, data: dict[str, Any], entry: int | None = None
+    ) -> dict[str, Any] | None:
+        """Process input data and return products to merge into it."""
+
+    def close_writers(self) -> None:
+        """Close all CSV writers owned by the module."""
+
+    def flush_writers(self) -> None:
+        """Flush all CSV writers owned by the module."""
+
+
+class AnaManager(ModuleManager[AnaModule]):
     """Manager class to initialize and execute analysis scripts.
 
     Analysis scripts use the output of the reconstruction chain and the
@@ -20,7 +38,12 @@ class AnaManager:
     CSV writers needed to store the output of the analysis scripts.
     """
 
-    def __init__(self, cfg, log_dir=None, prefix=None):
+    def __init__(
+        self,
+        cfg: Mapping[str, Any],
+        log_dir: str | None = None,
+        prefix: str | None = None,
+    ) -> None:
         """Initialize the analysis manager.
 
         Parameters
@@ -34,17 +57,38 @@ class AnaManager:
             all the output CSV files.
         """
         # Parse the analysis block configuration
-        self.parse_config(log_dir, prefix, **cfg)
+        config = dict(cfg)
+
+        overwrite = config.pop("overwrite", None)
+        if overwrite is not None and not isinstance(overwrite, bool):
+            raise TypeError("`overwrite` must be a boolean when provided.")
+
+        prefix_output = config.pop("prefix_output", False)
+        if not isinstance(prefix_output, bool):
+            raise TypeError("`prefix_output` must be a boolean.")
+
+        buffer_size = config.pop("buffer_size", 1)
+        if not isinstance(buffer_size, int):
+            raise TypeError("`buffer_size` must be an integer.")
+
+        self.parse_config(
+            log_dir,
+            prefix,
+            overwrite=overwrite,
+            prefix_output=prefix_output,
+            buffer_size=buffer_size,
+            **config,
+        )
 
     def parse_config(
         self,
-        log_dir,
-        prefix,
-        overwrite=None,
-        prefix_output=False,
-        buffer_size=1,
-        **modules,
-    ):
+        log_dir: str | None,
+        prefix: str | None,
+        overwrite: bool | None = None,
+        prefix_output: bool = False,
+        buffer_size: int = 1,
+        **modules: dict[str, Any] | None,
+    ) -> None:
         """Parse the analysis tool configuration.
 
         Parameters
@@ -64,82 +108,41 @@ class AnaManager:
         **modules : dict
             List of analysis script modules
         """
-        # Loop over the analyzer modules and get their priorities
-        modules = deepcopy(modules)
-        keys = np.array(list(modules.keys()))
-        priorities = -np.ones(len(keys), dtype=np.int32)
-        for i, k in enumerate(keys):
-            if "priority" in modules[k]:
-                priorities[i] = modules[k].pop("priority")
-
         # Only use the prefix if the output is to be prefixed
         if not prefix_output:
             prefix = None
 
         # Add the modules to a processor list in decreasing order of priority
         self.watch = StopwatchManager()
-        self.modules = OrderedDict()
-        keys = keys[np.argsort(-priorities)]
-        for k in keys:
+        module_map: OrderedDict[str, AnaModule] = OrderedDict()
+        parsed = parse_module_config(
+            modules, sort_by_priority=True, priority_descending=True
+        )
+        for key, spec in parsed.items():
             # Profile the module
-            self.watch.initialize(k)
+            self.watch.initialize(key)
 
             # Append
-            self.modules[k] = ana_script_factory(
-                k, modules[k], overwrite, log_dir, prefix, buffer_size
+            module_map[key] = ana_script_factory(
+                spec["name"],
+                spec["cfg"],
+                overwrite,
+                log_dir,
+                prefix,
+                buffer_size,
             )
+        self.modules = module_map
 
-    def __call__(self, data):
-        """Pass one batch of data through the analysis scripts
-
-        Parameters
-        ----------
-        data : dict
-            Dictionary of data products
-        """
-        # Reset active stopwatches
-        self.watch.reset_if_active()
-
-        # Loop over the analysis script modules
-        single_entry = np.isscalar(data["index"])
-        for key, module in self.modules.items():
-            # Run the analysis script on each entry
-            self.watch.start(key)
-            if single_entry:
-                num_entries = 1
-                result = module(data)
-
-            else:
-                num_entries = len(data["index"])
-                result = defaultdict(list)
-                for entry in range(num_entries):
-                    result_e = module(data, entry)
-                    if result_e is not None:
-                        for k, v in result_e.items():
-                            result[k].append(v)
-
-            self.watch.stop(key)
-
-            # Update the input dictionary
-            if result is not None:
-                for key, val in result.items():
-                    if not single_entry:
-                        assert len(val) == num_entries, (
-                            f"The number {key} ({len(val)}) does not match "
-                            f"the number of entries ({num_entries})."
-                        )
-                    data[key] = val
-
-    def close(self):
+    def close(self) -> None:
         """Close all analysis script writers and flush remaining data.
 
         This should be called when analysis is complete to ensure all
         CSV files are properly closed and data is written.
         """
-        for module in self.modules.values():
+        for module in getattr(self, "modules", {}).values():
             module.close_writers()
 
-    def flush(self):
+    def flush(self) -> None:
         """Flush all analysis script writer buffers.
 
         This forces any buffered data to be written to disk without
@@ -148,7 +151,7 @@ class AnaManager:
         for module in self.modules.values():
             module.flush_writers()
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Destructor to ensure analysis writers are closed.
 
         Acts as a safety net in case close() is not called explicitly.

--- a/src/spine/ana/metric/cluster.py
+++ b/src/spine/ana/metric/cluster.py
@@ -233,7 +233,8 @@ class ClusterAna(AnaBase):
             for metric, func in self.metrics.items():
                 valid_index = np.where((preds > -1) & (labels > -1))[0]
                 row_dict[metric] = func(labels[valid_index], preds[valid_index])
-                if self.per_shape and shapes is not None:
+                if self.per_shape and obj_type != "interaction":
+                    assert shapes is not None
                     for shape in range(LOWES_SHP):
                         shape_index = np.where((shapes == shape) & (labels > -1))[0]
                         row_dict[f"{metric}_{shape}"] = func(

--- a/src/spine/ana/metric/cluster.py
+++ b/src/spine/ana/metric/cluster.py
@@ -1,6 +1,12 @@
 """Analysis script used to evaluate the clustering accuracy."""
 
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
 import numpy as np
+from numpy.typing import NDArray
 
 import spine.utils.metrics
 from spine.ana.base import AnaBase
@@ -11,8 +17,8 @@ __all__ = ["ClusterAna"]
 
 
 class ClusterAna(AnaBase):
-    """Class which computes and stores the necessary data to evaluate
-    clustering metrics at different aggregation stages:
+    """Compute clustering metrics at different aggregation stages:
+
     - fragments
     - particles
     - interactions
@@ -30,21 +36,21 @@ class ClusterAna(AnaBase):
 
     def __init__(
         self,
-        obj_type=None,
-        use_objects=False,
-        per_object=True,
-        per_shape=True,
-        metrics=("pur", "eff", "ari"),
-        label_key="clust_label_adapt",
-        label_col=None,
-        truth_index_mode="index_adapt",
-        **kwargs,
-    ):
+        obj_type: str | Sequence[str] | None = None,
+        use_objects: bool = False,
+        per_object: bool = True,
+        per_shape: bool = True,
+        metrics: Sequence[str] = ("pur", "eff", "ari"),
+        label_key: str = "clust_label_adapt",
+        label_col: str | None = None,
+        truth_index_mode: str = "index_adapt",
+        **kwargs: Any,
+    ) -> None:
         """Initialize the analysis script.
 
         Parameters
         ----------
-        obj_type : Union[str, List[str]], optional
+        obj_type : str or Sequence[str], optional
             Name or list of names of the object types to process
         use_objects : bool, default False
             If `True`, rebuild the clustering assignments for truth and reco
@@ -55,7 +61,7 @@ class ClusterAna(AnaBase):
         per_shape : bool, default True
             Evaluate the clustering accuracy for each object shape (not
             relevant in the case of interactions)
-        metrics : Tuple[str], default ('pur', 'eff', 'ari')
+        metrics : Sequence[str], default ('pur', 'eff', 'ari')
             List of clustering metrics to evaluate
         label_key : str, default 'clust_label_adapt'
             Name of the tensor which contains the cluster labels, when
@@ -69,25 +75,34 @@ class ClusterAna(AnaBase):
             Additional arguments to pass to :class:`AnaBase`
         """
         # Check parameters
-        assert obj_type is not None or not per_object, (
-            "If evaluating clustering metrics per object, provide a list "
-            "of object types to evaluate the clustering for."
-        )
-        assert per_object or label_col is not None, (
-            "If evaluating clustering standalone (not per object), must "
-            "provide the name of the target clustering label column."
-        )
-        assert per_object or not use_objects, (
-            "If evaluating clustering standalone (not per object), cannot "
-            "use objects to evaluate it."
-        )
+        if obj_type is None and per_object:
+            raise ValueError(
+                "If evaluating clustering metrics per object, provide a list "
+                "of object types to evaluate the clustering for."
+            )
+        if not per_object and label_col is None:
+            raise ValueError(
+                "If evaluating clustering standalone (not per object), must "
+                "provide the name of the target clustering label column."
+            )
+        if not per_object and use_objects:
+            raise ValueError(
+                "If evaluating clustering standalone (not per object), cannot "
+                "use objects to evaluate it."
+            )
+        standalone_label_col = label_col if not per_object else None
 
         # Initialize the parent class
-        super().__init__(obj_type, "both", truth_index_mode=truth_index_mode, **kwargs)
+        super().__init__(
+            obj_type=obj_type,
+            run_mode="both",
+            truth_index_mode=truth_index_mode,
+            **kwargs,
+        )
 
         # If the clustering is not done per object, fix target
-        if not per_object:
-            self.obj_type = [label_col]
+        if standalone_label_col is not None:
+            self.obj_type = [standalone_label_col]
 
         # Store the basic parameters
         self.use_objects = use_objects
@@ -96,12 +111,14 @@ class ClusterAna(AnaBase):
         self.label_key = label_key
 
         # Parse the label_col column, if necessary
-        self.label_col = None
-        if label_col is not None:
-            self.label_col = enum_factory("cluster", label_col)
+        self.label_col: int | None = (
+            enum_factory("cluster", label_col) if label_col is not None else None
+        )
 
         # Convert metric strings to functions
-        self.metrics = {m: getattr(spine.utils.metrics, m) for m in metrics}
+        self.metrics: dict[str, Callable[..., float]] = {
+            m: getattr(spine.utils.metrics, m) for m in metrics
+        }
 
         # If objects are not used, remove them from the required keys
         keys = self.keys
@@ -134,18 +151,18 @@ class ClusterAna(AnaBase):
             self.initialize_writer(obj)
 
     @property
-    def label_cols(self):
+    def label_cols(self) -> dict[str, int]:
         """Dictionary of (key, column_id) pairs which determine which column
         in the label tensor corresponds to a specific clustering target.
 
         Returns
         -------
-        Dict[str, int]
+        dict[str, int]
             Dictionary of (key, column_id) mapping from name to label column
         """
         return dict(self._label_cols)
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Store the clustering metrics for one entry.
 
         Parameters
@@ -155,35 +172,44 @@ class ClusterAna(AnaBase):
         """
         # Loop over the different object types
         for obj_type in self.obj_type:
+            shapes: NDArray[np.int32] | None = None
+
             # Build the cluster labels for this object type
             if not self.use_objects:
                 # Fetch the right label column
                 label_col = self.label_col or self.label_cols[obj_type]
                 num_points = len(data[self.label_key])
-                labels = data[self.label_key][:, label_col]
+                labels = data[self.label_key][:, label_col].astype(
+                    np.int32,
+                    copy=False,
+                )
                 if obj_type != "interaction":
-                    shapes = data[self.label_key][:, SHAPE_COL]
+                    shapes = data[self.label_key][:, SHAPE_COL].astype(
+                        np.int32,
+                        copy=False,
+                    )
                 num_truth = len(np.unique(labels[labels > -1]))
 
             else:
                 # Rebuild the labels
                 num_points = len(data["points"])
-                labels = -np.ones(num_points)
+                labels = np.full(num_points, -1, dtype=np.int32)
                 num_truth = len(data[f"truth_{obj_type}s"])
                 for i, obj in enumerate(data[f"truth_{obj_type}s"]):
                     labels[self.get_index(obj)] = i
 
             # Build the cluster predictions for this object type
-            preds = -np.ones(num_points)
+            preds = np.full(num_points, -1, dtype=np.int32)
             if self.per_object:
-                shapes = -np.full(num_points, LOWES_SHP)
+                pred_shapes = np.full(num_points, -LOWES_SHP, dtype=np.int32)
+                shapes = pred_shapes
                 if not self.use_objects:
                     # Use clusters directly from the full chain output
                     num_reco = len(data[f"{obj_type}_clusts"])
                     for i, index in enumerate(data[f"{obj_type}_clusts"]):
                         preds[index] = i
                         if obj_type != "interaction":
-                            shapes[index] = data[f"{obj_type}_shapes"][i]
+                            pred_shapes[index] = data[f"{obj_type}_shapes"][i]
 
                 else:
                     # Use clusters from the object indexes
@@ -191,19 +217,15 @@ class ClusterAna(AnaBase):
                     for i, obj in enumerate(data[f"reco_{obj_type}s"]):
                         preds[obj.index] = i
                         if obj_type != "interaction":
-                            shapes[obj.index] = obj.shape
+                            pred_shapes[obj.index] = obj.shape
 
             else:
                 num_reco = len(data["clusts"])
                 for i, index in enumerate(data["clusts"]):
-                    preds[index] = data["group_pred"][i]
-
-            # Cast the labels and predictions to int32 for metric functions
-            labels = labels.astype(np.int32)
-            preds = preds.astype(np.int32)
+                    preds[index] = int(data["group_pred"][i])
 
             # Evaluate clustering metrics
-            row_dict = {
+            row_dict: dict[str, int | float] = {
                 "num_points": num_points,
                 "num_truth": num_truth,
                 "num_reco": num_reco,
@@ -211,7 +233,7 @@ class ClusterAna(AnaBase):
             for metric, func in self.metrics.items():
                 valid_index = np.where((preds > -1) & (labels > -1))[0]
                 row_dict[metric] = func(labels[valid_index], preds[valid_index])
-                if self.per_shape and obj_type != "interaction":
+                if self.per_shape and shapes is not None:
                     for shape in range(LOWES_SHP):
                         shape_index = np.where((shapes == shape) & (labels > -1))[0]
                         row_dict[f"{metric}_{shape}"] = func(

--- a/src/spine/ana/metric/optical.py
+++ b/src/spine/ana/metric/optical.py
@@ -1,4 +1,9 @@
-"""Analysis script used to evaluate the semantic segmentation accuracy."""
+"""Analysis script used to evaluate optical flash matching."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 from spine.ana.base import AnaBase
 from spine.data.out import RecoInteraction, TruthInteraction
@@ -7,9 +12,7 @@ __all__ = ["FlashMatchingAna"]
 
 
 class FlashMatchingAna(AnaBase):
-    """Class which computes and stores the necessary data to build a
-    semantic segmentation confusion matrix.
-    """
+    """Store reco/truth interaction rows for flash matching performance studies."""
 
     # Name of the analysis script (as specified in the configuration)
     name = "flash_match_eval"
@@ -25,22 +28,22 @@ class FlashMatchingAna(AnaBase):
 
     def __init__(
         self,
-        time_window=None,
-        neutrino_only=True,
-        max_num_flashes=1,
-        match_mode="both",
-        **kwargs,
-    ):
+        time_window: Sequence[float] | None = None,
+        neutrino_only: bool = True,
+        max_num_flashes: int = 1,
+        match_mode: str = "both",
+        **kwargs: Any,
+    ) -> None:
         """Initialize the analysis script.
 
         Parameters
         ----------
-        time_window : List[float], optional
+        time_window : Sequence[float], optional
             Time window (in ns) for which interactions must have matched flash
-        neutrino_only : bool, default False
+        neutrino_only : bool, default True
             If `True`, only check if neutrino in-time activity is matched for
             the efficiency measurement (as opposed to any in-time activity)
-        max_num_flashes : int
+        max_num_flashes : int, default 1
             Maximum number of flash matches to store
         match_mode : str, default 'both'
             If reconstructed and truth are available, specified which matching
@@ -49,10 +52,17 @@ class FlashMatchingAna(AnaBase):
             Additional arguments to pass to :class:`AnaBase`
         """
         # Initialize the parent class
-        super().__init__("interaction", "both", **kwargs)
+        super().__init__(obj_type="interaction", run_mode="both", **kwargs)
 
         # Store basic parameters
-        self.time_window = time_window
+        normalized_time_window: tuple[float, float] | None = None
+        if time_window is not None:
+            if not isinstance(time_window, Sequence) or len(time_window) != 2:
+                raise ValueError(
+                    "Time window must be specified as an array of two values."
+                )
+            normalized_time_window = (time_window[0], time_window[1])
+        self.time_window = normalized_time_window
         self.neutrino_only = neutrino_only
 
         # Store default objects as a dictionary
@@ -60,10 +70,11 @@ class FlashMatchingAna(AnaBase):
 
         # Store the matching mode
         self.match_mode = match_mode
-        assert match_mode in self._match_modes, (
-            f"Invalid matching mode: {self.match_mode}. Must be one "
-            f"of {self._match_modes}."
-        )
+        if match_mode not in self._match_modes:
+            raise ValueError(
+                f"Invalid matching mode: {self.match_mode}. Must be one "
+                f"of {self._match_modes}."
+            )
 
         # Make sure the matches are loaded, initialize the output files
         keys = {}
@@ -93,8 +104,14 @@ class FlashMatchingAna(AnaBase):
             k: max_num_flashes for k in ["flash_ids", "flash_times", "flash_scores"]
         }
 
-        self.reco_attrs = ("id", "size", "is_contained", "topology", *flash_attrs)
-        self.truth_attrs = (
+        self.reco_attrs: tuple[str, ...] = (
+            "id",
+            "size",
+            "is_contained",
+            "topology",
+            *flash_attrs,
+        )
+        self.truth_attrs: tuple[str, ...] = (
             "id",
             "size",
             "is_contained",
@@ -104,10 +121,10 @@ class FlashMatchingAna(AnaBase):
             *nu_attrs,
         )
 
-        self.reco_lengths = flash_lengths
-        self.truth_lengths = None
+        self.reco_lengths: dict[str, int] | None = flash_lengths
+        self.truth_lengths: dict[str, int] | None = None
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Store the flash matching metrics for one entry.
 
         Parameters

--- a/src/spine/ana/metric/point.py
+++ b/src/spine/ana/metric/point.py
@@ -1,5 +1,10 @@
 """Analysis script used to evaluate the point proposal accuracy."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
 import numpy as np
 from scipy.spatial.distance import cdist
 
@@ -34,16 +39,20 @@ class PointProposalAna(AnaBase):
     _keys = (("ppn_pred", True),)
 
     def __init__(
-        self, num_classes=LOWES_SHP, label_key="ppn_label", endpoints=False, **kwargs
-    ):
+        self,
+        num_classes: int = LOWES_SHP,
+        label_key: str = "ppn_label",
+        endpoints: bool = False,
+        **kwargs: Any,
+    ) -> None:
         """Initialize the analysis script.
 
         Parameters
         ----------
         num_classes : int, default 4
-            Number of pixel classses, excluding the ghost class
-        label_key : str, default 'seg_label'
-            Name of the tensor which contains the segmentation labels
+            Number of pixel classes, excluding the ghost class
+        label_key : str, default 'ppn_label'
+            Name of the tensor which contains point proposal labels
         endpoints : bool, default False
             Evaluate the accuracy of end point classification
         **kwargs : dict, optional
@@ -72,8 +81,8 @@ class PointProposalAna(AnaBase):
             self.dummy_dict["end"] = -1
             self.dummy_dict["closest_end"] = -1
 
-    def process(self, data):
-        """Store the semantic segmentation metrics for one entry.
+    def process(self, data: Mapping[str, Any]) -> None:
+        """Store the point proposal metrics for one entry.
 
         Parameters
         ----------

--- a/src/spine/ana/metric/segment.py
+++ b/src/spine/ana/metric/segment.py
@@ -123,7 +123,7 @@ class SegmentAna(AnaBase):
                 # If there are ghost, must combine the predictions
                 full_seg_pred = np.full_like(seg_label, GHOST_SHP, dtype=np.int32)
                 deghost_mask = np.argmax(data["ghost"], axis=1) == 0
-                full_seg_pred[deghost_mask] = seg_pred[deghost_mask]
+                full_seg_pred[deghost_mask] = seg_pred
                 seg_pred = full_seg_pred
 
             if not self.summary:
@@ -133,7 +133,7 @@ class SegmentAna(AnaBase):
                     # If there are ghosts, interpret the non-ghost score
                     # as a shared score for all other classes.
                     full_seg_scores = np.zeros(
-                        (len(seg_scores), self.num_classes), dtype=seg_scores.dtype
+                        (len(seg_label), self.num_classes), dtype=seg_scores.dtype
                     )
                     ghost_scores = softmax(data["ghost"], axis=1)
                     full_seg_scores[:, :-1] = ghost_scores[:, 0, None] / (
@@ -141,7 +141,7 @@ class SegmentAna(AnaBase):
                     )
                     full_seg_scores[:, -1] = ghost_scores[:, 1]
 
-                    full_seg_scores[deghost_mask, :-1] = seg_scores[deghost_mask]
+                    full_seg_scores[deghost_mask, :-1] = seg_scores
                     seg_scores = full_seg_scores
 
         else:

--- a/src/spine/ana/metric/segment.py
+++ b/src/spine/ana/metric/segment.py
@@ -1,5 +1,10 @@
 """Analysis script used to evaluate the semantic segmentation accuracy."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
 import numpy as np
 from scipy.special import softmax
 
@@ -10,23 +15,21 @@ __all__ = ["SegmentAna"]
 
 
 class SegmentAna(AnaBase):
-    """Class which computes and stores the necessary data to build a
-    semantic segmentation confusion matrix.
-    """
+    """Compute semantic segmentation confusion summaries or per-pixel rows."""
 
     # Name of the analysis script (as specified in the configuration)
     name = "segment_eval"
 
     def __init__(
         self,
-        summary=True,
-        num_classes=GHOST_SHP,
-        ghost=False,
-        use_fragments=False,
-        use_particles=False,
-        label_key="seg_label",
-        **kwargs,
-    ):
+        summary: bool = True,
+        num_classes: int = GHOST_SHP,
+        ghost: bool = False,
+        use_fragments: bool = False,
+        use_particles: bool = False,
+        label_key: str = "seg_label",
+        **kwargs: Any,
+    ) -> None:
         """Initialize the analysis script.
 
         Parameters
@@ -36,7 +39,7 @@ class SegmentAna(AnaBase):
             `False`, store one row per pixel in the image (extremely memory
             intensive but gives details about pixel scores).
         num_classes : int, default 5
-            Number of pixel classses, excluding the ghost class
+            Number of pixel classes, excluding the ghost class
         ghost : bool, default False
             Evaluate deghosting performance
         use_fragments : bool, default False
@@ -66,22 +69,21 @@ class SegmentAna(AnaBase):
         self.use_fragments = use_fragments
         self.use_particles = use_particles
         self.label_key = label_key
+        self.object_collection: str | None = None
 
         # Basic logic checks
-        assert (
-            not use_fragments or not use_particles
-        ), "Cannot use both fragments and particles."
-        assert (
-            not (use_fragments or use_particles) or summary
-        ), "Cannot store detailed score information from fragments/particles."
-        assert (
-            not (use_fragments or use_particles) or not ghost
-        ), "Cannot produce ghost metrics from fragments/particles."
+        if use_fragments and use_particles:
+            raise ValueError("Cannot use both fragments and particles.")
+        if (use_fragments or use_particles) and not summary:
+            raise ValueError(
+                "Cannot store detailed score information from fragments/particles."
+            )
+        if (use_fragments or use_particles) and ghost:
+            raise ValueError("Cannot produce ghost metrics from fragments/particles.")
 
         # List the necessary data products
         keys = self.keys
         if not use_fragments and not use_particles:
-            self.obj_source = None
             keys[label_key] = True
             keys["segmentation"] = True
             if ghost:
@@ -90,9 +92,9 @@ class SegmentAna(AnaBase):
 
         else:
             keys["points"] = True
-            self.obj_type = "fragments" if use_fragments else "particles"
+            self.object_collection = "fragments" if use_fragments else "particles"
             for prefix in ["reco", "truth"]:
-                keys[f"{prefix}_{self.obj_type}"] = True
+                keys[f"{prefix}_{self.object_collection}"] = True
 
         self.keys = keys
 
@@ -102,7 +104,7 @@ class SegmentAna(AnaBase):
         else:
             self.initialize_writer("pixel")
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Store the semantic segmentation metrics for one entry.
 
         Parameters
@@ -121,7 +123,7 @@ class SegmentAna(AnaBase):
                 # If there are ghost, must combine the predictions
                 full_seg_pred = np.full_like(seg_label, GHOST_SHP, dtype=np.int32)
                 deghost_mask = np.argmax(data["ghost"], axis=1) == 0
-                full_seg_pred[deghost_mask] = seg_pred
+                full_seg_pred[deghost_mask] = seg_pred[deghost_mask]
                 seg_pred = full_seg_pred
 
             if not self.summary:
@@ -131,36 +133,40 @@ class SegmentAna(AnaBase):
                     # If there are ghosts, interpret the non-ghost score
                     # as a shared score for all other classes.
                     full_seg_scores = np.zeros(
-                        (len(seg_scores), self.num_classes), dtype=np.int32
+                        (len(seg_scores), self.num_classes), dtype=seg_scores.dtype
                     )
                     ghost_scores = softmax(data["ghost"], axis=1)
-                    full_seg_scores[:, :-1] = ghost_scores[:0] / (self.num_classes - 1)
+                    full_seg_scores[:, :-1] = ghost_scores[:, 0, None] / (
+                        self.num_classes - 1
+                    )
                     full_seg_scores[:, -1] = ghost_scores[:, 1]
 
-                    full_seg_scores[deghost_mask, :-1] = seg_scores
+                    full_seg_scores[deghost_mask, :-1] = seg_scores[deghost_mask]
                     seg_scores = full_seg_scores
 
         else:
+            if self.object_collection is None:
+                raise ValueError("Object collection mode was not initialized.")
             # Rebuild the labels/predictions from the fragment/particle objects
             seg_label = np.full(len(data["points"]), LOWES_SHP, dtype=np.int32)
-            for obj in data[f"truth_{self.obj_type}"]:
-                assert len(obj.index > 0), (
-                    "The `index` of true fragments is not filled, indicating "
-                    "that the original label tensor was modified. Cannot use "
-                    "modified fragments to rebuild semantic labels."
-                )
+            for obj in data[f"truth_{self.object_collection}"]:
+                if len(obj.index) == 0:
+                    raise ValueError(
+                        "The `index` of true fragments is not filled, indicating "
+                        "that the original label tensor was modified. Cannot use "
+                        "modified fragments to rebuild semantic labels."
+                    )
                 seg_label[obj.index] = obj.shape
 
             seg_pred = np.full_like(seg_label, LOWES_SHP)
-            for obj in data[f"reco_{self.obj_type}"]:
+            for obj in data[f"reco_{self.object_collection}"]:
                 seg_pred[obj.index] = obj.shape
 
         # Store the information
         if not self.summary:
             # Store one row per pixel in the image, including pixel scores
-            assert (
-                seg_scores is not None
-            ), "Segment scores not available for detailed storage."
+            if seg_scores is None:
+                raise ValueError("Segment scores not available for detailed storage.")
             for i, (seg_l, seg_p) in enumerate(zip(seg_label, seg_pred)):
                 row_dict = {"label": seg_l, "pred": seg_p}
                 for s in range(self.num_classes):

--- a/src/spine/ana/script/save.py
+++ b/src/spine/ana/script/save.py
@@ -1,5 +1,10 @@
 """Analysis script used to store the reconstruction output to CSV files."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 from spine.ana.base import AnaBase
 from spine.data.out import (
     RecoFragment,
@@ -33,35 +38,36 @@ class SaveAna(AnaBase):
 
     def __init__(
         self,
-        obj_type,
-        fragment=None,
-        particle=None,
-        interaction=None,
-        lengths=None,
-        run_mode="both",
-        match_mode="both",
-        **kwargs,
-    ):
+        obj_type: str | Sequence[str],
+        fragment: Sequence[str] | None = None,
+        particle: Sequence[str] | None = None,
+        interaction: Sequence[str] | None = None,
+        lengths: Mapping[str, int] | None = None,
+        run_mode: str = "both",
+        match_mode: str | None = "both",
+        **kwargs: Any,
+    ) -> None:
         """Initialize the CSV logging class.
 
-        If any of the `fragments`, `particles` or `interactions` are specified
-        as lists of strings, it will be used to restrict the list of
-        object attributes which get stored to CSV.
+        If any of `fragment`, `particle` or `interaction` are specified as
+        sequences of strings, only those object attributes are written.
 
         Parameters
         ----------
-        obj_type : Union[str, List[str]], default ['particle', 'interaction']
-            Objects to build files from
-        fragment : List[str], optional
+        obj_type : str or Sequence[str]
+            Object types to write
+        fragment : Sequence[str], optional
             List of fragment attributes to store
-        particle : List[str], optional
+        particle : Sequence[str], optional
             List of particle attributes to store
-        interaction : List[str], optional
+        interaction : Sequence[str], optional
             List of interaction attributes to store
-        lengths : Dict[str, int], optional
+        lengths : Mapping[str, int], optional
             Lengths to use for variable-length object attributes
+        run_mode : str, default 'both'
+            Whether to write reconstructed, truth, or both object collections.
         match_mode : str, default 'both'
-            If reconstructed and truth are available, specified which matching
+            If reconstructed and truth are available, specifies which matching
             direction(s) should be saved to the log file.
         **kwargs : dict, optional
             Additional arguments to pass to :class:`AnaBase`
@@ -71,24 +77,27 @@ class SaveAna(AnaBase):
 
         # Store the matching mode
         self.match_mode = match_mode
-        assert match_mode in self._match_modes, (
-            f"Invalid matching mode: {self.match_mode}. Must be one "
-            f"of {self._match_modes}."
-        )
-        assert match_mode is None or run_mode == "both", (
-            "When storing matches, you must load both reco and truth "
-            f"objects, i.e. set `run_mode` to `True`. Got {run_mode}."
-        )
+        if match_mode not in self._match_modes:
+            raise ValueError(
+                f"Invalid matching mode: {self.match_mode}. Must be one "
+                f"of {self._match_modes}."
+            )
+        if match_mode is not None and run_mode != "both":
+            raise ValueError(
+                "When storing matches, you must load both reco and truth "
+                f"objects, i.e. set `run_mode` to `both`. Got {run_mode}."
+            )
 
         # Store default objects as a dictionary
         self.default_objs = dict(self._default_objs)
 
         # Store the list of attributes to store for each object type
-        attrs = {
-            "fragments": fragment,
-            "particles": particle,
-            "interactions": interaction,
+        attrs: dict[str, list[str] | None] = {
+            "fragments": list(fragment) if fragment is not None else None,
+            "particles": list(particle) if particle is not None else None,
+            "interactions": list(interaction) if interaction is not None else None,
         }
+        self.attrs: dict[str, list[str] | None]
         if run_mode != "both":
             # If there is only one object type, the keys specified are unique
             self.attrs = {f"{run_mode}_{k}": v for k, v in attrs.items()}
@@ -98,30 +107,37 @@ class SaveAna(AnaBase):
             # each declination of the object knows, as long as either one does
             self.attrs = {}
             for obj_t, attrs_t in attrs.items():
-                # Create a list speicific to each object declination
+                # Create a list specific to each object declination
                 leftover = set(attrs_t) if attrs_t is not None else None
-                for run_mode in ["reco", "truth"]:
-                    key = f"{run_mode}_{obj_t}"
+                for prefix in ["reco", "truth"]:
+                    key = f"{prefix}_{obj_t}"
                     if attrs_t is not None:
                         all_keys = self.default_objs[key].as_dict().keys()
-                        self.attrs[key] = set(attrs_t) & set(all_keys)
-                        leftover -= leftover & self.attrs[key]
+                        attrs_key = sorted(set(attrs_t) & set(all_keys))
+                        self.attrs[key] = attrs_key
+                        if leftover is not None:
+                            leftover -= set(attrs_key)
 
                     else:
                         self.attrs[key] = attrs_t
 
                 # Check that there are no leftover keys
-                assert leftover is None or len(leftover) == 0, (
-                    "The following keys were not found in either the reco "
-                    f"or the truth {obj_t} : {leftover}"
-                )
+                if leftover is not None and len(leftover) > 0:
+                    raise ValueError(
+                        "The following keys were not found in either the reco "
+                        f"or the truth {obj_t} : {leftover}"
+                    )
 
         # Store the list of variable-length array lengths
-        self.lengths = lengths
+        self.lengths: dict[str, int] | None = (
+            dict(lengths) if lengths is not None else None
+        )
 
         # Add the necessary keys associated with matching, if needed
         keys = {}
         if match_mode is not None:
+            if self.obj_type is None:
+                raise ValueError("Must provide object types when storing matches.")
             for prefix in self.prefixes:
                 for obj_name in self.obj_type:
                     if prefix == "reco" and match_mode != "truth_to_reco":
@@ -137,9 +153,10 @@ class SaveAna(AnaBase):
         for key in self.obj_keys:
             self.initialize_writer(key)
 
-        assert len(self.writers), "Must request to save something."
+        if len(self.writers) == 0:
+            raise ValueError("Must request to save something.")
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Store the information from one entry.
 
         Parameters
@@ -157,7 +174,7 @@ class SaveAna(AnaBase):
             lengths = self.lengths
             if self.match_mode is None or self.match_mode == f"{other}_to_{prefix}":
                 # If there is no matches, save objects by themselves
-                for i, obj in enumerate(data[key]):
+                for obj in data[key]:
                     self.append(key, **obj.scalar_dict(attrs, lengths))
 
             else:
@@ -166,14 +183,13 @@ class SaveAna(AnaBase):
                 match_suffix = f"{prefix[0]}2{other[0]}"
                 match_key = f"{obj_type[:-1]}_matches_{match_suffix}"
                 attrs_other = self.attrs[f"{other}_{obj_type}"]
-                lengths_other = self.lengths  # TODO
                 for idx, (obj_i, obj_j) in enumerate(data[match_key]):
                     src_dict = obj_i.scalar_dict(attrs, lengths)
                     if obj_j is not None:
-                        tgt_dict = obj_j.scalar_dict(attrs_other, lengths_other)
+                        tgt_dict = obj_j.scalar_dict(attrs_other, lengths)
                     else:
                         default_obj = self.default_objs[f"{other}_{obj_type}"]
-                        tgt_dict = default_obj.scalar_dict(attrs_other, lengths_other)
+                        tgt_dict = default_obj.scalar_dict(attrs_other, lengths)
 
                     src_dict = {f"{prefix}_{k}": v for k, v in src_dict.items()}
                     tgt_dict = {f"{other}_{k}": v for k, v in tgt_dict.items()}

--- a/src/spine/ana/template.py
+++ b/src/spine/ana/template.py
@@ -5,11 +5,17 @@ script takes the output of the reconstruction and the post-processors and
 performs basic selection cuts and stores the output to a CSV file.
 """
 
-# Add the imports specific to this module here
-# import ...
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 # Must import the analysis script base class
 from spine.ana.base import AnaBase
+
+# Add the imports specific to this module here
+# import ...
+
 
 # Must list the analysis script(s) here to be found by the factory.
 # You must also add it to the list of imported modules in the
@@ -18,37 +24,38 @@ __all__ = ["TemplateAna"]
 
 
 class TemplateAna(AnaBase):
-    """Description of what the analysis script is supposed to be doing."""
+    """Template analysis script showing the expected AnaBase interface."""
 
     # Name of the analysis script (as specified in the configuration)
     name = "template"
 
     def __init__(
-        self, arg0, arg1, obj_type, run_mode, append_file, overwrite_file, output_prefix
-    ):
+        self,
+        arg0: Any,
+        arg1: Any,
+        obj_type: str | Sequence[str] | None = None,
+        run_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Initialize the analysis script.
 
         Parameters
         ----------
-        arg0 : type
-            Description of arg0
-        arg1 : type
-            Description of arg1
-        obj_type : Union[str, List[str]]
+        arg0 : object
+            Example required argument
+        arg1 : object
+            Example required argument
+        obj_type : str or Sequence[str], optional
             Name or list of names of the object types to process
         run_mode : str, optional
             If specified, tells whether the analysis script must run on
             reconstructed ('reco'), true ('true') or both objects
             ('both' or 'all')
-        append_file : bool, default False
-            If True, appends existing CSV files instead of creating new ones
-        overwrite_file : bool, default False
-            If True and the output CSV file exists, overwrite it
-        output_prefix : str, default None
-            Name to prefix every output CSV file with
+        **kwargs : dict, optional
+            Additional arguments to pass to :class:`AnaBase`
         """
         # Initialize the parent class
-        super().__init__(obj_type, run_mode, append_file, overwrite_file, output_prefix)
+        super().__init__(obj_type=obj_type, run_mode=run_mode, **kwargs)
 
         # Store parameter
         self.arg0 = arg0
@@ -60,7 +67,7 @@ class TemplateAna(AnaBase):
         # Add additional required data products
         self.update_keys({"prod": True})  # Means we must have 'prod' in the dictionary
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Pass data products corresponding to one entry through the analysis.
 
         Parameters
@@ -78,7 +85,7 @@ class TemplateAna(AnaBase):
                 # Do something with the object
                 disp = obj.end_point - obj.start_point
 
-                # Make a dictionary of integer out of it
+                # Build a dictionary of scalar values to write
                 out = {"disp_x": disp[0], "disp_y": disp[1], "disp_z": disp[2]}
 
                 # Write the row to file

--- a/src/spine/post/base.py
+++ b/src/spine/post/base.py
@@ -1,6 +1,10 @@
 """Contains base class of all post-processors."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from collections.abc import Mapping, MutableMapping, Sequence
+from typing import Any
 
 
 class PostBase(ABC):
@@ -73,13 +77,13 @@ class PostBase(ABC):
 
     def __init__(
         self,
-        obj_type=None,
-        run_mode=None,
-        truth_point_mode=None,
-        truth_dep_mode=None,
-        pid_mode=None,
-        parent_path=None,
-    ):
+        obj_type: str | Sequence[str] | None = None,
+        run_mode: str | None = None,
+        truth_point_mode: str | None = None,
+        truth_dep_mode: str | None = None,
+        pid_mode: str | None = None,
+        parent_path: str | None = None,
+    ) -> None:
         """Initialize default post-processor object properties.
 
         Parameters
@@ -105,49 +109,59 @@ class PostBase(ABC):
         # If run mode is specified, process it
         if run_mode is not None:
             # Check that the run mode is recognized
-            assert run_mode in self._run_modes, (
-                f"`run_mode` not recognized: {run_mode}. Must be one of "
-                f"{self._run_modes}."
-            )
+            if run_mode not in self._run_modes:
+                raise ValueError(
+                    f"`run_mode` not recognized: {run_mode}. Must be one of "
+                    f"{self._run_modes}."
+                )
 
         # Check that all the object sources are recognized
         if obj_type is None:
-            obj_type = []
+            obj_types: list[str] = []
         elif isinstance(obj_type, str):
-            obj_type = [obj_type]
+            obj_types = [obj_type]
+        elif isinstance(obj_type, Sequence):
+            obj_types = list(obj_type)
+        else:
+            raise TypeError("`obj_type` must be a string or sequence of strings.")
 
-        for obj in obj_type:
-            assert obj in self._obj_types, (
-                f"Object type must be one of {self._obj_types}. Got "
-                f"`{obj}` instead."
-            )
+        for obj in obj_types:
+            if obj not in self._obj_types:
+                raise ValueError(
+                    f"Object type must be one of {self._obj_types}. Got "
+                    f"`{obj}` instead."
+                )
 
         # Make a list of object keys to process
-        self.fragment_keys = []
-        self.particle_keys = []
-        self.interaction_keys = []
+        self.obj_type = obj_types
+        self.fragment_keys: list[str] = []
+        self.particle_keys: list[str] = []
+        self.interaction_keys: list[str] = []
         for name in self._obj_types:
             # Initialize one list per object type
             setattr(self, f"{name}_keys", [])
 
             # Skip object types which are not requested
-            if name in obj_type:
+            if name in obj_types:
                 if run_mode != "truth":
                     getattr(self, f"{name}_keys").append(f"reco_{name}s")
                 if run_mode != "reco":
                     getattr(self, f"{name}_keys").append(f"truth_{name}s")
 
-        self.obj_keys = self.fragment_keys + self.particle_keys + self.interaction_keys
+        self.obj_keys: list[str] = (
+            self.fragment_keys + self.particle_keys + self.interaction_keys
+        )
 
         # Update underlying keys, if needed
         self.update_keys({k: True for k in self.obj_keys})
 
         # If a truth point mode is specified, store it
         if truth_point_mode is not None:
-            assert truth_point_mode in self.point_modes, (
-                "The `truth_point_mode` argument must be one of "
-                f"{self.point_modes.keys()}. Got `{truth_point_mode}` instead."
-            )
+            if truth_point_mode not in self.point_modes:
+                raise ValueError(
+                    "The `truth_point_mode` argument must be one of "
+                    f"{self.point_modes.keys()}. Got `{truth_point_mode}` instead."
+                )
             self.truth_point_mode = truth_point_mode
             self.truth_point_key = self.point_modes[self.truth_point_mode]
             self.truth_source_mode = truth_point_mode.replace("points", "sources")
@@ -156,32 +170,35 @@ class PostBase(ABC):
 
         # If a truth deposition mode is specified, store it
         if truth_dep_mode is not None:
-            assert truth_dep_mode in self.dep_modes, (
-                "The `truth_dep_mode` argument must be one of "
-                f"{self.dep_modes.keys()}. Got `{truth_dep_mode}` instead."
-            )
+            if truth_dep_mode not in self.dep_modes:
+                raise ValueError(
+                    "The `truth_dep_mode` argument must be one of "
+                    f"{self.dep_modes.keys()}. Got `{truth_dep_mode}` instead."
+                )
             if truth_point_mode is not None:
                 prefix = truth_point_mode.replace("points", "depositions")
-                assert truth_dep_mode.startswith(prefix), (
-                    f"Points mode {truth_point_mode} and deposition mode "
-                    f"{truth_dep_mode} are incompatible."
-                )
+                if not truth_dep_mode.startswith(prefix):
+                    raise ValueError(
+                        f"Points mode {truth_point_mode} and deposition mode "
+                        f"{truth_dep_mode} are incompatible."
+                    )
             self.truth_dep_mode = truth_dep_mode
             self.truth_dep_key = self.dep_modes[truth_dep_mode]
 
         # If a PID mode is specified, store it
         if pid_mode is not None:
-            assert pid_mode in self._pid_modes, (
-                f"The `pid_mode` argument must be one of {self._pid_modes}. "
-                f"Got {pid_mode} instead."
-            )
+            if pid_mode not in self._pid_modes:
+                raise ValueError(
+                    f"The `pid_mode` argument must be one of {self._pid_modes}. "
+                    f"Got {pid_mode} instead."
+                )
             self.pid_mode = pid_mode
 
         # Store the parent path
         self.parent_path = parent_path
 
     @property
-    def keys(self):
+    def keys(self) -> dict[str, bool]:
         """Dictionary of (key, necessity) pairs which determine which data keys
         are needed/optional for the post-processor to run.
 
@@ -193,8 +210,8 @@ class PostBase(ABC):
         return dict(self._keys)
 
     @property
-    def point_modes(self):
-        """Dictionary which makes the correspondance between the name of a true
+    def point_modes(self) -> dict[str, str]:
+        """Dictionary which maps the name of a true
         object point attribute with the underlying point tensor it points to.
 
         Returns
@@ -205,8 +222,8 @@ class PostBase(ABC):
         return dict(self._point_modes)
 
     @property
-    def source_modes(self):
-        """Dictionary which makes the correspondance between the name of a true
+    def source_modes(self) -> dict[str, str]:
+        """Dictionary which maps the name of a true
         object source attribute with the underlying source tensor it points to.
 
         Returns
@@ -217,8 +234,8 @@ class PostBase(ABC):
         return dict(self._source_modes)
 
     @property
-    def dep_modes(self):
-        """Dictionary which makes the correspondance between the name of a true
+    def dep_modes(self) -> dict[str, str]:
+        """Dictionary which maps the name of a true
         object deposition attribute with the underlying deposition array it points to.
 
         Returns
@@ -228,7 +245,7 @@ class PostBase(ABC):
         """
         return dict(self._dep_modes)
 
-    def update_keys(self, update_dict):
+    def update_keys(self, update_dict: Mapping[str, bool]) -> None:
         """Update the underlying set of keys and their necessity in place.
 
         Parameters
@@ -241,7 +258,7 @@ class PostBase(ABC):
             keys.update(update_dict)
             self._keys = tuple(keys.items())
 
-    def update_upstream(self, key):
+    def update_upstream(self, key: str) -> None:
         """Update the underlying set of required upstream modules in place.
 
         Parameters
@@ -251,7 +268,9 @@ class PostBase(ABC):
         """
         self._upstream = (*self._upstream, key)
 
-    def __call__(self, data, entry=None):
+    def __call__(
+        self, data: Mapping[str, Any], entry: int | None = None
+    ) -> dict[str, Any] | None:
         """Calls the post processor on one entry.
 
         Parameters
@@ -270,10 +289,11 @@ class PostBase(ABC):
         data_filter = {}
         for key, req in self._keys:
             # If this key is needed, check that it exists
-            assert not req or key in data, (
-                f"Post-processor `{self.name}` is missing an essential "
-                f"input to be used: `{key}`."
-            )
+            if req and key not in data:
+                raise KeyError(
+                    f"Post-processor `{self.name}` is missing an essential "
+                    f"input to be used: `{key}`."
+                )
 
             # Append
             if key in data:
@@ -284,7 +304,7 @@ class PostBase(ABC):
         # Run the post-processor
         return self.process(data_filter)
 
-    def get_index(self, obj):
+    def get_index(self, obj: Any) -> Any:
         """Get a certain pre-defined index attribute of an object.
 
         The :class:`TruthFragment`, :class:`TruthParticle` and
@@ -306,7 +326,7 @@ class PostBase(ABC):
         else:
             return getattr(obj, self.truth_index_mode)
 
-    def get_points(self, obj):
+    def get_points(self, obj: Any) -> Any:
         """Get a certain pre-defined point attribute of an object.
 
         The :class:`TruthFragment`, :class:`TruthParticle` and
@@ -328,7 +348,7 @@ class PostBase(ABC):
         else:
             return getattr(obj, self.truth_point_mode)
 
-    def get_sources(self, obj):
+    def get_sources(self, obj: Any) -> Any:
         """Get a certain pre-defined sources attribute of an object.
 
         The :class:`TruthFragment`, :class:`TruthParticle` and
@@ -350,7 +370,7 @@ class PostBase(ABC):
         else:
             return getattr(obj, self.truth_source_mode)
 
-    def get_depositions(self, obj):
+    def get_depositions(self, obj: Any) -> Any:
         """Get a certain pre-defined deposition attribute of an object.
 
         The :class:`TruthFragment`, :class:`TruthParticle` and
@@ -372,7 +392,7 @@ class PostBase(ABC):
         else:
             return getattr(obj, self.truth_dep_mode)
 
-    def get_pid(self, obj):
+    def get_pid(self, obj: Any) -> Any:
         """Get a certain pre-defined PID prediction of an object.
 
         The :class:`TruthParticle` PID predictions are obtained using the
@@ -393,7 +413,7 @@ class PostBase(ABC):
         else:
             return obj.pid
 
-    def check_units(self, obj):
+    def check_units(self, obj: Any) -> None:
         """Check that the point coordinates of an object are as expected.
 
         Parameters
@@ -413,7 +433,7 @@ class PostBase(ABC):
             )
 
     @abstractmethod
-    def process(self, data):
+    def process(self, data: MutableMapping[str, Any]) -> dict[str, Any] | None:
         """Place-holder method to be defined in each post-processor.
 
         Parameters

--- a/src/spine/post/base.py
+++ b/src/spine/post/base.py
@@ -11,7 +11,7 @@ class PostBase(ABC):
     """Base class of all post-processors.
 
     This base class performs the following functions:
-      - Ensures that the necessary method exist
+      - Ensures that the necessary methods exist
       - Checks that the post-processor is provided the necessary information
         to do its job
       - Fetches the appropriate coordinate attributes
@@ -21,7 +21,7 @@ class PostBase(ABC):
     ----------
     name : str
         Name of the post-processor as defined in the configuration file
-    aliases : Tuple[str]
+    aliases : tuple[str, ...]
         Alternative acceptable names for a post-processor
     """
 
@@ -88,11 +88,11 @@ class PostBase(ABC):
 
         Parameters
         ----------
-        obj_type : Union[str, List[str]]
+        obj_type : str or sequence[str], optional
             Name or list of names of the object types to process
         run_mode : str, optional
             If specified, tells whether the post-processor must run on
-            reconstructed ('reco'), true ('true') or both objects
+            reconstructed ('reco'), true ('truth') or both objects
             ('both' or 'all')
         truth_point_mode : str, optional
             If specified, tells which attribute of the :class:`TruthFragment`,
@@ -204,7 +204,7 @@ class PostBase(ABC):
 
         Returns
         -------
-        Dict[str, bool]
+        dict[str, bool]
             Dictionary of (key, necessity) pairs to be used
         """
         return dict(self._keys)
@@ -216,7 +216,7 @@ class PostBase(ABC):
 
         Returns
         -------
-        Dict[str, str]
+        dict[str, str]
             Dictionary of (attribute, key) mapping for point coordinates
         """
         return dict(self._point_modes)
@@ -228,7 +228,7 @@ class PostBase(ABC):
 
         Returns
         -------
-        Dict[str, str]
+        dict[str, str]
             Dictionary of (attribute, key) mapping for point sources
         """
         return dict(self._source_modes)
@@ -240,7 +240,7 @@ class PostBase(ABC):
 
         Returns
         -------
-        Dict[str, str]
+        dict[str, str]
             Dictionary of (attribute, key) mapping for point depositions
         """
         return dict(self._dep_modes)
@@ -250,7 +250,7 @@ class PostBase(ABC):
 
         Parameters
         ----------
-        update_dict : Dict[str, bool]
+        update_dict : Mapping[str, bool]
             Dictionary of (key, necessity) pairs to update the keys with
         """
         if len(update_dict) > 0:
@@ -313,7 +313,7 @@ class PostBase(ABC):
 
         Parameters
         ----------
-        obj : Union[FragmentBase, ParticleBase, InteractionBase]
+        obj : FragmentBase, ParticleBase or InteractionBase
             Fragment, Particle or Interaction object
 
         Results
@@ -335,7 +335,7 @@ class PostBase(ABC):
 
         Parameters
         ----------
-        obj : Union[FragmentBase, ParticleBase, InteractionBase]
+        obj : FragmentBase, ParticleBase or InteractionBase
             Fragment, Particle or Interaction object
 
         Results
@@ -357,7 +357,7 @@ class PostBase(ABC):
 
         Parameters
         ----------
-        obj : Union[FragmentBase, ParticleBase, InteractionBase]
+        obj : FragmentBase, ParticleBase or InteractionBase
             Fragment, Particle or Interaction object
 
         Results
@@ -379,7 +379,7 @@ class PostBase(ABC):
 
         Parameters
         ----------
-        obj : Union[FragmentBase, ParticleBase, InteractionBase]
+        obj : FragmentBase, ParticleBase or InteractionBase
             Fragment, Particle or Interaction object
 
         Results
@@ -400,7 +400,7 @@ class PostBase(ABC):
 
         Parameters
         ----------
-        obj : Union[ParticleBase]
+        obj : ParticleBase
             Particle object
 
         Results
@@ -418,7 +418,7 @@ class PostBase(ABC):
 
         Parameters
         ----------
-        obj : Union[FragmentBase, ParticleBase, InteractionBase]
+        obj : FragmentBase, ParticleBase or InteractionBase
             Particle or interaction object
 
         Results

--- a/src/spine/post/crt/crt_matching.py
+++ b/src/spine/post/crt/crt_matching.py
@@ -1,6 +1,10 @@
 """Post-processor in charge of finding matches between charge and CRT."""
 
+from __future__ import annotations
+
 from collections import defaultdict
+from collections.abc import Mapping
+from typing import Any
 
 import numpy as np
 
@@ -23,7 +27,7 @@ class CRTMatchProcessor(PostBase):
     # Set of post-processors which must be run before this one is
     _upstream = ("direction",)
 
-    def __init__(self, crt_key, run_mode="reco", **kwargs):
+    def __init__(self, crt_key: str, run_mode: str = "reco", **kwargs: Any) -> None:
         """Initialize the CRT/TPC matching post-processor.
 
         Parameters
@@ -43,7 +47,7 @@ class CRTMatchProcessor(PostBase):
         # Initialzie the matcher
         self.matcher = CRTMatcher(**kwargs)
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Find [particle, crthit] pairs.
 
         Parameters

--- a/src/spine/post/crt/match.py
+++ b/src/spine/post/crt/match.py
@@ -1,5 +1,10 @@
 """Module that supports TPC-CRT matching."""
 
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
 import numpy as np
 
 from spine.constants import TRACK_SHP
@@ -17,21 +22,21 @@ class CRTMatcher:
 
     def __init__(
         self,
-        driftv,
-        match_method="threshold",
-        tolerance=5,
-        time_window=None,
-        min_part_size=None,
-        min_crt_pe=None,
-        match_distance=None,
-    ):
-        """Initalize the barycenter flash matcher.
+        driftv: float,
+        match_method: str = "threshold",
+        tolerance: float = 5.0,
+        time_window: Sequence[float] | None = None,
+        min_part_size: int | None = None,
+        min_crt_pe: float | None = None,
+        match_distance: float | None = None,
+    ) -> None:
+        """Initialize the CRT/TPC matcher.
 
         Parameters
         ----------
         driftv : float
             Drift velocity in cm/us
-        match_method : str, default 'distance'
+        match_method : str, default 'threshold'
             Matching method (one of 'threshold' or 'best')
             - 'threshold': If a TPC track can be propagated such that it matches
             the CRT hit within some threshold, they are matched
@@ -39,10 +44,8 @@ class CRTMatcher:
         tolerance : float, default 5
             Distance along x in cm that a track is allowed to float around the
             expected position given a CRT hit time
-        time_window : List, optional
+        time_window : Sequence[float], optional
             List of [min, max] values of optical flash times to consider
-        first_flash_only : bool, default False
-            Only try to match the first flash in the time window
         min_part_size : int, optional
             Minimum number of voxel in an particle to consider it
         min_crt_pe : float, optional
@@ -75,20 +78,22 @@ class CRTMatcher:
         self.min_part_size = min_part_size
         self.min_crt_pe = min_crt_pe
 
-    def get_matches(self, particles, crthits):
+    def get_matches(
+        self, particles: Sequence[Any], crthits: Sequence[Any]
+    ) -> list[tuple[Any, Any, float]]:
         """Makes [particle, crthit] pairs that are compatible.
 
         Parameters
         ----------
-        particles : List[Union[RecoParticle, TruthParticle]]
+        particles : Sequence[RecoParticle | TruthParticle]
             List of particles
-        crthits : List[CRTHit]
+        crthits : Sequence[CRTHit]
             List of CRT hits
 
         Returns
         -------
-        List[[Interaction, larcv.Flash, float]]
-            List of [particle, flash, distance] triplets
+        list[tuple[Particle, CRTHit, float]]
+            List of [particle, CRT hit, distance] triplets
         """
         # Check on the geometry
         assert (
@@ -178,27 +183,31 @@ class CRTMatcher:
 
         return matches
 
-    def restrict_objects(self, particles, crthits):
+    def restrict_objects(
+        self, particles: Sequence[Any], crthits: Sequence[Any]
+    ) -> tuple[list[Any], list[Any]]:
         """Restrict the list of particles/CRT hits to match the configuration.
 
         Parameters
         ----------
-        particles : List[Union[RecoParticle, TruthParticle]]
+        particles : Sequence[RecoParticle | TruthParticle]
             List of particles
-        crthits : List[CRTHit]
+        crthits : Sequence[CRTHit]
             List of CRT hits
 
         Returns
         -------
-        List[Union[RecoParticle, TruthParticle]]
+        list[RecoParticle | TruthParticle]
             Restricted list of particles
-        List[CRTHit]
+        list[CRTHit]
             Restricted list of CRT hits
         """
         # Restrict the CRT hits to those that fit the selection criterion
         if self.time_window is not None:
             t1, t2 = self.time_window
             crthits = [h for h in crthits if (h.time > t1 and h.time < t2)]
+        else:
+            crthits = list(crthits)
 
         # Restrict the particles to tracks that fit the selection criteria
         particles = [part for part in particles if part.shape == TRACK_SHP]
@@ -207,7 +216,13 @@ class CRTMatcher:
 
         return particles, crthits
 
-    def line_plane_intercept(self, line_p, line_v, plane_p, plane_n):
+    def line_plane_intercept(
+        self,
+        line_p: np.ndarray,
+        line_v: np.ndarray,
+        plane_p: np.ndarray,
+        plane_n: np.ndarray,
+    ) -> np.ndarray:
         """Find the intercept between a line and a plane in 3D.
 
         Parameters

--- a/src/spine/post/factories.py
+++ b/src/spine/post/factories.py
@@ -1,5 +1,10 @@
 """Construct a post-processor module class from its name."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
 from spine.utils.factory import instantiate, module_dict
 
 from . import crt, optical, reco, trigger, truth
@@ -10,7 +15,9 @@ for module in [reco, truth, optical, crt, trigger]:
     POST_DICT.update(**module_dict(module))
 
 
-def post_processor_factory(name, cfg, parent_path=None):
+def post_processor_factory(
+    name: str, cfg: Mapping[str, Any], parent_path: str | None = None
+) -> Any:
     """Instantiates a post-processor module from a configuration dictionary.
 
     Parameters
@@ -28,10 +35,11 @@ def post_processor_factory(name, cfg, parent_path=None):
          Initialized post-processor object
     """
     # Provide the name to the configuration
-    cfg["name"] = name
+    config = dict(cfg)
+    config["name"] = name
 
     # Instantiate the post-processor
     if POST_DICT[name].provide_parent_path:
-        return instantiate(POST_DICT, cfg, parent_path=parent_path)
+        return instantiate(POST_DICT, config, parent_path=parent_path)
     else:
-        return instantiate(POST_DICT, cfg)
+        return instantiate(POST_DICT, config)

--- a/src/spine/post/manager.py
+++ b/src/spine/post/manager.py
@@ -25,7 +25,7 @@ class PostModule(Protocol):
 
 
 class PostManager(ModuleManager[PostModule]):
-    """Manager in charge of handling post-processing scripts.
+    """Manager in charge of handling post-processors.
 
     It loads all the post-processor objects once and feeds them data.
     """
@@ -42,10 +42,10 @@ class PostManager(ModuleManager[PostModule]):
         ----------
         cfg : dict
             Post-processor configurations
-        post_list : List[str], optional
+        post_list : sequence[str], optional
             List of post-processors which have already been run
         parent_path : str, optional
-            Path to the analysis tools configuration file
+            Path to the parent directory of the main configuration file
         """
         # Add the modules to a processor list in decreasing order of priority
         self.watch = StopwatchManager()

--- a/src/spine/post/manager.py
+++ b/src/spine/post/manager.py
@@ -4,27 +4,17 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence
-from typing import Any, Protocol
+from typing import Any
 
 from spine.utils.factory import parse_module_config
 from spine.utils.manager import ModuleManager
 from spine.utils.stopwatch import StopwatchManager
 
+from .base import PostBase
 from .factories import post_processor_factory
 
 
-class PostModule(Protocol):
-    """Post-processing module interface used by :class:`PostManager`."""
-
-    _upstream: Sequence[str]
-
-    def __call__(
-        self, data: dict[str, Any], entry: int | None = None
-    ) -> dict[str, Any] | None:
-        """Process input data and return products to merge into it."""
-
-
-class PostManager(ModuleManager[PostModule]):
+class PostManager(ModuleManager[PostBase]):
     """Manager in charge of handling post-processors.
 
     It loads all the post-processor objects once and feeds them data.
@@ -49,7 +39,7 @@ class PostManager(ModuleManager[PostModule]):
         """
         # Add the modules to a processor list in decreasing order of priority
         self.watch = StopwatchManager()
-        modules: OrderedDict[str, PostModule] = OrderedDict()
+        modules: OrderedDict[str, PostBase] = OrderedDict()
         parsed = parse_module_config(
             cfg, sort_by_priority=True, priority_descending=True
         )

--- a/src/spine/post/manager.py
+++ b/src/spine/post/manager.py
@@ -1,22 +1,41 @@
 """Manages the operation of post-processors."""
 
-from collections import OrderedDict, defaultdict
-from copy import deepcopy
+from __future__ import annotations
 
-import numpy as np
+from collections import OrderedDict
+from collections.abc import Mapping, Sequence
+from typing import Any, Protocol
 
+from spine.utils.factory import parse_module_config
+from spine.utils.manager import ModuleManager
 from spine.utils.stopwatch import StopwatchManager
 
 from .factories import post_processor_factory
 
 
-class PostManager:
+class PostModule(Protocol):
+    """Post-processing module interface used by :class:`PostManager`."""
+
+    _upstream: Sequence[str]
+
+    def __call__(
+        self, data: dict[str, Any], entry: int | None = None
+    ) -> dict[str, Any] | None:
+        """Process input data and return products to merge into it."""
+
+
+class PostManager(ModuleManager[PostModule]):
     """Manager in charge of handling post-processing scripts.
 
     It loads all the post-processor objects once and feeds them data.
     """
 
-    def __init__(self, cfg, post_list=None, parent_path=None):
+    def __init__(
+        self,
+        cfg: Mapping[str, dict[str, Any] | None],
+        post_list: Sequence[str] | None = None,
+        parent_path: str | None = None,
+    ) -> None:
         """Initialize the post-processing manager.
 
         Parameters
@@ -28,74 +47,30 @@ class PostManager:
         parent_path : str, optional
             Path to the analysis tools configuration file
         """
-        # Loop over the post-processor modules and get their priorities
-        cfg = deepcopy(cfg)
-        keys = np.array(list(cfg.keys()))
-        priorities = -np.ones(len(keys), dtype=np.int32)
-        for i, key in enumerate(keys):
-            if "priority" in cfg[key]:
-                priorities[i] = cfg[key].pop("priority")
-
         # Add the modules to a processor list in decreasing order of priority
         self.watch = StopwatchManager()
-        self.modules = OrderedDict()
-        keys = keys[np.argsort(-priorities)]
-        for key in keys:
+        modules: OrderedDict[str, PostModule] = OrderedDict()
+        parsed = parse_module_config(
+            cfg, sort_by_priority=True, priority_descending=True
+        )
+        module_names: list[str] = []
+        for key, spec in parsed.items():
             # Profile the module
             self.watch.initialize(key)
 
             # Append
-            self.modules[key] = post_processor_factory(
-                key, cfg[key], parent_path=parent_path
+            modules[key] = post_processor_factory(
+                spec["name"], spec["cfg"], parent_path=parent_path
             )
 
             # Check dependencies
             if post_list is not None:
-                ups_post = tuple(self.modules)
-                for post in self.modules[key]._upstream:
-                    assert post in (post_list + ups_post), (
-                        f"Post-processor `{key}` is missing an essential "
-                        f"upstream post-processor: `{post}`."
-                    )
-
-    def __call__(self, data):
-        """Pass one batch of data through the post-processors.
-
-        Parameters
-        ----------
-        data : dict
-            Dictionary of data products
-        """
-        # Reset active stopwatches
-        self.watch.reset_if_active()
-
-        # Loop over the post-processor modules
-        single_entry = np.isscalar(data["index"])
-        for key, module in self.modules.items():
-            # Run the post-processor on each entry
-            self.watch.start(key)
-            if single_entry:
-                num_entries = 1
-                result = module(data)
-
-            else:
-                num_entries = len(data["index"])
-                result = defaultdict(list)
-                for entry in range(num_entries):
-                    result_e = module(data, entry)
-                    if result_e is not None:
-                        for k, v in result_e.items():
-                            result[k].append(v)
-
-            self.watch.stop(key)
-
-            # Update the input dictionary
-            if result is not None:
-                for key, val in result.items():
-                    if not single_entry:
-                        assert len(val) == num_entries, (
-                            f"The number of {key} ({len(val)}) returned by the {key} "
-                            "post-processor does not match the number of entries "
-                            f"({num_entries}) in the batch."
+                ups_post = tuple(post_list) + tuple(modules) + tuple(module_names)
+                for post in modules[key]._upstream:
+                    if post not in ups_post:
+                        raise ValueError(
+                            f"Post-processor `{key}` is missing an essential "
+                            f"upstream post-processor: `{post}`."
                         )
-                    data[key] = val
+            module_names.append(spec["name"])
+        self.modules = modules

--- a/src/spine/post/optical/barycenter.py
+++ b/src/spine/post/optical/barycenter.py
@@ -2,8 +2,6 @@
 
 import numpy as np
 
-from spine.math.distance import cdist
-
 
 class BarycenterFlashMatcher:
     """Matches interactions and flashes by matching the charge barycenter of
@@ -54,8 +52,8 @@ class BarycenterFlashMatcher:
                 f"{match_method}. Must be one of {self._match_methods}."
             )
 
-        if match_method == "threshold":
-            assert match_distance is not None, (
+        if match_method == "threshold" and match_distance is None:
+            raise ValueError(
                 "When using the `threshold` method, must specify the "
                 "`match_distance` parameter."
             )
@@ -114,9 +112,10 @@ class BarycenterFlashMatcher:
         # Get the flash centroids
         op_centroids = np.empty((len(flashes), len(self.dims)))
         op_widths = np.empty((len(flashes), len(self.dims)))
+        dims = list(self.dims)
         for i, f in enumerate(flashes):
-            op_centroids[i] = f.center[self.dims]
-            op_widths[i] = f.width[self.dims]
+            op_centroids[i] = f.center[dims]
+            op_widths[i] = f.width[dims]
 
         # Get interactions centroids
         int_centroids = np.empty((len(interactions), len(self.dims)))
@@ -131,7 +130,9 @@ class BarycenterFlashMatcher:
                 int_centroids[i] /= np.sum(inter.depositions)
 
         # Compute the flash to interaction distance matrix
-        dist_mat = cdist(op_centroids, int_centroids)
+        dist_mat = np.linalg.norm(
+            op_centroids[:, None, :] - int_centroids[None, :, :], axis=2
+        )
 
         # Produce matches
         matches = []

--- a/src/spine/post/optical/barycenter.py
+++ b/src/spine/post/optical/barycenter.py
@@ -1,5 +1,10 @@
 """Module that supports barycenter-based flash matching."""
 
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
 import numpy as np
 
 
@@ -13,28 +18,28 @@ class BarycenterFlashMatcher:
 
     def __init__(
         self,
-        match_method="threshold",
-        dimensions=(1, 2),
-        charge_weighted=False,
-        time_window=None,
-        first_flash_only=False,
-        min_inter_size=None,
-        min_flash_pe=None,
-        match_distance=None,
-    ):
-        """Initalize the barycenter flash matcher.
+        match_method: str = "threshold",
+        dimensions: Sequence[int] = (1, 2),
+        charge_weighted: bool = False,
+        time_window: Sequence[float] | None = None,
+        first_flash_only: bool = False,
+        min_inter_size: int | None = None,
+        min_flash_pe: float | None = None,
+        match_distance: float | None = None,
+    ) -> None:
+        """Initialize the barycenter flash matcher.
 
         Parameters
         ----------
-        match_method: str, default 'distance'
+        match_method : str, default 'threshold'
             Matching method (one of 'threshold' or 'best')
             - 'threshold': If the two barycenters are within some distance, match
             - 'best': For each flash, pick the best matched interaction
-        dimensions: Tuple[int], default (1, 2)
+        dimensions : Sequence[int], default (1, 2)
             Dimensions involved in the distance computation
         charge_weighted : bool, default False
             Use interaction pixel charge information to weight the centroid
-        time_window : List, optional
+        time_window : Sequence[float], optional
             List of [min, max] values of optical flash times to consider
         first_flash_only : bool, default False
             Only try to match the first flash in the time window
@@ -68,21 +73,26 @@ class BarycenterFlashMatcher:
         self.min_flash_pe = min_flash_pe
         self.match_distance = match_distance
 
-    def get_matches(self, interactions, flashes):
+    def get_matches(
+        self, interactions: Sequence[Any], flashes: Sequence[Any]
+    ) -> list[tuple[Any, Any, float]]:
         """Makes [interaction, flash] pairs that have compatible barycenters.
 
         Parameters
         ----------
-        interactions : List[Union[RecoInteraction, TruthInteraction]]
+        interactions : Sequence[RecoInteraction | TruthInteraction]
             List of interactions
-        flashes : List[Flash]
+        flashes : Sequence[Flash]
             List of optical flashes
 
         Returns
         -------
-        List[[Interaction, larcv.Flash, float]]
+        list[tuple[Interaction, Flash, float]]
             List of [interaction, flash, distance] triplets
         """
+        interactions = list(interactions)
+        flashes = list(flashes)
+
         # Restrict the flashes to those that fit the selection criteria.
         # Skip if there are no valid flashes
         if self.time_window is not None:
@@ -125,7 +135,7 @@ class BarycenterFlashMatcher:
 
             else:
                 int_centroids[i] = np.sum(
-                    inter.depositions * inter.points[:, self.dims], axis=0
+                    inter.depositions[:, None] * inter.points[:, self.dims], axis=0
                 )
                 int_centroids[i] /= np.sum(inter.depositions)
 
@@ -139,7 +149,7 @@ class BarycenterFlashMatcher:
         if self.match_method == "best":
             # For each flash, select the best match, save attributes
             for i, f in enumerate(flashes):
-                best_match = np.argmin(dist_mat[i])
+                best_match = int(np.argmin(dist_mat[i]))
                 dist = dist_mat[i, best_match]
                 if self.match_distance is not None and dist > self.match_distance:
                     continue

--- a/src/spine/post/optical/flash_matching.py
+++ b/src/spine/post/optical/flash_matching.py
@@ -34,20 +34,20 @@ class FlashMatchProcessor(PostBase):
 
     def __init__(
         self,
-        flash_key,
-        volume,
-        ref_volume_id=None,
-        method="likelihood",
-        time_contained=False,
-        max_cathode_offset=None,
-        run_mode="reco",
-        truth_point_mode="points",
-        truth_dep_mode="depositions",
-        parent_path=None,
-        merge=None,
-        update_flashes=False,
-        **kwargs,
-    ):
+        flash_key: str,
+        volume: str,
+        ref_volume_id: int | None = None,
+        method: str = "likelihood",
+        time_contained: bool = False,
+        max_cathode_offset: float | None = None,
+        run_mode: str = "reco",
+        truth_point_mode: str = "points",
+        truth_dep_mode: str = "depositions",
+        parent_path: str | None = None,
+        merge: Mapping[str, Any] | None = None,
+        update_flashes: bool = False,
+        **kwargs: Any,
+    ) -> None:
         """Initialize the flash matching algorithm.
 
         Parameters

--- a/src/spine/post/optical/flash_matching.py
+++ b/src/spine/post/optical/flash_matching.py
@@ -1,6 +1,8 @@
 """Post-processor in charge of finding matches between charge and light."""
 
 from collections import defaultdict
+from collections.abc import Mapping
+from typing import Any
 
 import numpy as np
 
@@ -86,14 +88,12 @@ class FlashMatchProcessor(PostBase):
         )
 
         # Make sure the flash data product is available, store
-        self.flash_key = flash_key
+        self.flash_key: str = flash_key
         self.update_keys({flash_key: True})
 
         # Get the volume within which each flash is confined
-        assert volume in (
-            "tpc",
-            "module",
-        ), "The `volume` must be one of 'tpc' or 'module'."
+        if volume not in ("tpc", "module"):
+            raise ValueError("The `volume` must be one of 'tpc' or 'module'.")
         self.volume = volume
         self.ref_volume_id = ref_volume_id
 
@@ -126,7 +126,7 @@ class FlashMatchProcessor(PostBase):
             self.merger = FlashMerger(**merge)
         self.update_flashes = update_flashes
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> dict[str, Any] | None:
         """Find [interaction, flash] pairs.
 
         Parameters
@@ -244,10 +244,14 @@ class FlashMatchProcessor(PostBase):
 
                     # Get the flash hypothesis (if the matcher produces one)
                     hypo_pe, score = -1.0, -1.0
-                    if hasattr(match, "hypothesis"):
-                        hypo_pe = float(np.sum(list(match.hypothesis)))
-                    if hasattr(match, "score"):
-                        score = float(match.score)
+                    if np.isscalar(match):
+                        score = float(np.asarray(match, dtype=np.float64).item())
+                    else:
+                        match_obj: Any = match
+                        if hasattr(match_obj, "hypothesis"):
+                            hypo_pe = float(np.sum(list(match_obj.hypothesis)))
+                        if hasattr(match_obj, "score"):
+                            score = float(match_obj.score)
 
                     # Update
                     if not inter.is_flash_matched:

--- a/src/spine/post/optical/likelihood.py
+++ b/src/spine/post/optical/likelihood.py
@@ -24,14 +24,14 @@ class LikelihoodFlashMatcher:
 
     def __init__(
         self,
-        cfg,
-        detector,
-        parent_path=None,
-        scaling=1.0,
-        alpha=0.21,
-        recombination_mip=0.65,
-        legacy=False,
-    ):
+        cfg: str,
+        detector: str | None,
+        parent_path: str | None = None,
+        scaling: float | str = 1.0,
+        alpha: float | str = 0.21,
+        recombination_mip: float | str = 0.65,
+        legacy: bool = False,
+    ) -> None:
         """Initialize the likelihood-based flash matching algorithm.
 
         Parameters
@@ -42,7 +42,7 @@ class LikelihoodFlashMatcher:
             Detector to get the optical detector properties for
         parent_path : str, optional
             Path to the parent configuration file (allows for relative paths)
-        scaling : Union[float, str], default 1.
+        scaling : float or str, default 1.
             Global scaling factor for the depositions (can be an expression)
         alpha : float, default 0.21
             Number of excitons (Ar*) divided by number of electron-ion pairs (e-,Ar+)
@@ -71,7 +71,9 @@ class LikelihoodFlashMatcher:
         self.qcluster_v = None
         self.flash_v = None
 
-    def initialize_backend(self, cfg, detector, parent_path):
+    def initialize_backend(
+        self, cfg: str, detector: str | None, parent_path: str | None
+    ) -> None:
         """Initialize OpT0Finder (backend).
 
         Expects that the environment variable `FMATCH_BASEDIR` is set.
@@ -81,7 +83,7 @@ class LikelihoodFlashMatcher:
 
         Parameters
         ----------
-        cfg: str
+        cfg : str
             Path to config for OpT0Finder
         detector : str, optional
             Detector to get the optical detector properties for
@@ -128,34 +130,36 @@ class LikelihoodFlashMatcher:
         if not os.path.isfile(cfg):
             raise FileNotFoundError(f"Cannot find flash-matcher config: {cfg}")
 
-        cfg = flashmatch.CreateFMParamsFromFile(cfg)
+        fm_cfg = flashmatch.CreateFMParamsFromFile(cfg)
 
         # Initialize The OpT0Finder flash match manager
         self.mgr = flashmatch.FlashMatchManager()
-        self.mgr.Configure(cfg)
+        self.mgr.Configure(fm_cfg)
 
         # Get the light path algorithm to produce QCluster_t objects
         self.light_path = flashmatch.CustomAlgoFactory.get().create(
             "LightPath", "ToyMCLightPath"
         )
-        self.light_path.Configure(cfg.get["flashmatch::FMParams"]("LightPath"))
+        self.light_path.Configure(fm_cfg.get["flashmatch::FMParams"]("LightPath"))
 
-    def get_matches(self, interactions, flashes):
+    def get_matches(
+        self, interactions: list[Any], flashes: list[Any]
+    ) -> list[tuple[Any, Any, Any]]:
         """Find TPC interactions compatible with optical flashes.
 
         Parameters
         ----------
-        interactions : List[Union[Interaction, TruthInteraction]]
+        interactions : list[Interaction | TruthInteraction]
             List of TPC interactions
-        flashes : List[Flash]
+        flashes : list[Flash]
             List of optical flashes
 
         Returns
         -------
-        List[Tuple[Interaction, Flash, flashmatch::FlashMatch_t]]
+        list[tuple[Interaction, Flash, flashmatch::FlashMatch_t]]
             Set of interaction/flash matches with their matching characteristics
         """
-        # If there is no interaction or no flashe, nothing to do
+        # If there is no interaction or no flash, nothing to do
         if not len(interactions) or not len(flashes):
             return []
 
@@ -177,21 +181,21 @@ class LikelihoodFlashMatcher:
 
         return result
 
-    def make_qcluster_list(self, interactions):
+    def make_qcluster_list(self, interactions: list[Any]) -> list[Any]:
         """Converts a list of SPINE interaction into a list of OpT0Finder
         flashmatch.QCluster_t objects.
 
         Parameters
         ----------
-        interactions : List[Union[Interaction, TruthInteraction]]
+        interactions : list[Interaction | TruthInteraction]
             List of TPC interactions
 
         Returns
         -------
-        List[QCluster_t]
+        list[QCluster_t]
            List of OpT0Finder flashmatch::QCluster_t objects
         """
-        # Loop over the interacions
+        # Loop over the interactions
         flashmatch = get_flashmatch()
         qcluster_v = []
         for idx, inter in enumerate(interactions):
@@ -228,17 +232,17 @@ class LikelihoodFlashMatcher:
 
         return qcluster_v
 
-    def make_flash_list(self, flashes):
+    def make_flash_list(self, flashes: list[Any]) -> tuple[list[Any], list[Any]]:
         """Creates a list of flashmatch.Flash_t from the local class.
 
         Parameters
         ----------
-        flashes : List[Flash]
+        flashes : list[Flash]
             List of optical flashes
 
         Returns
         -------
-        List[Flash_t]
+        list[Flash_t]
             List of flashmatch::Flash_t objects
         """
         # Loop over the optical flashes
@@ -264,12 +268,12 @@ class LikelihoodFlashMatcher:
 
         return flash_v, flashes
 
-    def run_flash_matching(self):
+    def run_flash_matching(self) -> list[Any]:
         """Drive the OpT0Finder flash matching.
 
         Returns
         -------
-        List[flashmatch::FlashMatch_t]
+        list[flashmatch::FlashMatch_t]
             List of matches
         """
         # Make sure the interaction and flash objects were set
@@ -295,7 +299,7 @@ class LikelihoodFlashMatcher:
 
         return all_matches
 
-    def get_qcluster(self, idx, array=False):
+    def get_qcluster(self, idx: int, array: bool = False) -> Any:
         """Fetch a given flashmatch::QCluster_t object.
 
         Parameters
@@ -307,7 +311,7 @@ class LikelihoodFlashMatcher:
 
         Returns
         -------
-        Union[flashmatch::QCluster_t, np.ndarray]
+        flashmatch::QCluster_t or np.ndarray
             QCluster object
         """
         flashmatch = get_flashmatch()
@@ -324,7 +328,7 @@ class LikelihoodFlashMatcher:
 
         raise IndexError(f"TPC object {idx} does not exist in self.qcluster_v")
 
-    def get_flash(self, idx, array=False):
+    def get_flash(self, idx: int, array: bool = False) -> Any:
         """Fetch a given flashmatch::Flash object.
 
         Parameters
@@ -336,7 +340,7 @@ class LikelihoodFlashMatcher:
 
         Returns
         -------
-        Union[flashmatch::Flash, np.ndarray]
+        flashmatch::Flash or np.ndarray
             Flash object
         """
         flashmatch = get_flashmatch()
@@ -353,7 +357,7 @@ class LikelihoodFlashMatcher:
 
         raise IndexError(f"Flash {idx} does not exist in self.flash_v")
 
-    def get_match(self, idx):
+    def get_match(self, idx: int) -> Any | None:
         """Fetch a match for a given TPC interaction ID.
 
         Parameters
@@ -376,7 +380,7 @@ class LikelihoodFlashMatcher:
 
         return None
 
-    def get_matched_flash(self, idx):
+    def get_matched_flash(self, idx: int) -> Any | None:
         """Fetch a matched flash for a given TPC interaction ID.
 
         Parameters
@@ -407,7 +411,7 @@ class LikelihoodFlashMatcher:
 
         return self.flash_v[flash_id]
 
-    def get_t0(self, idx):
+    def get_t0(self, idx: int) -> float | None:
         """Fetch a matched flash time for a given TPC interaction ID.
 
         Parameters

--- a/src/spine/post/optical/likelihood.py
+++ b/src/spine/post/optical/likelihood.py
@@ -1,10 +1,19 @@
 """Module which supports likelihood-based flash matchin (OpT0Finder)."""
 
+from __future__ import annotations
+
 import os
 import sys
+from importlib import import_module
+from typing import Any
 
 import numexpr as ne
 import numpy as np
+
+
+def get_flashmatch() -> Any:
+    """Load the optional OpT0Finder Python bindings at runtime."""
+    return import_module("flashmatch").flashmatch
 
 
 class LikelihoodFlashMatcher:
@@ -81,11 +90,12 @@ class LikelihoodFlashMatcher:
         """
         # Add OpT0finder python interface to the python path
         basedir = os.getenv("FMATCH_BASEDIR")
-        assert basedir is not None, (
-            "You need to source OpT0Finder's configure.sh or set the "
-            "FMATCH_BASEDIR environment variable before running flash "
-            "matching."
-        )
+        if basedir is None:
+            raise ValueError(
+                "You need to source OpT0Finder's configure.sh or set the "
+                "FMATCH_BASEDIR environment variable before running flash "
+                "matching."
+            )
         sys.path.append(os.path.join(basedir, "python"))
 
         # Add the OpT0Finder library to the dynamic link loader
@@ -109,8 +119,7 @@ class LikelihoodFlashMatcher:
                 f"Cannot file detector specification file: {det_cfg}."
             )
 
-        from flashmatch import flashmatch
-
+        flashmatch = get_flashmatch()
         flashmatch.DetectorSpecs.GetME(det_cfg)
 
         # Fetch and initialize the OpT0Finder configuration
@@ -183,8 +192,7 @@ class LikelihoodFlashMatcher:
            List of OpT0Finder flashmatch::QCluster_t objects
         """
         # Loop over the interacions
-        from flashmatch import flashmatch
-
+        flashmatch = get_flashmatch()
         qcluster_v = []
         for idx, inter in enumerate(interactions):
             # Produce a mask to remove negative value points (can happen)
@@ -234,8 +242,7 @@ class LikelihoodFlashMatcher:
             List of flashmatch::Flash_t objects
         """
         # Loop over the optical flashes
-        from flashmatch import flashmatch
-
+        flashmatch = get_flashmatch()
         flash_v = []
         for idx, f in enumerate(flashes):
             # Initialize the Flash_t object
@@ -266,9 +273,8 @@ class LikelihoodFlashMatcher:
             List of matches
         """
         # Make sure the interaction and flash objects were set
-        assert (
-            self.qcluster_v is not None and self.flash_v is not None
-        ), "Must make_qcluster_list and make_flash_list first."
+        if self.qcluster_v is None or self.flash_v is None:
+            raise ValueError("Must make_qcluster_list and make_flash_list first.")
 
         # Register all objects in the manager
         self.mgr.Reset()
@@ -304,8 +310,7 @@ class LikelihoodFlashMatcher:
         Union[flashmatch::QCluster_t, np.ndarray]
             QCluster object
         """
-        from flashmatch import flashmatch
-
+        flashmatch = get_flashmatch()
         if self.qcluster_v is None:
             raise ValueError("self.qcluster_v is None")
 
@@ -334,8 +339,7 @@ class LikelihoodFlashMatcher:
         Union[flashmatch::Flash, np.ndarray]
             Flash object
         """
-        from flashmatch import flashmatch
-
+        flashmatch = get_flashmatch()
         if self.flash_v is None:
             raise ValueError("self.flash_v is None")
 

--- a/src/spine/post/reco/calo.py
+++ b/src/spine/post/reco/calo.py
@@ -1,5 +1,10 @@
 """Calorimetric energy reconstruction module."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 import numexpr as ne
 import numpy as np
 
@@ -23,35 +28,37 @@ class CalorimetricEnergyProcessor(PostBase):
 
     def __init__(
         self,
-        scaling=1.0,
-        shower_fudge=1.0,
-        obj_type="particle",
-        run_mode="reco",
-        truth_dep_mode="depositions",
-    ):
+        scaling: float | str = 1.0,
+        shower_fudge: float | str = 1.0,
+        obj_type: str | Sequence[str] | None = "particle",
+        run_mode: str = "reco",
+        truth_dep_mode: str = "depositions",
+    ) -> None:
         """Stores the ADC to MeV conversion factor.
 
         Parameters
         ----------
-        scaling : Union[float, str], default 1.
+        scaling : float or str, default 1.
             Global scaling factor for the depositions (can be an expression)
-        shower_fudge : Union[float, str], default 1.
+        shower_fudge : float or str, default 1.
             Shower energy fudge factor (accounts for missing cluster energy)
         """
         # Initialize the parent class
         super().__init__(obj_type, run_mode, truth_dep_mode=truth_dep_mode)
 
         # Store the conversion factor
-        self.scaling = scaling
-        if isinstance(self.scaling, str):
-            self.scaling = float(ne.evaluate(self.scaling))
+        self.scaling = (
+            float(ne.evaluate(scaling)) if isinstance(scaling, str) else scaling
+        )
 
         # Store the shower fudge factor
-        self.shower_fudge = shower_fudge
-        if isinstance(self.shower_fudge, str):
-            self.shower_fudge = float(ne.evaluate(self.shower_fudge))
+        self.shower_fudge = (
+            float(ne.evaluate(shower_fudge))
+            if isinstance(shower_fudge, str)
+            else shower_fudge
+        )
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Reconstruct the calorimetric KE for each particle in one entry.
 
         Parameters
@@ -87,12 +94,12 @@ class CalibrationProcessor(PostBase):
 
     def __init__(
         self,
-        do_tracking=False,
-        obj_type=("particle", "interaction"),
-        run_mode="reco",
-        truth_point_mode="points",
-        **cfg,
-    ):
+        do_tracking: bool = False,
+        obj_type: str | Sequence[str] | None = ("particle", "interaction"),
+        run_mode: str = "reco",
+        truth_point_mode: str = "points",
+        **cfg: Any,
+    ) -> None:
         """Initialize the calibration manager.
 
         Parameters
@@ -128,7 +135,7 @@ class CalibrationProcessor(PostBase):
 
         self.update_keys(keys)
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Apply calibrations to each particle in one entry.
 
         Parameters

--- a/src/spine/post/reco/calorimetric_direction.py
+++ b/src/spine/post/reco/calorimetric_direction.py
@@ -1,5 +1,10 @@
 """Calorimetric interaction direction reconstruction module."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
 import numpy as np
 
 from spine.post.base import PostBase
@@ -24,9 +29,9 @@ class CalorimetricDirectionProcessor(PostBase):
 
     def __init__(
         self,
-        run_mode="both",
-        truth_point_mode="points",
-    ):
+        run_mode: str = "both",
+        truth_point_mode: str = "points",
+    ) -> None:
         """Initialize the calorimetric direction reconstruction parameters.
 
         Parameters
@@ -46,7 +51,7 @@ class CalorimetricDirectionProcessor(PostBase):
         if run_mode != "reco":
             self.update_keys({self.truth_point_key: True})
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Reconstruct the direction for each interaction.
 
         Parameters
@@ -59,7 +64,9 @@ class CalorimetricDirectionProcessor(PostBase):
             for inter in data[k]:
                 self._reconstruct_direction(inter, data, points_key)
 
-    def _reconstruct_direction(self, inter, data, points_key):
+    def _reconstruct_direction(
+        self, inter: Any, data: Mapping[str, Any], points_key: str
+    ) -> None:
         """Reconstruct the direction for one interaction.
 
         Parameters
@@ -75,9 +82,11 @@ class CalorimetricDirectionProcessor(PostBase):
         if vertex is None or len(inter.particles) == 0:
             return
 
-        all_indices = np.concatenate(
-            [part.index for part in inter.particles if part.size > 0]
-        )
+        indices = [part.index for part in inter.particles if part.size > 0]
+        if len(indices) == 0:
+            return
+
+        all_indices = np.concatenate(indices)
         if len(all_indices) == 0:
             return
 

--- a/src/spine/post/reco/cathode_cross.py
+++ b/src/spine/post/reco/cathode_cross.py
@@ -1,5 +1,10 @@
 """Cathode crossing identification + merging module."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
 import numpy as np
 from scipy.spatial.distance import cdist
 
@@ -17,8 +22,8 @@ class CathodeCrosserProcessor(PostBase):
     """Find particles that cross the cathode of a LArTPC module that is divided
     into two TPCs. It might manifest itself into two forms:
     - If the particle is ~in-time, it will be a single particle, with
-      potentially a small break/offset in the center
-    - If the particle is sigificantly out-of-time, a cathode crosser will
+      potentially a small break/offset near the cathode
+    - If the particle is significantly out-of-time, a cathode crosser will
       be composed of two distinct reconstructed particle objects
     """
 
@@ -36,15 +41,15 @@ class CathodeCrosserProcessor(PostBase):
 
     def __init__(
         self,
-        crossing_point_tolerance,
-        offset_tolerance,
-        angle_tolerance,
-        merge_crossers=True,
-        adjust_crossers=True,
-        adjust_method="distance",
-        run_mode="reco",
-        truth_point_mode="points",
-    ):
+        crossing_point_tolerance: float,
+        offset_tolerance: float,
+        angle_tolerance: float,
+        merge_crossers: bool = True,
+        adjust_crossers: bool = True,
+        adjust_method: str = "distance",
+        run_mode: str = "reco",
+        truth_point_mode: str = "points",
+    ) -> None:
         """Initialize the cathode crosser finder algorithm.
 
         Parameters
@@ -52,7 +57,7 @@ class CathodeCrosserProcessor(PostBase):
         crossing_point_tolerance : float
             Maximum allowed distance in the cathode plane (in cm) between two
             fragments of a cathode crosser to be considered compatible
-        offset_tolerance
+        offset_tolerance : float
             Maximum allowed discrepancy between end-point to cathode offsets of
             two fragments of a cathode crosser to be considered compatible
         angle_tolerance : float
@@ -64,7 +69,7 @@ class CathodeCrosserProcessor(PostBase):
             the crosser belongs to
         adjust_crossers : bool, default True
             If True, shifts cathode crosser positions to match at the cathode
-        adjust_method : str, default distance
+        adjust_method : str, default 'distance'
             Method used to adjust the cathode crossers:
             - 'distance': make the tracks meet at the cathode
             - 'projection': make the y-intercepts of the two tracks match in the
@@ -100,7 +105,7 @@ class CathodeCrosserProcessor(PostBase):
             keys[self.truth_point_key] = True
         self.update_keys(keys)
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> dict[str, Any]:
         """Find cathode crossing particles in one entry.
 
         Parameters
@@ -148,7 +153,7 @@ class CathodeCrosserProcessor(PostBase):
                 # TODO: expand functionality to support multi-module crossers
                 modules, tpcs = self.geo.get_contributors(self.get_sources(part))
                 assert len(np.unique(modules)) == 1, (
-                    "The cathode crosser identification/mergin post-"
+                    "The cathode crosser identification/merging post-"
                     "processor does not support multi-module crossers."
                 )
 
@@ -208,20 +213,20 @@ class CathodeCrosserProcessor(PostBase):
 
         return update_dict
 
-    def find_matches(self, particles):
+    def find_matches(self, particles: list[Any]) -> tuple[list[Any], list[Any]]:
         """Loop over all particles, find matches and update the
         particle/interaction list accordingly.
 
         Parameters
         ----------
-        particles : List[RecoParticle]
+        particles : list[RecoParticle]
             List of reconstructed particles
 
         Returns
         -------
-        List[RecoParticle]
+        list[RecoParticle]
             Updated list of reconstructed particles
-        List[RecoInteraction]
+        list[RecoInteraction]
             Updated list of reconstructed interactions
         """
         # Restrict candidates to particles which are not already tagged and
@@ -323,7 +328,9 @@ class CathodeCrosserProcessor(PostBase):
 
         return particles, interactions
 
-    def merge_particles(self, particles, idx_i, idx_j):
+    def merge_particles(
+        self, particles: list[Any], idx_i: int, idx_j: int
+    ) -> list[Any]:
         """Given two particles which form a single cathode crosser, merge
         the two instances into one in place.
 
@@ -332,7 +339,7 @@ class CathodeCrosserProcessor(PostBase):
 
         Parameters
         ----------
-        particles : List[RecoParticle]
+        particles : list[RecoParticle]
             List of reconstructed particles
         idx_i : int
             Index of a cathode crosser (or a cathode crosser fragment)
@@ -341,7 +348,7 @@ class CathodeCrosserProcessor(PostBase):
 
         Returns
         -------
-        List[RecoParticle]
+        list[RecoParticle]
             Updated list of reconstructed particles
         """
         # Merge particles, retain original interaction IDs
@@ -358,21 +365,19 @@ class CathodeCrosserProcessor(PostBase):
 
         return particles
 
-    def get_cathode_offset(self, particle):
+    def get_cathode_offset(self, particle: Any) -> float:
         """Find the distance one must shift a particle points by to make
         both TPC contributions align at the cathode.
 
         Parameters
         ----------
-        particle : Union[Particle, TruthParticle]
+        particle : Particle or TruthParticle
             Particle object
 
         Returns
         -------
-        np.ndarray
-            Offsets to apply to the each TPC contributions
         float
-            Offset applied to the particle as a whole (signed by time)
+            Offset applied to the particle as a whole, signed by drift direction
         """
         # Get TPCs that contributed to this particle
         modules, tpcs = self.geo.get_contributors(self.get_sources(particle))
@@ -432,7 +437,7 @@ class CathodeCrosserProcessor(PostBase):
         return global_offset
 
     @staticmethod
-    def projection_offset(points, directions):
+    def projection_offset(points: np.ndarray, directions: np.ndarray) -> float:
         """Finds the offset to optimize the alignment in xy and xz.
 
         It minimizes (xy intercept mismatch)^2 + (xz intercept mismatch)^2.
@@ -447,7 +452,7 @@ class CathodeCrosserProcessor(PostBase):
         Returns
         -------
         float
-            Optimal offset based on projection projection interecepts
+            Optimal offset based on projection intercepts
         """
         # Check that the x component of the two vector is non-zero
         assert np.all(np.abs(directions[:, 0]) > 0.0), (
@@ -473,7 +478,7 @@ class CathodeCrosserProcessor(PostBase):
         return -np.sum(weights * diffs) / np.sum(weights**2)
 
     @staticmethod
-    def dot_offset(points, directions):
+    def dot_offset(points: np.ndarray, directions: np.ndarray) -> float:
         """Finds the offset to optimize the alignment between the line
         directions and the vector joining the two line points.
 
@@ -506,7 +511,14 @@ class CathodeCrosserProcessor(PostBase):
         # Optimize delta such that the norm displacement vector are perpendicular
         return -np.dot(norm, v) / 2 * norm[0]
 
-    def adjust_positions(self, data, particles, interactions, idx, offset):
+    def adjust_positions(
+        self,
+        data: Mapping[str, Any],
+        particles: list[Any],
+        interactions: list[Any],
+        idx: int,
+        offset: float,
+    ) -> None:
         """Given a cathode crosser, apply the necessary position offsets to
         match it at the cathode.
 
@@ -514,9 +526,9 @@ class CathodeCrosserProcessor(PostBase):
         ----------
         data : dict
             Dictionary of data products
-        particles : List[ParticleBase]
+        particles : list[ParticleBase]
             List of particles
-        interactions : List[InteractionBase]
+        interactions : list[InteractionBase]
             List of interactions
         idx : int
             Index of a cathode crosser

--- a/src/spine/post/reco/cluster.py
+++ b/src/spine/post/reco/cluster.py
@@ -5,6 +5,11 @@ without requiring model weights. This is useful to produce basic data
 assessment metrics without relying on high-level reconstruction tools.
 """
 
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
 import numpy as np
 
 from spine.constants import TRACK_SHP
@@ -37,25 +42,25 @@ class TrackClusterer(PostBase):
 
     def __init__(
         self,
-        eps=5.0,
-        min_samples=1,
-        metric="euclidean",
-        min_size=10,
-        max_rel_spread=0.1,
-        max_axis_dist=None,
-        split_volume=None,
-        particle_type="reco",
-    ):
+        eps: float = 5.0,
+        min_samples: int = 1,
+        metric: str = "euclidean",
+        min_size: int = 10,
+        max_rel_spread: float = 0.1,
+        max_axis_dist: float | None = None,
+        split_volume: str | None = None,
+        particle_type: str = "reco",
+    ) -> None:
         """Initialize the track factory.
 
         Parameters
         ----------
         eps : float, default 5.
-            DBSCAN distance parameter for intial clustering (cm)
+            DBSCAN distance parameter for initial clustering (cm)
         min_samples : int, default 1
             DBSCAN min samples parameter for initial clustering
         metric : str, default 'euclidean'
-            DBSCAN metric for intial clustering
+            DBSCAN metric for initial clustering
         min_size : int, default 10
             Minimum track size, in number of hits
         max_rel_spread : float, default 0.1
@@ -64,7 +69,7 @@ class TrackClusterer(PostBase):
             Maximum track axis distance to filter points to, if requested
         split_volume : str, optional
             If specified, the track clusters are restricted within either
-            a detecor 'module' or 'tpc'
+            a detector 'module' or 'tpc'
         particle_type : str, default 'reco'
             Type of particle output by this algorithm
         """
@@ -98,7 +103,7 @@ class TrackClusterer(PostBase):
         self.particle_class = self.particle_classes[particle_type]
 
     @property
-    def particle_classes(self):
+    def particle_classes(self) -> dict[str, type[RecoParticle] | type[TruthParticle]]:
         """Dictionary which maps particle type to particle classes.
 
         Returns
@@ -108,7 +113,7 @@ class TrackClusterer(PostBase):
         """
         return dict(self._particle_classes)
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> dict[str, ObjectList]:
         """Produce track clusters for one entry.
 
         Parameters
@@ -119,7 +124,7 @@ class TrackClusterer(PostBase):
         Returns
         -------
         dict
-            Dictionary which reconstructed track instances
+            Dictionary containing reconstructed track instances
         """
         # Dispatch
         points, depositions = data["points"], data["depositions"]
@@ -176,7 +181,7 @@ class TrackClusterer(PostBase):
 
         return {f"{self.particle_type}_particles": particles}
 
-    def process_volume(self, points):
+    def process_volume(self, points: np.ndarray) -> list[np.ndarray]:
         """Produce track clusters for one volume.
 
         Parameters
@@ -186,7 +191,7 @@ class TrackClusterer(PostBase):
 
         Returns
         -------
-        List[np.ndarray]
+        list[np.ndarray]
             List of cluster indexes
         """
         # Fetch the list of points in the image

--- a/src/spine/post/reco/direction.py
+++ b/src/spine/post/reco/direction.py
@@ -1,5 +1,10 @@
 """Particle direction reconstruction module."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 import numpy as np
 
 from spine.constants import TRACK_SHP
@@ -24,12 +29,12 @@ class DirectionProcessor(PostBase):
 
     def __init__(
         self,
-        radius=-1,
-        optimize=True,
-        obj_type="particle",
-        truth_point_mode="points",
-        run_mode="both",
-    ):
+        radius: float = -1.0,
+        optimize: bool = True,
+        obj_type: str | Sequence[str] | None = "particle",
+        truth_point_mode: str = "points",
+        run_mode: str = "both",
+    ) -> None:
         """Store the particle direction reconstruction parameters.
 
         Parameters
@@ -52,7 +57,7 @@ class DirectionProcessor(PostBase):
         if run_mode != "reco":
             self.update_keys({self.truth_point_key: True})
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Reconstruct the directions of all particles in one entry.
 
         Parameters

--- a/src/spine/post/reco/geometry.py
+++ b/src/spine/post/reco/geometry.py
@@ -1,5 +1,12 @@
 """Detector-geometry-based reconstruction module."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
 from spine.constants import PID_LABELS
 from spine.geo import GeoManager
 from spine.post.base import PostBase
@@ -23,17 +30,17 @@ class ContainmentProcessor(PostBase):
 
     def __init__(
         self,
-        margin,
-        cathode_margin=None,
-        mode="module",
-        allow_multi_module=False,
-        logical=False,
-        exclude_pids=None,
-        min_particle_sizes=0,
-        obj_type=("particle", "interaction"),
-        truth_point_mode="points",
-        run_mode="both",
-    ):
+        margin: float | list[float] | np.ndarray,
+        cathode_margin: float | None = None,
+        mode: str = "module",
+        allow_multi_module: bool = False,
+        logical: bool = False,
+        exclude_pids: Sequence[int] | None = None,
+        min_particle_sizes: int | Mapping[int | str, int] = 0,
+        obj_type: str | Sequence[str] | None = ("particle", "interaction"),
+        truth_point_mode: str = "points",
+        run_mode: str = "both",
+    ) -> None:
         """Initialize the containment conditions.
 
         If the `source` method is used, the cut will be based on the source of
@@ -43,17 +50,18 @@ class ContainmentProcessor(PostBase):
 
         Parameters
         ----------
-        margin : Union[float, List[float], np.array]
+        margin : float, sequence or np.ndarray
             Minimum distance from a detector wall to be considered contained:
             - If float: distance buffer is shared between all 6 walls
-            - If [x,y,z]: distance is shared between pairs of falls facing
+            - If [x,y,z]: distance is shared between pairs of walls facing
               each other and perpendicular to a shared axis
             - If [[x_low,x_up], [y_low,y_up], [z_low,z_up]]: distance is
               specified individually of each wall.
         cathode_margin : float, optional
             If specified, sets a different margin for the cathode boundaries
         mode : str, default 'module'
-            Containement criterion (one of 'global', 'module', 'tpc'):
+            Containment criterion (one of 'detector', 'module', 'tpc',
+            'source' or 'meta'):
             - If 'tpc', makes sure it is contained within a single tpc
             - If 'module', makes sure it is contained within a single module
             - If 'detector', makes sure it is contained within the
@@ -68,10 +76,10 @@ class ContainmentProcessor(PostBase):
             If `True`, the module is checking for logical containment, i.e. that
             particles/interactions do not span outside of the drift window, with
             padding defined by the margin/cathode margin parameters
-        exclude_pids : List[int], optional
+        exclude_pids : sequence[int], optional
             When checking interaction containment, ignore particles which
             have a species specified by this list
-        min_particle_sizes : Union[int, dict], default 0
+        min_particle_sizes : int or dict, default 0
             When checking interaction containment, ignore particles below the
             size (in voxel count) specified by this parameter. If specified
             as a dictionary, it maps a specific particle type to its own cut.
@@ -123,7 +131,7 @@ class ContainmentProcessor(PostBase):
             else:
                 self.min_particle_sizes[pid] = 0
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Check the containment of all objects in one entry.
 
         Parameters
@@ -219,34 +227,34 @@ class FiducialProcessor(PostBase):
 
     def __init__(
         self,
-        margin,
-        cathode_margin=None,
-        mode="module",
-        run_mode="both",
-        truth_vertex_mode="vertex",
-    ):
+        margin: float | list[float] | np.ndarray,
+        cathode_margin: float | None = None,
+        mode: str = "module",
+        run_mode: str = "both",
+        truth_vertex_mode: str = "vertex",
+    ) -> None:
         """Initialize the fiducial conditions.
 
         Parameters
         ----------
-        margin : Union[float, List[float], np.array]
+        margin : float, sequence or np.ndarray
             Minimum distance from a detector wall to be considered contained:
             - If float: distance buffer is shared between all 6 walls
-            - If [x,y,z]: distance is shared between pairs of falls facing
+            - If [x,y,z]: distance is shared between pairs of walls facing
               each other and perpendicular to a shared axis
             - If [[x_low,x_up], [y_low,y_up], [z_low,z_up]]: distance is
               specified individually of each wall.
         cathode_margin : float, optional
             If specified, sets a different margin for the cathode boundaries
         mode : str, default 'module'
-            Containement criterion (one of 'global', 'module', 'tpc'):
+            Containment criterion (one of 'detector', 'module', 'tpc' or 'meta'):
             - If 'tpc', makes sure it is contained within a single tpc
             - If 'module', makes sure it is contained within a single module
             - If 'detector', makes sure it is contained within the
               outermost walls
             - If 'meta', use the metadata range as a basis for containment.
               Note that this does not guarantee containment within the detector.
-        truth_vertex_mode : str, default 'truth_vertex'
+        truth_vertex_mode : str, default 'vertex'
              Vertex attribute to use to check containment of true interactions
         """
         # Initialize the parent class
@@ -272,7 +280,7 @@ class FiducialProcessor(PostBase):
         )
         self.truth_vertex_mode = truth_vertex_mode
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Check the fiducial status of all interactions in one entry.
 
         Parameters
@@ -297,7 +305,7 @@ class FiducialProcessor(PostBase):
                         vertex > (data["meta"].lower + self.margin)
                     ).all() and (vertex < (data["meta"].upper - self.margin)).all()
 
-    def get_vertex(self, inter):
+    def get_vertex(self, inter: Any) -> np.ndarray:
         """Get a certain pre-defined vertex attribute of an interaction.
 
         The :class:`TruthInteraction` vertexes are obtained using the
@@ -305,7 +313,7 @@ class FiducialProcessor(PostBase):
 
         Parameters
         ----------
-        obj : InteractionBase
+        inter : InteractionBase
             Interaction object
 
         Returns

--- a/src/spine/post/reco/kinematics.py
+++ b/src/spine/post/reco/kinematics.py
@@ -1,5 +1,10 @@
 """Kinematics update module."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
 import numpy as np
 
 from spine.constants import (
@@ -41,7 +46,12 @@ class ParticleShapeLogicProcessor(PostBase):
     # Alternative allowed names of the post-processor
     aliases = ("enforce_particle_semantics",)
 
-    def __init__(self, enforce_pid=True, enforce_primary=True, maximum_michel_ke=None):
+    def __init__(
+        self,
+        enforce_pid: bool = True,
+        enforce_primary: bool = True,
+        maximum_michel_ke: float | None = None,
+    ) -> None:
         """Store information about which particle properties should
         or should not be updated.
 
@@ -67,7 +77,7 @@ class ParticleShapeLogicProcessor(PostBase):
         if self.maximum_michel_ke is not None:
             self.update_upstream("calo_ke")
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Update PID and primary predictions of each particle in one entry
 
         Parameters
@@ -122,10 +132,10 @@ class ParticleThresholdProcessor(PostBase):
 
     def __init__(
         self,
-        shower_pid_thresholds=None,
-        track_pid_thresholds=None,
-        primary_threshold=None,
-    ):
+        shower_pid_thresholds: Mapping[int, float] | None = None,
+        track_pid_thresholds: Mapping[int, float] | None = None,
+        primary_threshold: float | None = None,
+    ) -> None:
         """Store the new thresholds to be used to update the PID and primary
         information of particles.
 
@@ -137,7 +147,7 @@ class ParticleThresholdProcessor(PostBase):
         track_pid_thresholds : dict, optional
             Dictionary which maps a track PID output to a threshold value,
             in order
-        primary_treshold : float, optional
+        primary_threshold : float, optional
             Primary score above which a particle is considered a primary
         """
         # Intialize the parent class
@@ -159,7 +169,7 @@ class ParticleThresholdProcessor(PostBase):
         self.track_pid_thresholds = track_pid_thresholds
         self.primary_threshold = primary_threshold
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Update PID predictions of each particle one entry.
 
         Parameters
@@ -217,7 +227,7 @@ class ParticleNeutrinoLogicProcessor(PostBase):
     # Lepton selection method
     _methods = ("size", "score")
 
-    def __init__(self, method="size", cc_only=True):
+    def __init__(self, method: str = "size", cc_only: bool = True) -> None:
         """Store information about how to enforce neutrino logic.
 
         Parameters
@@ -240,7 +250,7 @@ class ParticleNeutrinoLogicProcessor(PostBase):
         self.method = method
         self.cc_only = cc_only
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Update PID and primary predictions of each particle in one entry
 
         Parameters
@@ -302,18 +312,18 @@ class InteractionTopologyProcessor(PostBase):
 
     def __init__(
         self,
-        ke_thresholds=None,
-        reco_ke_mode="ke",
-        truth_ke_mode="energy_deposit",
-        run_mode="both",
-    ):
+        ke_thresholds: float | Mapping[int | str, float] | None = None,
+        reco_ke_mode: str = "ke",
+        truth_ke_mode: str = "energy_deposit",
+        run_mode: str = "both",
+    ) -> None:
         """Store the new thresholds to be used to update interaction topologies.
 
         Parameters
         ----------
-        ke_thresholds : Union[float, dict]
+        ke_thresholds : float or dict, optional
             If a scalar, it specifies a blanket KE cut to apply to all
-            particles. If it is a dictionary, it maps an PID to a KE threshold.
+            particles. If it is a dictionary, it maps a PID to a KE threshold.
             If a 'default' key is provided, it is used for all particles,
             unless a number is provided for a specific PID.
         reco_ke_mode : str, default 'ke'
@@ -341,7 +351,7 @@ class InteractionTopologyProcessor(PostBase):
             else:
                 self.ke_thresholds[pid] = 0.0
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Update each interaction topology in one interaction.
 
         Parameters

--- a/src/spine/post/reco/mcs.py
+++ b/src/spine/post/reco/mcs.py
@@ -1,5 +1,10 @@
 """Multiple-Coulomb scattering (MCS) energy reconstruction module."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 import numpy as np
 
 from spine.constants import (
@@ -30,23 +35,23 @@ class MCSEnergyProcessor(PostBase):
 
     def __init__(
         self,
-        tracking_mode="bin_pca",
-        segment_length=5.0,
-        res_a=0.25,
-        res_b=1.25,
-        res_mixture=False,
-        res_weight_ratio=0.5,
-        res_scale_ratio=2.25,
-        include_pids=(MUON_PID, PION_PID, PROT_PID, KAON_PID),
-        fill_per_pid=False,
-        only_uncontained=False,
-        angle_method="atan2",
-        obj_type="particle",
-        run_mode="both",
-        truth_point_mode="points",
-        pid_mode="pid",
-        **kwargs,
-    ):
+        tracking_mode: str = "bin_pca",
+        segment_length: float = 5.0,
+        res_a: float = 0.25,
+        res_b: float = 1.25,
+        res_mixture: bool = False,
+        res_weight_ratio: float = 0.5,
+        res_scale_ratio: float = 2.25,
+        include_pids: Sequence[int] = (MUON_PID, PION_PID, PROT_PID, KAON_PID),
+        fill_per_pid: bool = False,
+        only_uncontained: bool = False,
+        angle_method: str = "atan2",
+        obj_type: str | Sequence[str] | None = "particle",
+        run_mode: str = "both",
+        truth_point_mode: str = "points",
+        pid_mode: str = "pid",
+        **kwargs: Any,
+    ) -> None:
         """Store the necessary attributes to do MCS-based estimations.
 
         Parameters
@@ -66,7 +71,7 @@ class MCSEnergyProcessor(PostBase):
             When using a Rayleigh mixture, defines the weight ratio between components
         res_scale_ratio : float, default 2.25
             When using a Rayleigh mixture, defines the scale ratio between components
-        include_pids : list, default [2, 3, 4, 5]
+        include_pids : sequence[int], default [2, 3, 4, 5]
             Particle species to compute the kinetic energy for
         fill_per_pid : bool, default False
             If `True`, compute the MCS KE estimate under all PID assumptions
@@ -74,7 +79,7 @@ class MCSEnergyProcessor(PostBase):
             Only run the algorithm on particles that are not contained
         angle_method : str, default 'atan2'
             Angular reconstruction method
-        **kwargs : dict, optiona
+        **kwargs : dict, optional
             Additional arguments to pass to the tracking algorithm
         """
         # Initialize the parent class
@@ -107,7 +112,7 @@ class MCSEnergyProcessor(PostBase):
         self.res_weight_ratio = res_weight_ratio
         self.res_scale_ratio = res_scale_ratio
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Reconstruct the MCS KE estimates for each particle in one entry.
 
         Parameters

--- a/src/spine/post/reco/mcs.py
+++ b/src/spine/post/reco/mcs.py
@@ -86,19 +86,17 @@ class MCSEnergyProcessor(PostBase):
         self.only_uncontained = only_uncontained
 
         # Store the tracking parameters
-        assert tracking_mode in [
-            "step",
-            "step_next",
-            "bin_pca",
-        ], "The tracking algorithm must provide segment angles"
+        if tracking_mode not in ("step", "step_next", "bin_pca"):
+            raise ValueError("The tracking algorithm must provide segment angles.")
         self.tracking_mode = tracking_mode
         self.tracking_kwargs = kwargs
 
         # Store the angle computation parameters
-        assert angle_method in ANGLE_METHODS, (
-            f"Angular reconstruction method not recognized: {angle_method}. "
-            f"Must be one of {ANGLE_METHODS.keys()}"
-        )
+        if angle_method not in ANGLE_METHODS:
+            raise ValueError(
+                f"Angular reconstruction method not recognized: {angle_method}. "
+                f"Must be one of {ANGLE_METHODS.keys()}"
+            )
         self.angle_method = ANGLE_METHODS[angle_method]
 
         # Store the MCS parameters

--- a/src/spine/post/reco/pid.py
+++ b/src/spine/post/reco/pid.py
@@ -1,5 +1,10 @@
 """Particle identification modules."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 import numpy as np
 
 from spine.constants import TRACK_SHP
@@ -19,13 +24,13 @@ class PIDTemplateProcessor(PostBase):
 
     def __init__(
         self,
-        fill_per_pid=False,
-        obj_type="particle",
-        run_mode="reco",
-        truth_point_mode="points",
-        truth_dep_mode="depositions",
-        **identifier,
-    ):
+        fill_per_pid: bool = False,
+        obj_type: str | Sequence[str] | None = "particle",
+        run_mode: str = "reco",
+        truth_point_mode: str = "points",
+        truth_dep_mode: str = "depositions",
+        **identifier: Any,
+    ) -> None:
         """Store the necessary attributes to do template-based PID prediction.
 
         Parameters
@@ -44,8 +49,8 @@ class PIDTemplateProcessor(PostBase):
         # Initialize the underlying template-fitter class
         self.identifier = TemplateParticleIdentifier(**identifier)
 
-    def process(self, data):
-        """Reconstruct the CSDA KE estimates for each particle in one entry.
+    def process(self, data: Mapping[str, Any]) -> None:
+        """Reconstruct template PID estimates for each particle in one entry.
 
         Parameters
         ----------

--- a/src/spine/post/reco/points.py
+++ b/src/spine/post/reco/points.py
@@ -1,5 +1,10 @@
 """Track end point assignment module."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 from spine.constants import TRACK_SHP
 from spine.post.base import PostBase
 from spine.utils.ppn import check_track_orientation_ppn
@@ -20,7 +25,12 @@ class TrackExtremaProcessor(PostBase):
     # Set of data keys needed for this post-processor to operate
     _keys = (("ppn_candidates", False),)
 
-    def __init__(self, method="local", obj_type="particle", **kwargs):
+    def __init__(
+        self,
+        method: str = "local",
+        obj_type: str | Sequence[str] | None = "particle",
+        **kwargs: Any,
+    ) -> None:
         """Initialize the track end point assignment parameters.
 
         Parameters
@@ -35,7 +45,7 @@ class TrackExtremaProcessor(PostBase):
             density variation to estimate the direction.
             - ppn: uses ppn candidate predictions (classify_endpoints) to
             assign start and endpoints.
-        kwargs : dict
+        **kwargs : dict
             Extra arguments to pass to the `check_track_orientation` or the
             `check_track_orientation_ppn' functions
         """
@@ -46,7 +56,7 @@ class TrackExtremaProcessor(PostBase):
         self.method = method
         self.kwargs = kwargs
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Assign track end points in one entry
 
         Parameters
@@ -69,10 +79,11 @@ class TrackExtremaProcessor(PostBase):
                     )
 
                 elif self.method == "ppn":
-                    assert "ppn_candidates" in data, (
-                        "Must run the `ppn` post-processor "
-                        "before using PPN predictions to assign extrema."
-                    )
+                    if "ppn_candidates" not in data:
+                        raise KeyError(
+                            "Must run the `ppn` post-processor "
+                            "before using PPN predictions to assign extrema."
+                        )
                     flip = not check_track_orientation_ppn(
                         part.start_point, part.end_point, data["ppn_candidates"]
                     )

--- a/src/spine/post/reco/ppn.py
+++ b/src/spine/post/reco/ppn.py
@@ -1,5 +1,10 @@
 """PPN point construction module."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
 import numpy as np
 from scipy.spatial.distance import cdist
 
@@ -39,16 +44,16 @@ class PPNProcessor(PostBase):
 
     def __init__(
         self,
-        assign_to_particles=False,
-        restrict_shape=False,
-        match_threshold=2.0,
-        **ppn_pred_cfg,
-    ):
+        assign_to_particles: bool = False,
+        restrict_shape: bool = False,
+        match_threshold: float = 2.0,
+        **ppn_pred_cfg: Any,
+    ) -> None:
         """Store the `get_ppn_predictions` keyword arguments.
 
         Parameters
         ----------
-        assign_to_particles: bool, default False
+        assign_to_particles : bool, default False
             If `True`, will assign PPN candidates to particle objects
         restrict_shape : bool, default False
             If `True`, only associate PPN candidates with compatible shape
@@ -57,10 +62,6 @@ class PPNProcessor(PostBase):
         **ppn_pred_cfg : dict, optional
             Keyword arguments to pass to the `PPNPredictor` class
 
-        Returns
-        -------
-        dict
-            Update result dictionary containing 'ppn_candidates' key
         """
         # Intialize the parent class
         obj_type = "particle" if assign_to_particles else None
@@ -72,7 +73,7 @@ class PPNProcessor(PostBase):
         self.match_threshold = match_threshold
         self.ppn_predictor = PPNPredictor(**ppn_pred_cfg)
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> dict[str, Any]:
         """Produce PPN candidates for one entry.
 
         Parameters
@@ -98,11 +99,11 @@ class PPNProcessor(PostBase):
                     valid_index = np.where(ppn_pred[:, PPN_SHAPE_COL] == part.shape)[0]
                     candidates = ppn_points[valid_index]
 
-                # Restrict to points that are susfficienly close
+                # Restrict to points that are sufficiently close
                 dists = np.min(cdist(candidates, part.points), axis=1)
                 dist_index = np.where(dists < self.match_threshold)[0]
 
-                # Compute and sotre points matches to this particle
+                # Compute and store point matches to this particle
                 matches = candidates[dist_index]
                 part.ppn_points = matches
                 if not self.restrict_shape:

--- a/src/spine/post/reco/shower.py
+++ b/src/spine/post/reco/shower.py
@@ -1,5 +1,10 @@
 """Shower reconstruction module."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
 import numpy as np
 
 from spine.constants import PION_PID, PROT_PID, SHOWR_SHP, TRACK_SHP
@@ -34,16 +39,16 @@ class ShowerParametricEnergyProcessor(PostBase):
 
     def __init__(
         self,
-        n_points=10000,
-        seed=12345,
-        sigma_floor=1.0,
-        energy_bounds=(1, 10000),
-        use_gp=False,
-        mode="module",
-        run_mode="reco",
-        truth_point_mode="points",
-        truth_dep_mode="depositions",
-    ):
+        n_points: int = 10000,
+        seed: int = 12345,
+        sigma_floor: float = 1.0,
+        energy_bounds: tuple[float, float] = (1.0, 10000.0),
+        use_gp: bool = False,
+        mode: str = "module",
+        run_mode: str = "reco",
+        truth_point_mode: str = "points",
+        truth_dep_mode: str = "depositions",
+    ) -> None:
         """Store the shower energy fitter parameters.
 
         Parameters
@@ -55,7 +60,7 @@ class ShowerParametricEnergyProcessor(PostBase):
             Random seed to use for sampling points in the shower model.
         sigma_floor : float, default 1.0
             Minimum value for the energy deposition uncertainty.
-        energy_bounds : Tuple[float, float], default=(1, 10000)
+        energy_bounds : tuple[float, float], default=(1, 10000)
             Lower and upper bounds on the fitted energy, in MeV.
         use_gp : bool, default False
             Whether to use the Grindhammer and Peters (2000) parametrization for the
@@ -87,7 +92,7 @@ class ShowerParametricEnergyProcessor(PostBase):
         else:
             self.boundaries = [tpc.boundaries for tpc in self.geo.tpc.chambers]
 
-        # Initialize the underlyign shower energy fitter
+        # Initialize the underlying shower energy fitter
         self.fitter = ShowerEnergyFitter(
             boundaries=self.boundaries,
             n_points=n_points,
@@ -100,7 +105,7 @@ class ShowerParametricEnergyProcessor(PostBase):
         # Store the energy bounds
         self.energy_bounds = energy_bounds
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Fit the energy of showers in one entry.
 
         Parameters
@@ -162,7 +167,9 @@ class ShowerConversionDistanceProcessor(PostBase):
     # List of recognized ways to compute the vertex-to-shower distance
     _modes = ("vertex_to_start", "vertex_to_points", "protons_to_points")
 
-    def __init__(self, mode="vertex_to_points", include_secondary=False):
+    def __init__(
+        self, mode: str = "vertex_to_points", include_secondary: bool = False
+    ) -> None:
         """Store the conversion distance reconstruction parameters.
 
         Parameters
@@ -176,7 +183,7 @@ class ShowerConversionDistanceProcessor(PostBase):
             - 'protons_to_points': Distance between any proton/pion point and
               any shower point.
         include_secondary : bool, default False
-            If `True`, computes the covnersion distance for secondary particles
+            If `True`, computes the conversion distance for secondary particles
         """
         # Initialize the parent class
         super().__init__("interaction", "reco")
@@ -195,7 +202,7 @@ class ShowerConversionDistanceProcessor(PostBase):
         if "vertex" in self.mode:
             self.update_upstream("vertex")
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Compute the conversion distance of showers in each interaction.
 
         Parameters
@@ -220,7 +227,7 @@ class ShowerConversionDistanceProcessor(PostBase):
                     dist = self.get_vertex_to_start(inter, part)
                 elif self.mode == "vertex_to_points":
                     dist = self.get_vertex_to_points(inter, part)
-                elif self.mode == "protons_to_start":
+                elif self.mode == "protons_to_points":
                     dist = self.get_protons_to_points(inter, part)
                 else:
                     raise ValueError(
@@ -231,7 +238,7 @@ class ShowerConversionDistanceProcessor(PostBase):
                 part.vertex_distance = dist
 
     @staticmethod
-    def get_vertex_to_start(inter, shower):
+    def get_vertex_to_start(inter: Any, shower: Any) -> float:
         """Helper function to compute the closest distance between the vertex
         and the predicted shower startpoint.
 
@@ -245,15 +252,15 @@ class ShowerConversionDistanceProcessor(PostBase):
         Returns
         -------
         float
-            Distance betweenthe vertex and the shower start point
+            Distance between the vertex and the shower start point
         """
         # Compute distance from the vertex to the shower start point
         dist = np.linalg.norm(inter.vertex - shower.start_point)
 
-        return dist
+        return float(dist)
 
     @staticmethod
-    def get_vertex_to_points(inter, shower):
+    def get_vertex_to_points(inter: Any, shower: Any) -> float:
         """Helper function to compute the closest distance between the vertex
         and all shower points.
 
@@ -272,10 +279,10 @@ class ShowerConversionDistanceProcessor(PostBase):
         # Compute distances from the vertex to all shower points, find minimum
         dists = cdist(inter.vertex.reshape(-1, 3), shower.points)
 
-        return dists.min()
+        return float(dists.min())
 
     @staticmethod
-    def get_protons_to_points(inter, shower):
+    def get_protons_to_points(inter: Any, shower: Any) -> float:
         """Helper function to compute the closest distance between any
         proton/pion point and any shower point.
 
@@ -305,14 +312,14 @@ class ShowerConversionDistanceProcessor(PostBase):
         proton_points = np.vstack(proton_points)
         dists = cdist(proton_points, shower.points)
 
-        return dists.min()
+        return float(dists.min())
 
 
 class ShowerStartMergeProcessor(PostBase):
     """Merge shower start if it was classified as track points.
 
     This post-processor is used to patch upstream semantic segmentation mistakes
-    where part of the shower trunk is assigned to track points and subsequantly
+    where part of the shower trunk is assigned to track points and subsequently
     classified as a separate particle.
     """
 
@@ -324,11 +331,11 @@ class ShowerStartMergeProcessor(PostBase):
 
     def __init__(
         self,
-        angle_threshold=0.175,
-        distance_threshold=1.0,
-        track_length_limit=50,
-        track_dedx_limit=None,
-    ):
+        angle_threshold: float = 0.175,
+        distance_threshold: float = 1.0,
+        track_length_limit: float = 50.0,
+        track_dedx_limit: float | None = None,
+    ) -> None:
         """Store the shower start merging parameters.
 
         Parameters
@@ -351,7 +358,7 @@ class ShowerStartMergeProcessor(PostBase):
         self.track_length_limit = track_length_limit
         self.track_dedx_limit = track_dedx_limit
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> dict[str, ObjectList]:
         """Merge split shower starts for all particles in one entry.
 
         Parameters
@@ -361,7 +368,7 @@ class ShowerStartMergeProcessor(PostBase):
 
         Returns
         -------
-        List[RecoParticle]
+        list[RecoParticle]
             Updated set of particles (interactions modified in place)
         """
         # Loop over the reco interactions
@@ -402,7 +409,7 @@ class ShowerStartMergeProcessor(PostBase):
 
         return {"reco_particles": particles}
 
-    def check_merge(self, shower, track):
+    def check_merge(self, shower: Any, track: Any) -> bool:
         """Check if a shower and a track can be merged.
 
         Parameters
@@ -455,7 +462,12 @@ class ShowerStartCorrectionProcessor(PostBase):
     # Set of post-processors which must be run before this one is
     _upstream = ("direction",)
 
-    def __init__(self, update_directions=True, radius=-1, optimize=True):
+    def __init__(
+        self,
+        update_directions: bool = True,
+        radius: float = -1.0,
+        optimize: bool = True,
+    ) -> None:
         """Store the shower start corrector parameters.
 
         Parameters
@@ -476,7 +488,7 @@ class ShowerStartCorrectionProcessor(PostBase):
         self.radius = radius
         self.optimize = optimize
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Update the shower start point using the closest point to the vertex.
 
         Parameters
@@ -508,7 +520,7 @@ class ShowerStartCorrectionProcessor(PostBase):
                 part.start_point = new_start
 
     @staticmethod
-    def correct_shower_start(inter, shower):
+    def correct_shower_start(inter: Any, shower: Any) -> np.ndarray:
         """Function to correct the shower start point by finding the closest
         point to any primary track in the image.
 
@@ -534,7 +546,7 @@ class ShowerStartCorrectionProcessor(PostBase):
         if len(track_points) == 0:
             return shower.start_point
 
-        # Update the shower start point by finding the consitituent point
+        # Update the shower start point by finding the constituent point
         # closest to any of the track points
         track_points = np.vstack(track_points)
         dists = np.min(cdist(shower.points, track_points), axis=1)

--- a/src/spine/post/reco/source.py
+++ b/src/spine/post/reco/source.py
@@ -1,8 +1,13 @@
 """Source assignment modules.
 
 This module implements routines to assign module/tpc sources when
-they are not explicitely provided.
+they are not explicitly provided.
 """
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
 
 import numpy as np
 
@@ -25,10 +30,10 @@ class SourceAssigner(PostBase):
 
     def __init__(
         self,
-        run_mode="reco",
-        truth_point_mode="points",
-    ):
-        """Initialize the source assigner"""
+        run_mode: str = "reco",
+        truth_point_mode: str = "points",
+    ) -> None:
+        """Initialize the source assigner."""
         # Initialize the parent class, store run mode
         super().__init__(run_mode=run_mode, truth_point_mode=truth_point_mode)
 
@@ -42,7 +47,7 @@ class SourceAssigner(PostBase):
         if run_mode != "reco":
             self.update_keys({self.truth_point_key: True})
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> dict[str, np.ndarray]:
         """Assign sources to the relevant depositions.
 
         Parameters
@@ -53,7 +58,7 @@ class SourceAssigner(PostBase):
         Returns
         -------
         dict
-            Dictionary which sources
+            Dictionary containing source assignment tensors
         """
         # Initialize output
         result = {}
@@ -68,7 +73,7 @@ class SourceAssigner(PostBase):
 
         return result
 
-    def get_closest(self, points):
+    def get_closest(self, points: np.ndarray) -> np.ndarray:
         """Assign sources to one set of points based on proximity.
 
         Parameters

--- a/src/spine/post/reco/topology.py
+++ b/src/spine/post/reco/topology.py
@@ -1,7 +1,11 @@
 """Particle topology module."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 import numpy as np
-from scipy.stats import pearsonr
 
 from spine.constants import ELEC_PID, PHOT_PID, SHOWR_SHP
 from spine.math.decomposition import PCA
@@ -31,12 +35,12 @@ class ParticleDEDXProcessor(PostBase):
 
     def __init__(
         self,
-        radius=3.0,
-        anchor=False,
-        mode="direction",
-        include_pids=(PHOT_PID, ELEC_PID),
-        include_secondary=False,
-    ):
+        radius: float = 3.0,
+        anchor: bool = False,
+        mode: str = "direction",
+        include_pids: Sequence[int] = (PHOT_PID, ELEC_PID),
+        include_secondary: bool = False,
+    ) -> None:
         """Store the particle start dE/dx reconstruction parameters.
 
         Parameters
@@ -48,7 +52,7 @@ class ParticleDEDXProcessor(PostBase):
             is irrelevant for reconstruction particles (always anchored)
         mode : str, default 'direction'
             Method to use for dE/dx calculation.
-        include_pids : list, default [0, 1]
+        include_pids : sequence[int], default [0, 1]
             Particle species to compute the start dE/dx for
         include_secondary : bool, default False
             If `True`, computes the start dE/dx for secondary particles
@@ -73,7 +77,7 @@ class ParticleDEDXProcessor(PostBase):
         if mode == "direction":
             self.update_upstream("direction")
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Compute the start dE/dx for all particles in one entry.
 
         Parameters
@@ -141,11 +145,11 @@ class ParticleStartStraightnessProcessor(PostBase):
 
     def __init__(
         self,
-        radius=3.0,
-        n_components=3,
-        include_pids=(PHOT_PID, ELEC_PID),
-        include_secondary=False,
-    ):
+        radius: float = 3.0,
+        n_components: int = 3,
+        include_pids: Sequence[int] = (PHOT_PID, ELEC_PID),
+        include_secondary: bool = False,
+    ) -> None:
         """Store the particle start straightness reconstruction parameters.
 
         Parameters
@@ -154,10 +158,10 @@ class ParticleStartStraightnessProcessor(PostBase):
             Radius around the start point to include in the straightness calculation.
         n_components : int, default 3
             Number of components to compute the PCA for
-        include_pids : list, default [0, 1]
-            Particle species to compute the start dE/dx for
+        include_pids : sequence[int], default [0, 1]
+            Particle species to compute the start straightness for
         include_secondary : bool, default False
-            If `True`, computes the start dE/dx for secondary particles
+            If `True`, computes the start straightness for secondary particles
         """
         # Initialize the parent class
         super().__init__("particle", "reco")
@@ -175,7 +179,7 @@ class ParticleStartStraightnessProcessor(PostBase):
         self.include_pids = include_pids
         self.include_secondary = include_secondary
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Compute the start straightness for all particles in one entry.
 
         Parameters
@@ -196,7 +200,7 @@ class ParticleStartStraightnessProcessor(PostBase):
             # Compute the particle start straightness
             part.start_straightness = self.get_start_straightness(part)
 
-    def get_start_straightness(self, particle):
+    def get_start_straightness(self, particle: Any) -> float:
         """Evaluates the straightness of the start of a particle by computing
         the PCA principal explained variance ratio.
 
@@ -245,12 +249,12 @@ class ParticleSpreadProcessor(PostBase):
 
     def __init__(
         self,
-        start_mode="vertex",
-        length_scale=14.0,
-        use_start_dir=False,
-        include_pids=(PHOT_PID, ELEC_PID),
-        include_secondary=False,
-    ):
+        start_mode: str = "vertex",
+        length_scale: float = 14.0,
+        use_start_dir: bool = False,
+        include_pids: Sequence[int] = (PHOT_PID, ELEC_PID),
+        include_secondary: bool = False,
+    ) -> None:
         """Store the particle spread reconstruction parameters.
 
         Parameters
@@ -263,10 +267,10 @@ class ParticleSpreadProcessor(PostBase):
         use_start_dir : bool, default False
             If `True`, use the direction estimate of the particle to compute
             the axial spread. If `False`, the direction is estimated using PCA
-        include_pids : list, default [0, 1]
-            Particle species to compute the start dE/dx for
+        include_pids : sequence[int], default [0, 1]
+            Particle species to compute the spread for
         include_secondary : bool, default False
-            If `True`, computes the start dE/dx for secondary particles
+            If `True`, computes the spread for secondary particles
         """
         # Initialize the parent class
         super().__init__("interaction", "reco")
@@ -288,7 +292,7 @@ class ParticleSpreadProcessor(PostBase):
         if not use_start_dir:
             self.pca = PCA(n_components=3)
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Compute the shower spread for all particles in one entry.
 
         Parameters
@@ -320,7 +324,7 @@ class ParticleSpreadProcessor(PostBase):
                     part.points, part.start_dir, ref_point
                 )
 
-    def get_dir_spread(self, points, ref_point):
+    def get_dir_spread(self, points: np.ndarray, ref_point: np.ndarray) -> float:
         """Compute the directional spread of the particle by computing the mean
         direction and the weighted average cosine distance with respect to it.
 
@@ -355,7 +359,9 @@ class ParticleSpreadProcessor(PostBase):
 
         return spread
 
-    def get_axial_spread(self, points, start_dir, ref_point):
+    def get_axial_spread(
+        self, points: np.ndarray, start_dir: np.ndarray, ref_point: np.ndarray
+    ) -> float:
         """Compute the axial spread of a particle by evaluating the pearson R
         correlation coefficient between the distance of the particle points from
         the start point along the particle axis and the perpendicular distance
@@ -396,4 +402,10 @@ class ParticleSpreadProcessor(PostBase):
         )
         perps = np.linalg.norm(v, axis=1)
 
-        return pearsonr(dists, perps)[0]
+        dists_centered = dists - np.mean(dists)
+        perps_centered = perps - np.mean(perps)
+        denom = np.linalg.norm(dists_centered) * np.linalg.norm(perps_centered)
+        if denom == 0.0:
+            return np.nan
+
+        return float(np.dot(dists_centered, perps_centered) / denom)

--- a/src/spine/post/reco/tracking.py
+++ b/src/spine/post/reco/tracking.py
@@ -1,5 +1,10 @@
 """Tracking reconstruction modules."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 from spine.constants import KAON_PID, MUON_PID, PION_PID, PROT_PID, TRACK_SHP
 from spine.post.base import PostBase
 from spine.utils.energy_loss import csda_table_spline
@@ -21,15 +26,15 @@ class CSDAEnergyProcessor(PostBase):
 
     def __init__(
         self,
-        tracking_mode="step_next",
-        include_pids=(MUON_PID, PION_PID, PROT_PID, KAON_PID),
-        fill_per_pid=False,
-        obj_type="particle",
-        run_mode="both",
-        truth_point_mode="points",
-        pid_mode="pid",
-        **kwargs,
-    ):
+        tracking_mode: str = "step_next",
+        include_pids: Sequence[int] = (MUON_PID, PION_PID, PROT_PID, KAON_PID),
+        fill_per_pid: bool = False,
+        obj_type: str | Sequence[str] | None = "particle",
+        run_mode: str = "both",
+        truth_point_mode: str = "points",
+        pid_mode: str = "pid",
+        **kwargs: Any,
+    ) -> None:
         """Store the necessary attributes to do CSDA range-based estimation.
 
         Parameters
@@ -37,7 +42,7 @@ class CSDAEnergyProcessor(PostBase):
         tracking_mode : str, default 'step_next'
             Method used to compute the track length (one of 'displacement',
             'step', 'step_next', 'bin_pca' or 'spline')
-        include_pids : list, default [2, 3, 4, 5]
+        include_pids : sequence[int], default [2, 3, 4, 5]
             Particle species to compute the kinetic energy for
         fill_per_pid : bool, default False
             If `True`, compute the CSDA KE estimate under all PID assumptions
@@ -56,7 +61,7 @@ class CSDAEnergyProcessor(PostBase):
         self.tracking_mode = tracking_mode
         self.tracking_kwargs = kwargs
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Reconstruct the CSDA KE estimates for each particle in one entry.
 
         Parameters

--- a/src/spine/post/reco/vertex.py
+++ b/src/spine/post/reco/vertex.py
@@ -1,5 +1,10 @@
 """Interaction vertex reconstruction module."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 import numpy as np
 
 from spine.constants import SHOWR_SHP, TRACK_SHP
@@ -23,21 +28,21 @@ class VertexProcessor(PostBase):
 
     def __init__(
         self,
-        include_shapes=(SHOWR_SHP, TRACK_SHP),
-        use_primaries=True,
-        update_orientations=False,
-        update_primaries=False,
-        anchor_vertex=True,
-        touching_threshold=2.0,
-        angle_threshold=0.3,
-        run_mode="both",
-        truth_point_mode="points",
-    ):
+        include_shapes: Sequence[int] = (SHOWR_SHP, TRACK_SHP),
+        use_primaries: bool = True,
+        update_orientations: bool = False,
+        update_primaries: bool = False,
+        anchor_vertex: bool = True,
+        touching_threshold: float = 2.0,
+        angle_threshold: float = 0.3,
+        run_mode: str = "both",
+        truth_point_mode: str = "points",
+    ) -> None:
         """Initialize the vertex finder properties.
 
         Parameters
         ----------
-        include_shapes : List[int], default [0, 1]
+        include_shapes : sequence[int], default [0, 1]
             List of semantic classes to consider for vertex reconstruction
         use_primaries : bool, default True
             If true, only considers primary particles to reconstruct the vertex
@@ -47,7 +52,7 @@ class VertexProcessor(PostBase):
             Use the reconstructed vertex to update primaries
         anchor_vertex : bool, default True
             If true, anchor the candidate vertex to particle objects,
-            with the expection of interactions only composed of showers
+            with the exception of interactions only composed of showers
         touching_threshold : float, default 2.0
             Maximum distance for two track points to be considered touching (cm)
         angle_threshold : float, default 0.3 radians
@@ -66,7 +71,7 @@ class VertexProcessor(PostBase):
         self.touching_threshold = touching_threshold
         self.angle_threshold = angle_threshold
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Reconstruct the vertex position for each interaction in one entry.
 
         Parameters
@@ -79,13 +84,12 @@ class VertexProcessor(PostBase):
             for inter in data[k]:
                 self.reconstruct_vertex_single(inter)
 
-    def reconstruct_vertex_single(self, inter):
-        """Post-processor which reconstructs one vertex for each interaction
-        in the provided list.
+    def reconstruct_vertex_single(self, inter: Any) -> None:
+        """Reconstruct one vertex for an interaction.
 
         Parameters
         ----------
-        inter : List[RecoInteraction, TruthInteraction]
+        inter : RecoInteraction or TruthInteraction
             Reconstructed/truth interaction object
         """
         # Selected the set of particles to use as a basis for vertex prediction

--- a/src/spine/post/template.py
+++ b/src/spine/post/template.py
@@ -8,6 +8,10 @@ takes the output of the reconstruction and either
 
 # Add the imports specific to this module here
 # import ...
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 # Must import the post-processor base class
 from spine.post.base import PostBase
@@ -19,38 +23,47 @@ __all__ = ["TemplateProcessor"]
 
 
 class TemplateProcessor(PostBase):
-    """Description of what the post-processor is supposed to be doing."""
+    """Template post-processor showing the expected PostBase interface."""
 
     name = "template"  # Name used to call the post-processor in the config
 
-    def __init__(self, arg0, arg1, obj_type, run_mode):
+    def __init__(
+        self,
+        arg0: Any,
+        arg1: Any,
+        obj_type: str | Sequence[str] | None = None,
+        run_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Initialize the post-processor.
 
         Parameters
         ----------
-        arg0 : type
-            Description of arg0
-        arg1 : type
-            Description of arg1
-        obj_type : Union[str, List[str]]
+        arg0 : object
+            Example required argument
+        arg1 : object
+            Example required argument
+        obj_type : str or sequence[str], optional
             Types of objects needed in this post-processor (fragments,
             particles and/or interactions). This argument is shared between
             all post-processors. If None, does not load these objects.
         run_mode : str
             One of 'reco', 'truth' or 'both'. Determines what kind of object
             the post-processor has to run on.
+        **kwargs : dict, optional
+            Additional arguments to pass to :class:`PostBase`
         """
         # Initialize the parent class
-        super().__init__(obj_type, run_mode)
+        super().__init__(obj_type=obj_type, run_mode=run_mode, **kwargs)
 
         # Store parameter
         self.arg0 = arg0
         self.arg1 = arg1
 
         # Add additional required data products
-        self.keys["prod"] = True  # Means we must have 'prod' in the dictionary
+        self.update_keys({"prod": True})
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> dict[str, Any] | None:
         """Pass data products corresponding to one entry through the processor.
 
         Parameters
@@ -66,10 +79,10 @@ class TemplateProcessor(PostBase):
             # Loop over all objects of that type
             for obj in data[key]:
                 # Fetch points attributes
-                points = self.get_points(obj)
+                self.get_points(obj)
 
                 # Get another attribute
-                sources = obj.sources
+                obj.sources
 
                 # Do something...
 

--- a/src/spine/post/trigger/trigger.py
+++ b/src/spine/post/trigger/trigger.py
@@ -54,9 +54,10 @@ class TriggerProcessor(PostBase):
         # Store the parameters
         self.correct_flash_times = correct_flash_times
         if self.correct_flash_times:
-            assert flash_keys is not None and len(
-                flash_keys
-            ), "When correcting flash times, must provide the flash keys."
+            if flash_keys is None or len(flash_keys) == 0:
+                raise ValueError(
+                    "When correcting flash times, must provide the flash keys."
+                )
             self.flash_keys = flash_keys
             self.flash_time_corr_us = flash_time_corr_us
 
@@ -89,7 +90,7 @@ class TriggerProcessor(PostBase):
                 f"event {event_id} in the trigger file."
             )
 
-        trigger_info = trigger_info.to_dict(orient="records")[0]
+        trigger_info = trigger_info.iloc[0].to_dict()
 
         # Build trigger object
         trigger = Trigger(

--- a/src/spine/post/trigger/trigger.py
+++ b/src/spine/post/trigger/trigger.py
@@ -1,6 +1,10 @@
 """Trigger information parser post-processor module."""
 
+from __future__ import annotations
+
 import os
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 import pandas as pd
 
@@ -25,8 +29,12 @@ class TriggerProcessor(PostBase):
     _keys = (("run_info", True),)
 
     def __init__(
-        self, file_path, correct_flash_times=True, flash_keys=None, flash_time_corr_us=4
-    ):
+        self,
+        file_path: str,
+        correct_flash_times: bool = True,
+        flash_keys: Sequence[str] | None = None,
+        flash_time_corr_us: float = 4.0,
+    ) -> None:
         """Initialize the trigger information parser.
 
         Parameters
@@ -35,7 +43,7 @@ class TriggerProcessor(PostBase):
             Path to the csv file which contains the trigger information
         correct_flash_times : bool, default True
             If True, corrects the flash times using w.r.t. the trigger times
-        flash_keys : List[str], optional
+        flash_keys : sequence[str], optional
             When correcting flash times, provide the list of flash products
             to correct times for
         flash_time_corr_us : float, default 4
@@ -64,7 +72,7 @@ class TriggerProcessor(PostBase):
             # Add flash keys to the required data products
             self.update_keys({k: True for k in self.flash_keys})
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> dict[str, Trigger]:
         """Parse the trigger information of one entry.
 
         Parameters

--- a/src/spine/post/truth/label.py
+++ b/src/spine/post/truth/label.py
@@ -1,6 +1,10 @@
 """True particle children counting module."""
 
+from __future__ import annotations
+
 from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 import numpy as np
 
@@ -21,7 +25,9 @@ class ChildrenProcessor(PostBase):
     # Alternative allowed names of the post-processor
     aliases = ("count_children",)
 
-    def __init__(self, mode="shape", obj_type="particle"):
+    def __init__(
+        self, mode: str = "shape", obj_type: str | Sequence[str] | None = "particle"
+    ) -> None:
         """Initialize the children counting parameters.
 
         Parameters
@@ -45,7 +51,7 @@ class ChildrenProcessor(PostBase):
                 "one of 'shape' or 'pid'."
             )
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> None:
         """Count children of each true particle in one entry.
 
         Parameters

--- a/src/spine/post/truth/match.py
+++ b/src/spine/post/truth/match.py
@@ -1,6 +1,10 @@
 """Match objects and their label counterparts and vice versa."""
 
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from typing import Any
 
 import numba as nb
 import numpy as np
@@ -23,21 +27,21 @@ class MatchProcessor(PostBase):
 
     def __init__(
         self,
-        fragment=None,
-        particle=None,
-        interaction=None,
-        truth_point_mode="points",
-        **kwargs,
-    ):
-        """Initializes the matching post-processor.
+        fragment: bool | Mapping[str, Any] | None = None,
+        particle: bool | Mapping[str, Any] | None = None,
+        interaction: bool | Mapping[str, Any] | None = None,
+        truth_point_mode: str = "points",
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the matching post-processor.
 
         Parameters
         ----------
-        fragment: Union[bool, dict], optional
+        fragment : bool or dict, optional
             Matching flag or configuration for fragments
-        particle: Union[bool, dict], optional
+        particle : bool or dict, optional
             Matching flag or configuration for particles
-        interaction: Union[bool, dict], optional
+        interaction : bool or dict, optional
             Matching flag or configuration for interactions
         truth_point_mode : str, default 'points'
             Type of truth points to use to do the matching
@@ -73,10 +77,10 @@ class MatchProcessor(PostBase):
         ----------
         fn : function
             Function which computes overlaps between pairs of objects
-        match_mode : str, defualt 'both'
+        match_mode : str, default 'both'
             Matching mode. One of 'reco_to_truth', 'truth_to_reco' or 'both'
         overlap_mode : str, default 'iou'
-            Overlap estimatation method. One of 'count', 'iou', 'dice', 'chamfer'
+            Overlap estimation method. One of 'count', 'iou', 'dice', 'chamfer'
         min_overlap : float, default 0.
             Overlap value above which a pair is considered a match
         weight_overlap : bool, default False
@@ -91,7 +95,7 @@ class MatchProcessor(PostBase):
             back to recovering indexes from the coordinates and metadata
         """
 
-        fn: object = None
+        fn: Callable[..., np.ndarray] | None = None
         match_mode: str = "both"
         overlap_mode: str = "iou"
         min_overlap: float = 0.0
@@ -105,7 +109,7 @@ class MatchProcessor(PostBase):
         # Valid overlap modes
         _overlap_modes = ("count", "iou", "dice", "chamfer")
 
-        def __post_init__(self):
+        def __post_init__(self) -> None:
             """Check that the values provided are valid."""
             # Check match mode
             assert self.match_mode in self._match_modes, (
@@ -129,12 +133,12 @@ class MatchProcessor(PostBase):
             prefix = "overlap" if not self.weight_overlap else "overlap_weighted"
             self.fn = getattr(spine.utils.match, f"{prefix}_{self.overlap_mode}")
 
-    def process(self, data):
+    def process(self, data: Mapping[str, Any]) -> dict[str, Any]:
         """Match all the requested objects in one entry.
 
         Parameters
         ----------
-        data: dict
+        data : dict
             Dictionary of data products
         """
         # Loop over the matchers
@@ -170,14 +174,21 @@ class MatchProcessor(PostBase):
 
         return np.unique(index)
 
-    def process_single(self, reco_objs, truth_objs, matcher, name, meta=None):
+    def process_single(
+        self,
+        reco_objs: Sequence[Any],
+        truth_objs: Sequence[Any],
+        matcher: MatchProcessor.Matcher,
+        name: str,
+        meta: Any | None = None,
+    ) -> dict[str, Any]:
         """Match all the requested objects in a single category.
 
         Parameters
         ----------
-        reco_objs : List[object]
+        reco_objs : Sequence[object]
             List of reconstructed objects
-        truth_objs : List[object]
+        truth_objs : Sequence[object]
             List of truth objects
         matcher : MatchProcessor.Matcher
             Matching method and function
@@ -278,6 +289,7 @@ class MatchProcessor(PostBase):
 
         # Pass lists to the matching function to compute overlaps
         if len(reco_input) and len(truth_input):
+            assert matcher.fn is not None
             ovl_matrix = matcher.fn(reco_input, truth_input)
         else:
             ovl_matrix = np.empty((len(reco_input), len(truth_input)))
@@ -307,14 +319,19 @@ class MatchProcessor(PostBase):
         return result
 
     @staticmethod
-    def generate_matches(source_objs, target_objs, ovl_matrix, ovl_valid):
-        """Generate pairs for a srt of sources and targets.
+    def generate_matches(
+        source_objs: Sequence[Any],
+        target_objs: Sequence[Any],
+        ovl_matrix: np.ndarray,
+        ovl_valid: np.ndarray,
+    ) -> tuple[list[tuple[Any, Any | None]], list[float]]:
+        """Generate pairs for a set of sources and targets.
 
         Parameters
         ----------
-        source_objs : List[object]
+        source_objs : Sequence[object]
             (N) List of source objects
-        target_objs : List[object]
+        target_objs : Sequence[object]
             (M) List of truth objects
         ovl_matrix : np.ndarray
             (N, M) Matrix of overlap values
@@ -323,9 +340,9 @@ class MatchProcessor(PostBase):
 
         Returns
         -------
-        pairs : List[tuple]
+        pairs : list[tuple]
             (N) List of (source, target) matched pairs (best match only)
-        overlaps : List[float]
+        overlaps : list[float]
             (N) List of overlap between each source and the best matched target
         """
         # Build the matches based on the threshold

--- a/src/spine/utils/factory.py
+++ b/src/spine/utils/factory.py
@@ -210,6 +210,7 @@ def parse_module_config(
     name_key: str = "name",
     priority_key: str = "priority",
     sort_by_priority: bool = False,
+    priority_descending: bool = False,
     skip_none: bool = True,
 ) -> ParsedModules:
     """Parse an ordered mapping of module blocks.
@@ -246,6 +247,9 @@ def parse_module_config(
         If ``True``, modules with smaller priority values run first. Modules
         without a priority retain their relative order after prioritized
         modules.
+    priority_descending : bool, default False
+        If ``True`` and ``sort_by_priority`` is ``True``, modules with larger
+        priority values run first instead.
     skip_none : bool, default True
         If ``True``, skip entries explicitly set to ``None``.
 
@@ -271,13 +275,22 @@ def parse_module_config(
         parsed.append((index, label, name, priority, config))
 
     if sort_by_priority:
-        parsed.sort(
-            key=lambda item: (
-                item[3] is None,
-                item[3] if item[3] is not None else item[0],
-                item[0],
+        if priority_descending:
+            parsed.sort(
+                key=lambda item: (
+                    item[3] is None,
+                    -item[3] if item[3] is not None else item[0],
+                    item[0],
+                )
             )
-        )
+        else:
+            parsed.sort(
+                key=lambda item: (
+                    item[3] is None,
+                    item[3] if item[3] is not None else item[0],
+                    item[0],
+                )
+            )
 
     return OrderedDict(
         (label, {"name": name, "cfg": config, "priority": priority})
@@ -291,6 +304,7 @@ def instantiate_modules(
     name_key: str = "name",
     priority_key: str = "priority",
     sort_by_priority: bool = False,
+    priority_descending: bool = False,
     skip_none: bool = True,
     **kwargs: Any,
 ) -> OrderedDict[str, Any]:
@@ -308,6 +322,9 @@ def instantiate_modules(
         Configuration key which specifies optional execution priority.
     sort_by_priority : bool, default False
         If ``True``, modules with smaller priority values run first.
+    priority_descending : bool, default False
+        If ``True`` and ``sort_by_priority`` is ``True``, modules with larger
+        priority values run first instead.
     skip_none : bool, default True
         If ``True``, skip entries explicitly set to ``None``.
     **kwargs : dict
@@ -323,6 +340,7 @@ def instantiate_modules(
         name_key=name_key,
         priority_key=priority_key,
         sort_by_priority=sort_by_priority,
+        priority_descending=priority_descending,
         skip_none=skip_none,
     )
 

--- a/src/spine/utils/manager.py
+++ b/src/spine/utils/manager.py
@@ -1,0 +1,72 @@
+"""Shared manager utilities for configurable per-entry modules."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping
+from typing import Any, Generic, Protocol, TypeVar
+
+import numpy as np
+
+from spine.utils.stopwatch import StopwatchManager
+
+
+class ManagedModule(Protocol):
+    """Callable module which can process a batch or a single batch entry."""
+
+    def __call__(
+        self, data: dict[str, Any], entry: int | None = None
+    ) -> dict[str, Any] | None:
+        """Process input data and return products to merge into it."""
+
+
+ModuleT = TypeVar("ModuleT", bound=ManagedModule)
+
+
+class ModuleManager(Generic[ModuleT]):
+    """Base class for managers that run ordered modules on event data."""
+
+    modules: Mapping[str, ModuleT]
+    watch: StopwatchManager
+
+    def __call__(self, data: dict[str, Any]) -> None:
+        """Pass one batch of data through the managed modules.
+
+        Parameters
+        ----------
+        data : dict
+            Dictionary of data products. It is updated in place.
+        """
+        # Reset active stopwatches
+        self.watch.reset_if_active()
+
+        # Loop over the managed modules
+        single_entry = np.isscalar(data["index"])
+        for module_key, module in self.modules.items():
+            # Run the module on each entry
+            self.watch.start(module_key)
+            if single_entry:
+                num_entries = 1
+                result = module(data)
+
+            else:
+                num_entries = len(data["index"])
+                result = defaultdict(list)
+                for entry in range(num_entries):
+                    result_e = module(data, entry)
+                    if result_e is not None:
+                        for key, value in result_e.items():
+                            result[key].append(value)
+
+            self.watch.stop(module_key)
+
+            # Update the input dictionary
+            if result is not None:
+                for key, value in result.items():
+                    if not single_entry and len(value) != num_entries:
+                        raise ValueError(
+                            f"Module `{module_key}` returned {len(value)} values "
+                            f"for `{key}`, but the batch contains {num_entries} "
+                            "entries."
+                        )
+                    data[key] = value

--- a/test/test_ana/test_base.py
+++ b/test/test_ana/test_base.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import pytest
+
+import spine.ana.base as base_mod
+from spine.ana.base import AnaBase
+
+
+class DummyRunInfo:
+    def scalar_dict(self):
+        return {"run": 1}
+
+
+class DummyAna(AnaBase):
+    name = "dummy"
+
+    def process(self, data):
+        self.append("out", value=data["value"])
+        return {"updated": data["value"] + 1}
+
+
+class DummyWriter:
+    def __init__(self, file_name, append=False, overwrite=False, buffer_size=1):
+        self.file_name = file_name
+        self.append_file = append
+        self.overwrite_file = overwrite
+        self.buffer_size = buffer_size
+        self.rows = []
+        self.closed = False
+        self.flushed = False
+
+    def append(self, row):
+        self.rows.append(row)
+
+    def close(self):
+        self.closed = True
+
+    def flush(self):
+        self.flushed = True
+
+
+def test_ana_base_validates_configuration():
+    with pytest.raises(TypeError, match="obj_type"):
+        DummyAna(obj_type=1)
+
+    with pytest.raises(ValueError, match="run_mode"):
+        DummyAna(run_mode="bad")
+
+    with pytest.raises(ValueError, match="Object type"):
+        DummyAna(obj_type="bad")
+
+    with pytest.raises(ValueError, match="truth_point_mode"):
+        DummyAna(truth_point_mode="bad")
+
+    with pytest.raises(ValueError, match="incompatible"):
+        DummyAna(truth_point_mode="points_adapt", truth_dep_mode="depositions_g4")
+
+    with pytest.raises(ValueError, match="truth_dep_mode"):
+        DummyAna(truth_dep_mode="bad")
+
+    with pytest.raises(ValueError, match="non-empty"):
+        DummyAna().initialize_writer("")
+
+
+def test_ana_base_filters_entry_and_manages_writers(monkeypatch):
+    monkeypatch.setattr(base_mod, "CSVWriter", DummyWriter)
+    ana = DummyAna(log_dir="logs", prefix="prefix", append=True, overwrite=True)
+    ana.update_keys({"value": True})
+    ana.initialize_writer("out")
+
+    result = ana(
+        {
+            "index": [5],
+            "file_index": [2],
+            "run_info": [DummyRunInfo()],
+            "value": [9],
+        },
+        entry=0,
+    )
+    ana.flush_writers()
+    ana.close_writers()
+
+    writer = ana.writers["out"]
+    assert result == {"updated": 10}
+    assert writer.file_name == "logs/prefix_dummy_out.csv"
+    assert writer.rows == [{"index": 5, "file_index": 2, "run": 1, "value": 9}]
+    assert writer.flushed
+    assert writer.closed
+
+
+def test_ana_base_optional_base_fields_and_truth_accessors():
+    ana = DummyAna(truth_point_mode="points", truth_index_mode="custom_index")
+
+    class TruthObject:
+        is_truth = True
+        points = "truth_points"
+        custom_index = "truth_index"
+
+    base = ana.get_base_dict(
+        {
+            "index": 1,
+            "file_index": 2,
+            "file_entry_index": 3,
+            "run_info": DummyRunInfo(),
+        }
+    )
+
+    assert base == {"index": 1, "file_index": 2, "file_entry_index": 3, "run": 1}
+    assert ana.get_points(TruthObject()) == "truth_points"
+    assert ana.get_index(TruthObject()) == "truth_index"
+
+
+def test_ana_base_warns_without_run_info_and_reads_reco_index():
+    ana = DummyAna()
+
+    class RecoObject:
+        is_truth = False
+        index = [1, 2, 3]
+
+    with pytest.warns(UserWarning, match="run_info"):
+        base = ana.get_base_dict({"index": 1, "file_index": 2})
+
+    assert base == {"index": 1, "file_index": 2}
+    assert ana.get_index(RecoObject()) == [1, 2, 3]
+
+
+def test_ana_base_reports_missing_required_input():
+    ana = DummyAna()
+    ana.update_keys({"value": True})
+
+    with pytest.raises(KeyError, match="missing an essential"):
+        ana({"index": 0, "file_index": 0})

--- a/test/test_ana/test_cluster.py
+++ b/test/test_ana/test_cluster.py
@@ -5,7 +5,12 @@ import pytest
 
 from spine.ana.metric.cluster import ClusterAna
 from spine.constants import CLUST_COL, GROUP_COL, SHAPE_COL
-from spine.data.out import RecoParticle, TruthParticle
+from spine.data.out import (
+    RecoInteraction,
+    RecoParticle,
+    TruthInteraction,
+    TruthParticle,
+)
 
 
 def _run_particle_cluster_ana(monkeypatch, truth_index_mode="index_adapt"):
@@ -145,3 +150,32 @@ def test_cluster_ana_standalone_mode(monkeypatch):
             },
         )
     ]
+
+
+def test_cluster_ana_does_not_produce_per_shape_interaction_metrics(monkeypatch):
+    rows = []
+    monkeypatch.setattr(ClusterAna, "initialize_writer", lambda self, name: None)
+    monkeypatch.setattr(
+        ClusterAna, "append", lambda self, name, **kwargs: rows.append(kwargs)
+    )
+    ana = ClusterAna(
+        obj_type="interaction",
+        use_objects=True,
+        per_shape=True,
+        metrics=("ari",),
+        truth_index_mode="index",
+    )
+
+    ana.process(
+        {
+            "points": np.zeros((2, 3), dtype=np.float32),
+            "truth_interactions": [
+                TruthInteraction(index=np.array([0, 1], dtype=np.int32))
+            ],
+            "reco_interactions": [
+                RecoInteraction(index=np.array([0, 1], dtype=np.int32))
+            ],
+        }
+    )
+
+    assert rows == [{"num_points": 2, "num_truth": 1, "num_reco": 1, "ari": 1.0}]

--- a/test/test_ana/test_cluster.py
+++ b/test/test_ana/test_cluster.py
@@ -1,8 +1,10 @@
 """Tests for clustering analysis metrics."""
 
 import numpy as np
+import pytest
 
 from spine.ana.metric.cluster import ClusterAna
+from spine.constants import CLUST_COL, GROUP_COL, SHAPE_COL
 from spine.data.out import RecoParticle, TruthParticle
 
 
@@ -58,3 +60,88 @@ def test_cluster_ana_truth_index_mode_defaults_to_index_adapt(monkeypatch):
     row = _run_particle_cluster_ana(monkeypatch)
 
     assert row["ari"] != 1.0
+
+
+def test_cluster_ana_validates_configuration(monkeypatch):
+    monkeypatch.setattr(ClusterAna, "initialize_writer", lambda self, name: None)
+
+    with pytest.raises(ValueError, match="provide a list"):
+        ClusterAna(obj_type=None, per_object=True)
+
+    with pytest.raises(ValueError, match="target clustering label"):
+        ClusterAna(per_object=False)
+
+    with pytest.raises(ValueError, match="cannot.*use objects"):
+        ClusterAna(per_object=False, label_col="group", use_objects=True)
+
+
+def test_cluster_ana_raw_per_object_mode(monkeypatch):
+    rows = []
+    monkeypatch.setattr(ClusterAna, "initialize_writer", lambda self, name: None)
+    monkeypatch.setattr(
+        ClusterAna, "append", lambda self, name, **kwargs: rows.append((name, kwargs))
+    )
+    labels = np.zeros((4, 10), dtype=np.float32)
+    labels[:, CLUST_COL] = [0, 0, 1, 1]
+    labels[:, SHAPE_COL] = [0, 0, 1, 1]
+    ana = ClusterAna(
+        obj_type="fragment",
+        use_objects=False,
+        per_shape=True,
+        metrics=("ari",),
+    )
+
+    ana.process(
+        {
+            "clust_label_adapt": labels,
+            "fragment_clusts": [
+                np.array([0, 1], dtype=np.int32),
+                np.array([2, 3], dtype=np.int32),
+            ],
+            "fragment_shapes": [0, 1],
+        }
+    )
+
+    assert rows[0][0] == "fragment"
+    assert rows[0][1]["ari"] == 1.0
+    assert rows[0][1]["ari_0"] == 1.0
+    assert rows[0][1]["ari_1"] == 1.0
+
+
+def test_cluster_ana_standalone_mode(monkeypatch):
+    rows = []
+    monkeypatch.setattr(ClusterAna, "initialize_writer", lambda self, name: None)
+    monkeypatch.setattr(
+        ClusterAna, "append", lambda self, name, **kwargs: rows.append((name, kwargs))
+    )
+    labels = np.zeros((4, 10), dtype=np.float32)
+    labels[:, GROUP_COL] = [0, 0, 1, 1]
+    ana = ClusterAna(
+        per_object=False,
+        per_shape=False,
+        label_col="group",
+        metrics=("ari",),
+    )
+
+    ana.process(
+        {
+            "clust_label_adapt": labels,
+            "clusts": [
+                np.array([0, 1], dtype=np.int32),
+                np.array([2, 3], dtype=np.int32),
+            ],
+            "group_pred": [0, 1],
+        }
+    )
+
+    assert rows == [
+        (
+            "group",
+            {
+                "num_points": 4,
+                "num_truth": 2,
+                "num_reco": 2,
+                "ari": 1.0,
+            },
+        )
+    ]

--- a/test/test_ana/test_factories.py
+++ b/test/test_ana/test_factories.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import spine.ana.factories as factories
+
+
+class DummyAna:
+    name = "dummy"
+
+    def __init__(
+        self,
+        value=0,
+        overwrite=False,
+        log_dir=None,
+        prefix=None,
+        buffer_size=1,
+    ):
+        self.value = value
+        self.overwrite = overwrite
+        self.log_dir = log_dir
+        self.prefix = prefix
+        self.buffer_size = buffer_size
+
+
+def test_ana_script_factory_does_not_mutate_config(monkeypatch):
+    monkeypatch.setattr(factories, "ANA_DICT", {"dummy": DummyAna})
+    cfg = {"value": 3}
+
+    module = factories.ana_script_factory(
+        "dummy",
+        cfg,
+        overwrite=True,
+        log_dir="logs",
+        prefix="input",
+        buffer_size=8,
+    )
+
+    assert cfg == {"value": 3}
+    assert module.value == 3
+    assert module.overwrite is True
+    assert module.log_dir == "logs"
+    assert module.prefix == "input"
+    assert module.buffer_size == 8
+
+
+def test_ana_script_factory_omits_overwrite_when_unspecified(monkeypatch):
+    monkeypatch.setattr(factories, "ANA_DICT", {"dummy": DummyAna})
+
+    module = factories.ana_script_factory("dummy", {"value": 4})
+
+    assert module.value == 4
+    assert module.overwrite is False

--- a/test/test_ana/test_graph.py
+++ b/test/test_ana/test_graph.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import spine.ana.diag.graph as graph_mod
+from spine.ana.diag.graph import GraphEdgeLengthAna
+
+
+def test_graph_edge_length_ana_accepts_tuple_object_types(monkeypatch):
+    writers = []
+    monkeypatch.setattr(
+        GraphEdgeLengthAna, "initialize_writer", lambda self, name: writers.append(name)
+    )
+
+    ana = GraphEdgeLengthAna(obj_type=("particle", "interaction"))
+
+    assert ana.obj_type == ["particle", "interaction", "fragment"]
+    assert set(writers) == {
+        "truth_particles",
+        "truth_interactions",
+    }
+
+
+def test_graph_edge_length_ana_accepts_none_and_reco_modes(monkeypatch):
+    writers = []
+    monkeypatch.setattr(
+        GraphEdgeLengthAna, "initialize_writer", lambda self, name: writers.append(name)
+    )
+
+    empty = GraphEdgeLengthAna(obj_type=None)
+    reco = GraphEdgeLengthAna(obj_type="interaction", run_mode="reco")
+
+    assert empty.obj_type == []
+    assert reco.obj_type == ["interaction", "particle"]
+    assert "points" in reco.keys
+    assert writers == ["reco_particles", "reco_interactions"]
+
+
+def test_graph_edge_length_ana_validates_time_window(monkeypatch):
+    monkeypatch.setattr(
+        GraphEdgeLengthAna, "initialize_writer", lambda self, name: None
+    )
+
+    with pytest.raises(ValueError, match="two values"):
+        GraphEdgeLengthAna(time_window=(0.0, 1.0, 2.0))
+
+    with pytest.raises(ValueError, match="Cannot restrict timing"):
+        GraphEdgeLengthAna(time_window=(0.0, 1.0), run_mode="reco")
+
+
+class FakeConstituent:
+    def __init__(self, id, index, shape):
+        self.id = id
+        self.index = index
+        self.shape = shape
+
+
+class FakeGroup:
+    id = 10
+    is_truth = True
+    t = 5.0
+
+    def __init__(self, constituents):
+        self.fragments = constituents
+
+
+def test_graph_edge_length_ana_process_stores_distances(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        GraphEdgeLengthAna, "initialize_writer", lambda self, name: None
+    )
+    monkeypatch.setattr(
+        GraphEdgeLengthAna,
+        "append",
+        lambda self, name, **kwargs: rows.append((name, kwargs)),
+    )
+    monkeypatch.setattr(
+        graph_mod,
+        "inter_cluster_distance",
+        lambda points, indexes: np.array([[0.0, 3.0], [4.0, 0.0]]),
+    )
+    constituents = [
+        FakeConstituent(1, np.array([0]), 0),
+        FakeConstituent(2, np.array([1]), 1),
+    ]
+    ana = GraphEdgeLengthAna(obj_type="particle", time_window=(0.0, 10.0))
+
+    ana.process(
+        {
+            "truth_particles": [FakeGroup(constituents)],
+            "points_label": np.zeros((2, 3), dtype=np.float32),
+        }
+    )
+
+    assert rows == [
+        (
+            "truth_particles",
+            {
+                "id": 10,
+                "source_id": 1,
+                "sink_id": 2,
+                "source_shape": 0,
+                "sink_shape": 1,
+                "length": 3.0,
+            },
+        )
+    ]
+
+
+def test_graph_edge_length_ana_processes_particle_constituents(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        GraphEdgeLengthAna, "initialize_writer", lambda self, name: None
+    )
+    monkeypatch.setattr(
+        GraphEdgeLengthAna,
+        "append",
+        lambda self, name, **kwargs: rows.append((name, kwargs)),
+    )
+    monkeypatch.setattr(
+        graph_mod,
+        "inter_cluster_distance",
+        lambda points, indexes: np.array([[0.0, 2.0], [2.0, 0.0]]),
+    )
+
+    class InteractionGroup(FakeGroup):
+        def __init__(self, constituents):
+            self.particles = constituents
+
+    constituents = [
+        FakeConstituent(1, np.array([0]), 0),
+        FakeConstituent(2, np.array([1]), 1),
+    ]
+    ana = GraphEdgeLengthAna(obj_type="interaction")
+
+    ana.process(
+        {
+            "truth_particles": [],
+            "truth_interactions": [InteractionGroup(constituents)],
+            "points_label": np.zeros((2, 3), dtype=np.float32),
+        }
+    )
+
+    assert rows[0][1]["length"] == 2.0
+
+
+def test_graph_edge_length_ana_pairs_shape_indexes_with_offset(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        GraphEdgeLengthAna, "initialize_writer", lambda self, name: None
+    )
+    monkeypatch.setattr(
+        GraphEdgeLengthAna,
+        "append",
+        lambda self, name, **kwargs: rows.append(kwargs),
+    )
+    monkeypatch.setattr(
+        graph_mod,
+        "inter_cluster_distance",
+        lambda points, indexes: np.array(
+            [
+                [0.0, 9.0, 8.0, 7.0],
+                [9.0, 0.0, 6.0, 5.0],
+                [8.0, 6.0, 0.0, 4.0],
+                [7.0, 5.0, 4.0, 0.0],
+            ],
+            dtype=np.float32,
+        ),
+    )
+    constituents = [
+        FakeConstituent(1, np.array([0]), 0),
+        FakeConstituent(2, np.array([1]), 1),
+        FakeConstituent(3, np.array([2]), 1),
+        FakeConstituent(4, np.array([3]), 2),
+    ]
+    ana = GraphEdgeLengthAna(obj_type="particle")
+    group = FakeGroup(constituents)
+
+    ana.store_distances(
+        "truth_particles", np.zeros((4, 3), dtype=np.float32), group, constituents
+    )
+
+    shape_pairs = {(row["source_shape"], row["sink_shape"]) for row in rows}
+    assert (1, 2) in shape_pairs
+
+
+def test_graph_edge_length_ana_skips_out_of_time_groups(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        GraphEdgeLengthAna, "initialize_writer", lambda self, name: None
+    )
+    monkeypatch.setattr(
+        GraphEdgeLengthAna,
+        "append",
+        lambda self, name, **kwargs: rows.append(kwargs),
+    )
+    group = FakeGroup(
+        [FakeConstituent(1, np.array([0]), 0), FakeConstituent(2, np.array([1]), 1)]
+    )
+    group.t = 20.0
+    ana = GraphEdgeLengthAna(obj_type="particle", time_window=(0.0, 10.0))
+
+    ana.store_distances("truth_particles", np.zeros((2, 3)), group, group.fragments)
+
+    assert rows == []
+
+
+def test_graph_edge_length_ana_skips_single_constituent(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        GraphEdgeLengthAna,
+        "append",
+        lambda self, name, **kwargs: rows.append((name, kwargs)),
+    )
+    ana = GraphEdgeLengthAna(obj_type="particle")
+    group = FakeGroup([FakeConstituent(1, np.array([0]), 0)])
+
+    ana.store_distances("truth_particles", np.zeros((1, 3)), group, group.fragments)
+
+    assert rows == []

--- a/test/test_ana/test_manager.py
+++ b/test/test_ana/test_manager.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import pytest
+
+import spine.ana.manager as manager_mod
+from spine.ana.manager import AnaManager
+
+
+class FakeAnaModule:
+    def __init__(self, name, cfg, calls):
+        self.name = name
+        self.cfg = cfg
+        self.calls = calls
+        self.closed = False
+        self.flushed = False
+
+    def __call__(self, data, entry=None):
+        self.calls.append((self.name, entry))
+        if entry is None:
+            return {"value": data["index"] + self.cfg["offset"]}
+        return {"value": data["index"][entry] + self.cfg["offset"]}
+
+    def close_writers(self):
+        self.closed = True
+
+    def flush_writers(self):
+        self.flushed = True
+
+
+def test_ana_manager_parses_priority_names_and_keeps_config_clean(monkeypatch):
+    calls = []
+
+    def factory(name, cfg, overwrite, log_dir, prefix, buffer_size):
+        return FakeAnaModule(
+            name,
+            {
+                **cfg,
+                "overwrite": overwrite,
+                "log_dir": log_dir,
+                "prefix": prefix,
+                "buffer_size": buffer_size,
+            },
+            calls,
+        )
+
+    monkeypatch.setattr(manager_mod, "ana_script_factory", factory)
+    cfg = {
+        "low": {"name": "script", "priority": 1, "offset": 1},
+        "high": {"name": "script", "priority": 3, "offset": 2},
+        "overwrite": True,
+        "prefix_output": True,
+        "buffer_size": 4,
+    }
+
+    manager = AnaManager(cfg, log_dir="logs", prefix="input")
+
+    assert list(manager.modules) == ["high", "low"]
+    assert manager.modules["high"].cfg == {
+        "offset": 2,
+        "overwrite": True,
+        "log_dir": "logs",
+        "prefix": "input",
+        "buffer_size": 4,
+    }
+    assert cfg["high"]["priority"] == 3
+    assert cfg["high"]["name"] == "script"
+
+
+def test_ana_manager_runs_batches_and_writer_lifecycle(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        manager_mod,
+        "ana_script_factory",
+        lambda name, cfg, *args: FakeAnaModule(name, cfg, calls),
+    )
+    manager = AnaManager({"demo": {"offset": 10}})
+    data = {"index": [1, 2, 3]}
+
+    manager(data)
+    manager.flush()
+    manager.close()
+
+    assert data["value"] == [11, 12, 13]
+    assert calls == [("demo", 0), ("demo", 1), ("demo", 2)]
+    assert manager.modules["demo"].flushed
+    assert manager.modules["demo"].closed
+
+
+def test_ana_manager_validates_global_options():
+    with pytest.raises(TypeError, match="overwrite"):
+        AnaManager({"overwrite": "yes"})
+
+    with pytest.raises(TypeError, match="prefix_output"):
+        AnaManager({"prefix_output": 1})
+
+    with pytest.raises(TypeError, match="buffer_size"):
+        AnaManager({"buffer_size": 1.5})

--- a/test/test_ana/test_mcs.py
+++ b/test/test_ana/test_mcs.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import spine.ana.calib.mcs as mcs_mod
+from spine.ana.calib.mcs import MCSCalibAna
+from spine.constants import MUON_PID
+
+
+class FakeParticle:
+    is_truth = True
+    pid = MUON_PID
+    ke = 250.0
+    t = 5.0
+    start_point = np.zeros(3, dtype=np.float32)
+    points = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0]], dtype=np.float32
+    )
+
+
+@pytest.fixture(autouse=True)
+def _capture_writers(monkeypatch):
+    monkeypatch.setattr(MCSCalibAna, "initialize_writer", lambda self, name: None)
+
+
+def test_mcs_calib_ana_validates_configuration():
+    with pytest.raises(ValueError, match="Angular reconstruction method"):
+        MCSCalibAna(min_ke=100.0, segment_length=10.0, angle_method="bad")
+
+    with pytest.raises(ValueError, match="reconstructed objects"):
+        MCSCalibAna(
+            min_ke=100.0,
+            segment_length=10.0,
+            time_window=(0.0, 1.0),
+            run_mode="both",
+        )
+
+    with pytest.raises(ValueError, match="two scalars"):
+        MCSCalibAna(min_ke=100.0, segment_length=10.0, time_window=1.0)
+
+
+def test_mcs_calib_ana_process_writes_angle_rows(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        MCSCalibAna,
+        "append",
+        lambda self, name, **kwargs: rows.append((name, kwargs)),
+    )
+    monkeypatch.setattr(mcs_mod, "mcs_angles", lambda dirs, method: np.array([0.5]))
+    monkeypatch.setattr(
+        mcs_mod, "mcs_angles_proj", lambda dirs, method: np.array([[0.1, 0.2, 0.3]])
+    )
+
+    ana = MCSCalibAna(min_ke=100.0, segment_length=[10.0], time_window=(0.0, 10.0))
+    ana.get_track_segments = lambda points, length, start: (
+        [np.array([0, 1]), np.array([2])],
+        np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
+        np.array([2.0, 4.0]),
+    )
+
+    ana.process({"truth_particles": [FakeParticle()]})
+
+    assert rows == [
+        (
+            "truth_mcs_sl10.0",
+            {
+                "ke": 250.0,
+                "time": 5.0,
+                "dir_x": 0.5,
+                "dir_y": 0.5,
+                "dir_z": 0.0,
+                "angle_yz": 0.1,
+                "angle_xz": 0.2,
+                "angle_xy": 0.3,
+                "angle": 0.5,
+                "min_count": 1,
+                "distance": 3.0,
+            },
+        )
+    ]
+
+
+def test_mcs_calib_ana_skips_unusable_particles_and_empty_segments(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        MCSCalibAna,
+        "append",
+        lambda self, name, **kwargs: rows.append((name, kwargs)),
+    )
+    ana = MCSCalibAna(min_ke=100.0, segment_length=10.0, time_window=(0.0, 10.0))
+    ana.get_track_segments = lambda points, length, start: ([], np.empty((0, 3)), [])
+
+    low_ke = FakeParticle()
+    low_ke.ke = 50.0
+    out_of_time = FakeParticle()
+    out_of_time.t = 20.0
+    no_segments = FakeParticle()
+
+    ana.process({"truth_particles": [low_ke, out_of_time, no_segments]})
+
+    assert rows == []

--- a/test/test_ana/test_optical.py
+++ b/test/test_ana/test_optical.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from spine.ana.metric.optical import FlashMatchingAna
+
+
+class FakeInteraction:
+    def __init__(
+        self,
+        *,
+        is_truth: bool,
+        id: int,
+        t: float = 0.0,
+        nu_id: int = 1,
+        is_flash_matched: bool = True,
+    ):
+        self.is_truth = is_truth
+        self.id = id
+        self.size = 3
+        self.is_contained = True
+        self.topology = "1mu"
+        self.nu_id = nu_id
+        self.t = t
+        self.energy_init = 10.0
+        self.is_flash_matched = is_flash_matched
+        self.flash_ids = np.array([4], dtype=np.int32)
+        self.flash_times = np.array([1.0], dtype=np.float32)
+        self.flash_scores = np.array([0.5], dtype=np.float32)
+        self.flash_total_pe = 20.0
+        self.flash_hypo_pe = 18.0
+
+    def scalar_dict(self, attrs, lengths=None):
+        return {attr: getattr(self, attr) for attr in attrs}
+
+
+@pytest.fixture(autouse=True)
+def _disable_writers(monkeypatch):
+    monkeypatch.setattr(FlashMatchingAna, "initialize_writer", lambda self, name: None)
+
+
+def test_flash_matching_ana_validates_configuration():
+    with pytest.raises(ValueError, match="Invalid matching mode"):
+        FlashMatchingAna(match_mode="bad")
+
+    with pytest.raises(ValueError, match="two values"):
+        FlashMatchingAna(time_window=(0.0, 1.0, 2.0))
+
+
+def test_flash_matching_ana_process_writes_both_directions(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        FlashMatchingAna,
+        "append",
+        lambda self, name, **kwargs: rows.append((name, kwargs)),
+    )
+    reco = FakeInteraction(is_truth=False, id=1)
+    truth = FakeInteraction(is_truth=True, id=2, t=5.0)
+    ana = FlashMatchingAna(time_window=(0.0, 10.0), max_num_flashes=1)
+
+    ana.process(
+        {
+            "interaction_matches_r2t": [(reco, truth)],
+            "interaction_matches_r2t_overlap": [0.75],
+            "interaction_matches_t2r": [(truth, reco)],
+            "interaction_matches_t2r_overlap": [0.5],
+        }
+    )
+
+    assert [name for name, _ in rows] == ["reco", "truth"]
+    assert rows[0][1]["reco_id"] == 1
+    assert rows[0][1]["truth_id"] == 2
+    assert rows[0][1]["match_overlap"] == 0.75
+    assert rows[1][1]["match_overlap"] == 0.5
+
+
+def test_flash_matching_ana_filters_unmatched_or_out_of_time(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        FlashMatchingAna,
+        "append",
+        lambda self, name, **kwargs: rows.append((name, kwargs)),
+    )
+    reco = FakeInteraction(is_truth=False, id=1, is_flash_matched=False)
+    truth = FakeInteraction(is_truth=True, id=2, t=20.0)
+    ana = FlashMatchingAna(time_window=(0.0, 10.0))
+
+    ana.process(
+        {
+            "interaction_matches_r2t": [(reco, truth)],
+            "interaction_matches_r2t_overlap": [0.75],
+            "interaction_matches_t2r": [(truth, reco)],
+            "interaction_matches_t2r_overlap": [0.5],
+        }
+    )
+
+    assert rows == []
+
+
+def test_flash_matching_ana_filters_non_neutrino_truth(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        FlashMatchingAna,
+        "append",
+        lambda self, name, **kwargs: rows.append((name, kwargs)),
+    )
+    reco = FakeInteraction(is_truth=False, id=1)
+    truth = FakeInteraction(is_truth=True, id=2, nu_id=-1)
+    ana = FlashMatchingAna()
+
+    ana.process(
+        {
+            "interaction_matches_r2t": [],
+            "interaction_matches_r2t_overlap": [],
+            "interaction_matches_t2r": [(truth, reco)],
+            "interaction_matches_t2r_overlap": [0.5],
+        }
+    )
+
+    assert rows == []
+
+
+def test_flash_matching_ana_uses_default_object_for_missing_match(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        FlashMatchingAna,
+        "append",
+        lambda self, name, **kwargs: rows.append((name, kwargs)),
+    )
+    reco = FakeInteraction(is_truth=False, id=1)
+    ana = FlashMatchingAna(match_mode="reco_to_truth")
+
+    ana.process(
+        {
+            "interaction_matches_r2t": [(reco, None)],
+            "interaction_matches_r2t_overlap": [0.1],
+            "interaction_matches_t2r": [],
+            "interaction_matches_t2r_overlap": [],
+        }
+    )
+
+    assert rows[0][0] == "reco"
+    assert rows[0][1]["truth_id"] == -1
+    assert rows[0][1]["match_overlap"] == 0.1

--- a/test/test_ana/test_point.py
+++ b/test/test_ana/test_point.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from spine.ana.metric.point import PointProposalAna
+from spine.constants import (
+    COORD_COLS,
+    PPN_END_COLS,
+    PPN_LENDP_COL,
+    PPN_LTYPE_COL,
+    PPN_SHAPE_COL,
+)
+
+
+@pytest.fixture(autouse=True)
+def _disable_writers(monkeypatch):
+    monkeypatch.setattr(PointProposalAna, "initialize_writer", lambda self, name: None)
+
+
+def _point_tensor(num_rows: int) -> np.ndarray:
+    return np.zeros((num_rows, max(PPN_END_COLS) + 1), dtype=np.float32)
+
+
+def test_point_proposal_ana_processes_bidirectional_matches(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        PointProposalAna,
+        "append",
+        lambda self, name, **kwargs: rows.append((name, kwargs)),
+    )
+    labels = _point_tensor(2)
+    labels[:, COORD_COLS] = [[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]]
+    labels[:, PPN_LTYPE_COL] = [0, 1]
+    labels[:, PPN_LENDP_COL] = [0, 1]
+    preds = _point_tensor(1)
+    preds[:, COORD_COLS] = [[1.0, 0.0, 0.0]]
+    preds[:, PPN_SHAPE_COL] = [0]
+    preds[:, PPN_END_COLS] = [[0.1, 0.9]]
+    ana = PointProposalAna(num_classes=2, endpoints=True)
+
+    ana.process({"ppn_label": labels, "ppn_pred": preds})
+
+    names = [name for name, _ in rows]
+    assert names == ["truth_to_reco", "truth_to_reco", "reco_to_truth"]
+    assert rows[0][1]["dist"] == 1.0
+    assert rows[0][1]["closest_end"] == 1
+    assert rows[-1][1]["shape"] == 0
+
+
+def test_point_proposal_ana_records_dummy_when_target_is_empty(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        PointProposalAna,
+        "append",
+        lambda self, name, **kwargs: rows.append((name, kwargs)),
+    )
+    labels = _point_tensor(1)
+    labels[:, COORD_COLS] = [[0.0, 0.0, 0.0]]
+    labels[:, PPN_LTYPE_COL] = [1]
+    preds = _point_tensor(0)
+    ana = PointProposalAna(num_classes=2)
+
+    ana.process({"ppn_label": labels, "ppn_pred": preds})
+
+    assert rows == [
+        (
+            "truth_to_reco",
+            {
+                "dist": -1.0,
+                "shape": 1,
+                "closest_shape": -1,
+                "dist_0": -1.0,
+                "dist_1": -1.0,
+            },
+        )
+    ]
+
+
+def test_point_proposal_ana_records_endpoint_dummy_when_target_is_empty(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        PointProposalAna,
+        "append",
+        lambda self, name, **kwargs: rows.append((name, kwargs)),
+    )
+    labels = _point_tensor(1)
+    labels[:, COORD_COLS] = [[0.0, 0.0, 0.0]]
+    labels[:, PPN_LTYPE_COL] = [1]
+    labels[:, PPN_LENDP_COL] = [0]
+    preds = _point_tensor(0)
+    ana = PointProposalAna(num_classes=2, endpoints=True)
+
+    ana.process({"ppn_label": labels, "ppn_pred": preds})
+
+    assert rows[0][1]["end"] == 0
+    assert rows[0][1]["closest_end"] == -1

--- a/test/test_ana/test_save.py
+++ b/test/test_ana/test_save.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import pytest
+
+from spine.ana.script.save import SaveAna
+
+
+class FakeObject:
+    def __init__(self, id: int, value: float):
+        self.id = id
+        self.value = value
+
+    def scalar_dict(self, attrs=None, lengths=None):
+        keys = ("id", "value") if attrs is None else attrs
+        return {key: getattr(self, key) for key in keys}
+
+
+class FakeWriter:
+    def close(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _fake_writers(monkeypatch):
+    def initialize_writer(self, name):
+        self.writers[name] = FakeWriter()
+
+    monkeypatch.setattr(SaveAna, "initialize_writer", initialize_writer)
+
+
+def test_save_ana_validates_configuration():
+    with pytest.raises(ValueError, match="Invalid matching mode"):
+        SaveAna(obj_type="particle", match_mode="bad")
+
+    with pytest.raises(ValueError, match="run_mode.*both"):
+        SaveAna(obj_type="particle", run_mode="reco", match_mode="both")
+
+    with pytest.raises(ValueError, match="object types"):
+        SaveAna(obj_type=None, match_mode="both")
+
+    with pytest.raises(ValueError, match="not found"):
+        SaveAna(obj_type="particle", particle=["definitely_missing"])
+
+
+def test_save_ana_requires_at_least_one_writer(monkeypatch):
+    monkeypatch.setattr(SaveAna, "initialize_writer", lambda self, name: None)
+
+    with pytest.raises(ValueError, match="save something"):
+        SaveAna(obj_type="particle", run_mode="reco", match_mode=None)
+
+
+def test_save_ana_writes_objects_without_matches(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        SaveAna, "append", lambda self, name, **kwargs: rows.append((name, kwargs))
+    )
+    ana = SaveAna(
+        obj_type="particle",
+        particle=("id", "value"),
+        run_mode="reco",
+        match_mode=None,
+    )
+
+    ana.process({"reco_particles": [FakeObject(1, 3.0), FakeObject(2, 4.0)]})
+
+    assert rows == [
+        ("reco_particles", {"id": 1, "value": 3.0}),
+        ("reco_particles", {"id": 2, "value": 4.0}),
+    ]
+
+
+def test_save_ana_writes_matched_objects(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        SaveAna, "append", lambda self, name, **kwargs: rows.append((name, kwargs))
+    )
+    ana = SaveAna(obj_type="particle", particle=("id",), match_mode="both")
+    reco = FakeObject(1, 3.0)
+    truth = FakeObject(2, 4.0)
+
+    ana.process(
+        {
+            "particle_matches_r2t": [(reco, truth)],
+            "particle_matches_r2t_overlap": [0.8],
+            "particle_matches_t2r": [(truth, reco)],
+            "particle_matches_t2r_overlap": [0.6],
+        }
+    )
+
+    assert rows[0] == (
+        "reco_particles",
+        {
+            "reco_id": 1,
+            "truth_id": 2,
+            "match_overlap": 0.8,
+        },
+    )
+    assert rows[1][0] == "truth_particles"
+    assert rows[1][1]["match_overlap"] == 0.6
+
+
+def test_save_ana_uses_default_object_for_missing_match(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        SaveAna, "append", lambda self, name, **kwargs: rows.append((name, kwargs))
+    )
+    ana = SaveAna(obj_type="particle", particle=("id",), match_mode="reco_to_truth")
+    reco = FakeObject(1, 3.0)
+
+    ana.process(
+        {
+            "truth_particles": [],
+            "particle_matches_r2t": [(reco, None)],
+            "particle_matches_r2t_overlap": [0.2],
+        }
+    )
+
+    assert rows == [
+        (
+            "reco_particles",
+            {"reco_id": 1, "truth_id": -1, "match_overlap": 0.2},
+        )
+    ]

--- a/test/test_ana/test_segment.py
+++ b/test/test_ana/test_segment.py
@@ -60,7 +60,7 @@ def test_segment_ana_detailed_ghost_scores(monkeypatch):
     ana.process(
         {
             "seg_label": labels,
-            "segmentation": np.array([[3.0, 0.0, 0.0, 0.0, 0.0]] * 2),
+            "segmentation": np.array([[3.0, 0.0, 0.0, 0.0, 0.0]]),
             "ghost": np.array([[3.0, 0.0], [0.0, 3.0]]),
         }
     )

--- a/test/test_ana/test_segment.py
+++ b/test/test_ana/test_segment.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from spine.ana.metric.segment import SegmentAna
+from spine.constants import GHOST_SHP, SHAPE_COL
+
+
+class FakeObject:
+    def __init__(self, index, shape):
+        self.index = np.asarray(index, dtype=np.int32)
+        self.shape = shape
+
+
+@pytest.fixture(autouse=True)
+def _disable_writers(monkeypatch):
+    monkeypatch.setattr(SegmentAna, "initialize_writer", lambda self, name: None)
+
+
+def test_segment_ana_validates_configuration():
+    with pytest.raises(ValueError, match="both fragments and particles"):
+        SegmentAna(use_fragments=True, use_particles=True)
+
+    with pytest.raises(ValueError, match="detailed score"):
+        SegmentAna(use_fragments=True, summary=False)
+
+    with pytest.raises(ValueError, match="ghost metrics"):
+        SegmentAna(use_fragments=True, ghost=True)
+
+
+def test_segment_ana_writes_summary(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        SegmentAna, "append", lambda self, name, **kwargs: rows.append(kwargs)
+    )
+    ana = SegmentAna(summary=True, num_classes=2)
+    labels = np.zeros((3, 5), dtype=np.float32)
+    labels[:, SHAPE_COL] = [0, 1, 1]
+
+    ana.process(
+        {
+            "seg_label": labels,
+            "segmentation": np.array([[4.0, 0.0], [0.0, 3.0], [2.0, 0.0]]),
+        }
+    )
+
+    assert rows == [{"count_00": 1, "count_01": 1, "count_10": 0, "count_11": 1}]
+
+
+def test_segment_ana_detailed_ghost_scores(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        SegmentAna, "append", lambda self, name, **kwargs: rows.append(kwargs)
+    )
+    ana = SegmentAna(summary=False, ghost=True)
+    labels = np.zeros((2, 5), dtype=np.float32)
+    labels[:, SHAPE_COL] = [0, GHOST_SHP]
+
+    ana.process(
+        {
+            "seg_label": labels,
+            "segmentation": np.array([[3.0, 0.0, 0.0, 0.0, 0.0]] * 2),
+            "ghost": np.array([[3.0, 0.0], [0.0, 3.0]]),
+        }
+    )
+
+    assert len(rows) == 2
+    assert rows[0]["score_0"] > 0.0
+    assert rows[0][f"score_{GHOST_SHP}"] > 0.0
+
+
+def test_segment_ana_rebuilds_summary_from_objects(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        SegmentAna, "append", lambda self, name, **kwargs: rows.append(kwargs)
+    )
+    ana = SegmentAna(use_fragments=True, num_classes=2)
+
+    ana.process(
+        {
+            "points": np.zeros((3, 3)),
+            "truth_fragments": [FakeObject([0, 1], 0), FakeObject([2], 1)],
+            "reco_fragments": [FakeObject([0], 0), FakeObject([1, 2], 1)],
+        }
+    )
+
+    assert rows[0]["count_00"] == 1
+    assert rows[0]["count_10"] == 1
+    assert rows[0]["count_11"] == 1
+
+
+def test_segment_ana_rejects_empty_truth_object_index():
+    ana = SegmentAna(use_particles=True)
+
+    with pytest.raises(ValueError, match="index"):
+        ana.process(
+            {
+                "points": np.zeros((1, 3)),
+                "truth_particles": [FakeObject([], 0)],
+                "reco_particles": [],
+            }
+        )
+
+
+def test_segment_ana_rejects_missing_object_collection_state():
+    ana = SegmentAna(use_particles=True)
+    ana.object_collection = None
+
+    with pytest.raises(ValueError, match="Object collection"):
+        ana.process({"points": np.zeros((1, 3))})
+
+
+def test_segment_ana_rejects_missing_scores_for_detailed_object_mode():
+    ana = SegmentAna(use_particles=True)
+    ana.summary = False
+
+    with pytest.raises(ValueError, match="Segment scores"):
+        ana.process(
+            {
+                "points": np.zeros((1, 3)),
+                "truth_particles": [FakeObject([0], 0)],
+                "reco_particles": [FakeObject([0], 0)],
+            }
+        )

--- a/test/test_ana/test_shower.py
+++ b/test/test_ana/test_shower.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+from spine.ana.diag.shower import ShowerStartDEdxAna
+
+
+def test_shower_start_dedx_ana_process_is_not_implemented(monkeypatch):
+    monkeypatch.setattr(
+        ShowerStartDEdxAna, "initialize_writer", lambda self, name: None
+    )
+    ana = ShowerStartDEdxAna(radius=2.0)
+
+    with pytest.raises(NotImplementedError, match="not yet implemented"):
+        ana.process({})

--- a/test/test_ana/test_template.py
+++ b/test/test_ana/test_template.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import numpy as np
+
+from spine.ana.template import TemplateAna
+
+
+def test_template_ana_uses_current_base_constructor(monkeypatch):
+    writers = []
+    monkeypatch.setattr(
+        TemplateAna, "initialize_writer", lambda self, name: writers.append(name)
+    )
+
+    ana = TemplateAna("a", "b", obj_type="particle", run_mode="reco")
+
+    assert ana.arg0 == "a"
+    assert ana.arg1 == "b"
+    assert ana.obj_keys == ["reco_particles"]
+    assert writers == ["template"]
+    assert ana.keys["prod"] is True
+
+
+class FakeObject:
+    start_point = np.array([1.0, 2.0, 3.0])
+    end_point = np.array([4.0, 6.0, 8.0])
+
+
+def test_template_ana_process_writes_displacements(monkeypatch):
+    rows = []
+    monkeypatch.setattr(TemplateAna, "initialize_writer", lambda self, name: None)
+    monkeypatch.setattr(
+        TemplateAna, "append", lambda self, name, **kwargs: rows.append((name, kwargs))
+    )
+    ana = TemplateAna("a", "b", obj_type="particle", run_mode="reco")
+
+    ana.process({"prod": {"reco_particles": [FakeObject()]}})
+
+    assert rows == [("template", {"disp_x": 3.0, "disp_y": 4.0, "disp_z": 5.0})]

--- a/test/test_ana/test_track.py
+++ b/test/test_ana/test_track.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from spine.ana.diag.track import TrackCompletenessAna
+from spine.constants import MUON_PID, TRACK_SHP
+
+
+class FakeMeta:
+    size = np.array([1.0, 1.0, 1.0])
+
+
+class FakeParticle:
+    id = 7
+    shape = TRACK_SHP
+    pid = MUON_PID
+    start_point = np.array([0.0, 0.0, 0.0])
+    end_point = np.array([5.0, 0.0, 0.0])
+    points = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [4.0, 0.0, 0.0], [5.0, 0.0, 0.0]]
+    )
+    is_truth = False
+
+
+@pytest.fixture(autouse=True)
+def _disable_writers(monkeypatch):
+    monkeypatch.setattr(
+        TrackCompletenessAna, "initialize_writer", lambda self, name: None
+    )
+
+
+def test_track_completeness_ana_validates_configuration():
+    with pytest.raises(ValueError, match="two values"):
+        TrackCompletenessAna(time_window=(0.0, 1.0, 2.0), run_mode="truth")
+
+    with pytest.raises(ValueError, match="reconstructed particle"):
+        TrackCompletenessAna(time_window=(0.0, 1.0), run_mode="both")
+
+
+def test_track_completeness_ana_process_writes_gap_summary(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        TrackCompletenessAna,
+        "append",
+        lambda self, name, **kwargs: rows.append((name, kwargs)),
+    )
+    ana = TrackCompletenessAna(run_mode="reco", length_threshold=None)
+
+    ana.process({"meta": FakeMeta(), "reco_particles": [FakeParticle()]})
+
+    assert len(rows) == 1
+    name, row = rows[0]
+    assert name == "reco"
+    assert row["particle_id"] == 7
+    assert row["num_gaps"] == 1
+    assert row["gap_length"] > 0.0
+    assert row["gap_frac"] > 0.0
+
+
+def test_track_completeness_ana_skips_filtered_particles(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        TrackCompletenessAna,
+        "append",
+        lambda self, name, **kwargs: rows.append((name, kwargs)),
+    )
+    wrong_shape = FakeParticle()
+    wrong_shape.shape = 0
+    wrong_pid = FakeParticle()
+    wrong_pid.pid = 999
+    too_short = FakeParticle()
+    ana = TrackCompletenessAna(run_mode="reco", length_threshold=100.0)
+
+    ana.process(
+        {
+            "meta": FakeMeta(),
+            "reco_particles": [wrong_shape, wrong_pid, too_short],
+        }
+    )
+
+    assert rows == []
+
+
+def test_track_completeness_ana_skips_out_of_time_truth_particle(monkeypatch):
+    rows = []
+    monkeypatch.setattr(
+        TrackCompletenessAna,
+        "append",
+        lambda self, name, **kwargs: rows.append((name, kwargs)),
+    )
+
+    class TruthParticle(FakeParticle):
+        is_truth = True
+        t = 20.0
+
+    ana = TrackCompletenessAna(run_mode="truth", time_window=(0.0, 10.0))
+
+    ana.process({"meta": FakeMeta(), "truth_particles": [TruthParticle()]})
+
+    assert rows == []
+
+
+def test_track_completeness_static_helpers():
+    points = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [4.0, 0.0, 0.0], [5.0, 0.0, 0.0]]
+    )
+    labels = TrackCompletenessAna.cluster_track_chunks(
+        points, points[0], points[-1], pixel_size=1.0
+    )
+    gaps = TrackCompletenessAna.sequential_cluster_distances(points, labels, points[0])
+
+    assert labels.tolist() == [0, 0, 1, 1]
+    assert np.allclose(gaps, [3.0])
+
+
+def test_track_completeness_single_cluster_has_no_gaps():
+    labels = np.zeros(2, dtype=np.int32)
+    gaps = TrackCompletenessAna.sequential_cluster_distances(
+        np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+        labels,
+        np.zeros(3),
+    )
+
+    assert len(gaps) == 0
+
+
+def test_track_completeness_rejects_non_cubic_pixels(monkeypatch):
+    class BadMeta:
+        size = np.array([1.0, 2.0, 1.0])
+
+    ana = TrackCompletenessAna(run_mode="reco")
+
+    with pytest.raises(ValueError, match="Non-cubic"):
+        ana.process({"meta": BadMeta(), "reco_particles": []})

--- a/test/test_post/test_barycenter.py
+++ b/test/test_post/test_barycenter.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from spine.post.optical.barycenter import BarycenterFlashMatcher
+
+
+class FakeFlash:
+    def __init__(self, center, width, total_pe=10.0, time=0.0):
+        self.center = np.asarray(center, dtype=np.float32)
+        self.width = np.asarray(width, dtype=np.float32)
+        self.total_pe = total_pe
+        self.time = time
+
+
+class FakeInteraction:
+    def __init__(self, points, depositions=None):
+        self.points = np.asarray(points, dtype=np.float32)
+        self.depositions = (
+            np.ones(len(points), dtype=np.float32)
+            if depositions is None
+            else np.asarray(depositions, dtype=np.float32)
+        )
+        self.size = len(points)
+
+
+def test_barycenter_flash_matcher_validates_threshold_distance():
+    with pytest.raises(ValueError, match="match_distance"):
+        BarycenterFlashMatcher(match_method="threshold")
+
+
+def test_barycenter_flash_matcher_finds_best_match():
+    matcher = BarycenterFlashMatcher(match_method="best")
+    interaction = FakeInteraction([[0.0, 1.0, 1.0], [0.0, 1.2, 1.2]])
+    flash = FakeFlash([0.0, 1.1, 1.1], [0.0, 0.1, 0.1])
+
+    matches = matcher.get_matches([interaction], [flash])
+
+    assert matches[0][0] is interaction
+    assert matches[0][1] is flash
+    assert matches[0][2] == pytest.approx(0.0)

--- a/test/test_post/test_barycenter.py
+++ b/test/test_post/test_barycenter.py
@@ -26,6 +26,9 @@ class FakeInteraction:
 
 
 def test_barycenter_flash_matcher_validates_threshold_distance():
+    with pytest.raises(ValueError, match="not recognized"):
+        BarycenterFlashMatcher(match_method="closest")
+
     with pytest.raises(ValueError, match="match_distance"):
         BarycenterFlashMatcher(match_method="threshold")
 
@@ -40,3 +43,43 @@ def test_barycenter_flash_matcher_finds_best_match():
     assert matches[0][0] is interaction
     assert matches[0][1] is flash
     assert matches[0][2] == pytest.approx(0.0)
+
+
+def test_barycenter_flash_matcher_rejects_best_match_above_distance():
+    matcher = BarycenterFlashMatcher(match_method="best", match_distance=0.1)
+    interaction = FakeInteraction([[0.0, 1.0, 1.0]])
+    flash = FakeFlash([0.0, 10.0, 10.0], [0.0, 0.1, 0.1])
+
+    assert matcher.get_matches([interaction], [flash]) == []
+
+
+def test_barycenter_flash_matcher_filters_inputs():
+    matcher = BarycenterFlashMatcher(match_method="best", time_window=(0.0, 1.0))
+    interaction = FakeInteraction([[0.0, 1.0, 1.0]])
+    flash = FakeFlash([0.0, 1.0, 1.0], [0.0, 0.1, 0.1], time=2.0)
+
+    assert matcher.get_matches([interaction], [flash]) == []
+
+    matcher = BarycenterFlashMatcher(match_method="best", min_flash_pe=20.0)
+    assert matcher.get_matches([interaction], [flash]) == []
+
+    matcher = BarycenterFlashMatcher(match_method="best", min_inter_size=2)
+    assert matcher.get_matches([interaction], [flash]) == []
+
+
+def test_barycenter_flash_matcher_threshold_and_charge_weighting():
+    matcher = BarycenterFlashMatcher(
+        match_method="threshold",
+        match_distance=0.1,
+        charge_weighted=True,
+        first_flash_only=True,
+    )
+    interaction = FakeInteraction(
+        [[0.0, 1.0, 1.0], [0.0, 3.0, 3.0]], depositions=[1.0, 3.0]
+    )
+    flash = FakeFlash([0.0, 2.5, 2.5], [0.0, 0.1, 0.1])
+    ignored_flash = FakeFlash([0.0, 99.0, 99.0], [0.0, 0.1, 0.1])
+
+    matches = matcher.get_matches([interaction], [flash, ignored_flash])
+
+    assert matches == [(interaction, flash, pytest.approx(0.0))]

--- a/test/test_post/test_base.py
+++ b/test/test_post/test_base.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+
+from spine.post.base import PostBase
+
+
+class DummyPost(PostBase):
+    name = "dummy"
+
+    def process(self, data):
+        return {"updated": data["value"] + 1}
+
+
+def test_post_base_validates_configuration():
+    with pytest.raises(TypeError, match="obj_type"):
+        DummyPost(obj_type=1)
+
+    with pytest.raises(ValueError, match="run_mode"):
+        DummyPost(run_mode="bad")
+
+    with pytest.raises(ValueError, match="Object type"):
+        DummyPost(obj_type="bad")
+
+    with pytest.raises(ValueError, match="truth_point_mode"):
+        DummyPost(truth_point_mode="bad")
+
+    with pytest.raises(ValueError, match="incompatible"):
+        DummyPost(truth_point_mode="points_adapt", truth_dep_mode="depositions_g4")
+
+    with pytest.raises(ValueError, match="truth_dep_mode"):
+        DummyPost(truth_dep_mode="bad")
+
+    with pytest.raises(ValueError, match="pid_mode"):
+        DummyPost(pid_mode="bad")
+
+
+def test_post_base_filters_entry_and_reports_missing_required_input():
+    post = DummyPost()
+    post.update_keys({"value": True})
+
+    result = post({"value": [9]}, entry=0)
+
+    assert result == {"updated": 10}
+    with pytest.raises(KeyError, match="missing an essential"):
+        post({"index": 0})
+
+
+def test_post_base_object_keys_and_upstream():
+    post = DummyPost(obj_type=("particle", "interaction"), run_mode="reco")
+    post.update_upstream("source")
+
+    assert post.obj_keys == ["reco_particles", "reco_interactions"]
+    assert post._upstream == ("source",)
+
+
+def test_post_base_truth_accessors():
+    post = DummyPost(
+        truth_point_mode="points",
+        truth_dep_mode="depositions",
+        pid_mode="chi2_pid",
+    )
+
+    class TruthObject:
+        is_truth = True
+        points = "truth_points"
+        sources = "truth_sources"
+        depositions = "truth_depositions"
+        index = "truth_index"
+        pid = 2
+        units = "cm"
+
+    truth = TruthObject()
+
+    assert post.get_points(truth) == "truth_points"
+    assert post.get_sources(truth) == "truth_sources"
+    assert post.get_depositions(truth) == "truth_depositions"
+    assert post.get_index(truth) == "truth_index"
+    assert post.get_pid(truth) == 2
+    post.check_units(truth)
+
+
+def test_post_base_reco_accessors_and_units():
+    post = DummyPost(pid_mode="chi2_pid")
+
+    class RecoObject:
+        is_truth = False
+        points = "reco_points"
+        sources = "reco_sources"
+        depositions = "reco_depositions"
+        index = "reco_index"
+        chi2_pid = 3
+        units = "px"
+
+    reco = RecoObject()
+
+    assert post.get_points(reco) == "reco_points"
+    assert post.get_sources(reco) == "reco_sources"
+    assert post.get_depositions(reco) == "reco_depositions"
+    assert post.get_index(reco) == "reco_index"
+    assert post.get_pid(reco) == 3
+    with pytest.raises(ValueError, match="Coordinates"):
+        post.check_units(reco)

--- a/test/test_post/test_base.py
+++ b/test/test_post/test_base.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 
 from spine.post.base import PostBase
@@ -14,7 +16,7 @@ class DummyPost(PostBase):
 
 def test_post_base_validates_configuration():
     with pytest.raises(TypeError, match="obj_type"):
-        DummyPost(obj_type=1)
+        DummyPost(obj_type=cast(Any, 1))
 
     with pytest.raises(ValueError, match="run_mode"):
         DummyPost(run_mode="bad")

--- a/test/test_post/test_calo.py
+++ b/test/test_post/test_calo.py
@@ -57,6 +57,18 @@ class FakeCalibrationManager:
         return points, depositions + offset
 
 
+class FakePointCalibrationManager(FakeCalibrationManager):
+    def __init__(self, **cfg):
+        super().__init__(**cfg)
+        self.update_points = True
+
+    def __call__(self, points, depositions, sources=None, run_id=None, track=False):
+        _, calibrated_depositions = super().__call__(
+            points, depositions, sources, run_id, track
+        )
+        return points + np.array([2.0, 0.0, 0.0]), calibrated_depositions
+
+
 def test_calibration_processor_updates_particles_tensors_and_interactions(monkeypatch):
     monkeypatch.setattr(calo_mod, "CalibrationManager", FakeCalibrationManager)
     reco_particle = SimpleNamespace(
@@ -116,6 +128,38 @@ def test_calibration_processor_updates_particles_tensors_and_interactions(monkey
     assert calibrator.cfg == {"scale": 2.0}
     assert any(call["track"] for call in calibrator.calls)
     assert all(call["run_id"] == 7 for call in calibrator.calls)
+
+
+def test_calibration_processor_updates_truth_points_and_interactions(monkeypatch):
+    monkeypatch.setattr(calo_mod, "CalibrationManager", FakePointCalibrationManager)
+    particle = SimpleNamespace(
+        is_truth=True,
+        units="cm",
+        shape=0,
+        index=np.array([0], dtype=np.int64),
+        points=np.array([[1.0, 0.0, 0.0]], dtype=np.float32),
+        depositions_q=np.array([10.0], dtype=np.float32),
+        sources=np.array([[0, 0]], dtype=np.int64),
+    )
+    interaction = SimpleNamespace(
+        is_truth=True,
+        index=np.array([0, 1], dtype=np.int64),
+    )
+    data = {
+        "points_label": np.array([[1.0, 0.0, 0.0], [4.0, 0.0, 0.0]], dtype=np.float32),
+        "depositions_q_label": np.array([10.0, 20.0], dtype=np.float32),
+        "sources_label": np.array([[0, 0], [0, 0]], dtype=np.int64),
+        "truth_particles": [particle],
+        "truth_interactions": [interaction],
+    }
+    processor = CalibrationProcessor(run_mode="truth")
+
+    processor.process(data)
+
+    expected_points = np.array([[3.0, 0.0, 0.0], [6.0, 0.0, 0.0]], dtype=np.float32)
+    np.testing.assert_allclose(particle.points, expected_points[[0]])
+    np.testing.assert_allclose(interaction.points, expected_points)
+    np.testing.assert_allclose(data["points_label"], expected_points)
 
 
 def test_calibration_processor_skips_empty_particles(monkeypatch):

--- a/test/test_post/test_calo.py
+++ b/test/test_post/test_calo.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+
+from spine.constants import TRACK_SHP
+from spine.post.reco import calo as calo_mod
+from spine.post.reco.calo import CalibrationProcessor, CalorimetricEnergyProcessor
+
+
+def test_calorimetric_energy_processor_applies_scaling_and_shower_fudge():
+    track = SimpleNamespace(
+        is_truth=False,
+        shape=TRACK_SHP,
+        depositions=np.asarray([1.0, 2.0], dtype=np.float32),
+        calo_ke=-1.0,
+    )
+    shower = SimpleNamespace(
+        is_truth=False,
+        shape=0,
+        depositions=np.asarray([3.0], dtype=np.float32),
+        calo_ke=-1.0,
+    )
+    processor = CalorimetricEnergyProcessor(
+        scaling=cast(Any, "2.0"), shower_fudge=cast(Any, "3.0"), run_mode="reco"
+    )
+
+    processor.process({"reco_particles": [track, shower]})
+
+    assert track.calo_ke == 6.0
+    assert shower.calo_ke == 18.0
+
+
+class FakeCalibrationManager:
+    def __init__(self, **cfg):
+        self.cfg = cfg
+        self.calls = []
+
+    def __call__(self, points, depositions, sources=None, run_id=None, track=False):
+        self.calls.append(
+            {
+                "points": points,
+                "depositions": depositions,
+                "sources": sources,
+                "run_id": run_id,
+                "track": track,
+            }
+        )
+        offset = 10.0 if track else 1.0
+        return depositions + offset
+
+
+def test_calibration_processor_updates_particles_tensors_and_interactions(monkeypatch):
+    monkeypatch.setattr(calo_mod, "CalibrationManager", FakeCalibrationManager)
+    reco_particle = SimpleNamespace(
+        is_truth=False,
+        units="cm",
+        shape=TRACK_SHP,
+        index=np.array([0, 2], dtype=np.int64),
+        points=np.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]], dtype=np.float32),
+        depositions=np.array([1.0, 3.0], dtype=np.float32),
+        sources=np.array([[0, 0], [0, 0]], dtype=np.int64),
+    )
+    truth_particle = SimpleNamespace(
+        is_truth=True,
+        units="cm",
+        shape=0,
+        index=np.array([1], dtype=np.int64),
+        points=np.array([[1.0, 0.0, 0.0]], dtype=np.float32),
+        depositions_q=np.array([20.0], dtype=np.float32),
+        sources=np.array([[0, 1]], dtype=np.int64),
+    )
+    reco_interaction = SimpleNamespace(
+        is_truth=False, index=np.array([0, 1, 2, 3], dtype=np.int64)
+    )
+    truth_interaction = SimpleNamespace(
+        is_truth=True, index=np.array([0, 1, 2], dtype=np.int64)
+    )
+    data = {
+        "run_info": SimpleNamespace(run=7),
+        "points": np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]],
+            dtype=np.float32,
+        ),
+        "depositions": np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32),
+        "sources": np.array([[0, 0], [0, 0], [0, 0], [0, 0]], dtype=np.int64),
+        "points_label": np.array(
+            [[0.0, 1.0, 0.0], [1.0, 1.0, 0.0], [2.0, 1.0, 0.0]],
+            dtype=np.float32,
+        ),
+        "depositions_q_label": np.array([10.0, 20.0, 30.0], dtype=np.float32),
+        "sources_label": np.array([[0, 1], [0, 1], [0, 1]], dtype=np.int64),
+        "reco_particles": [reco_particle],
+        "truth_particles": [truth_particle],
+        "reco_interactions": [reco_interaction],
+        "truth_interactions": [truth_interaction],
+    }
+    processor = CalibrationProcessor(do_tracking=True, run_mode="both", scale=2.0)
+
+    processor.process(data)
+
+    calibrator = cast(FakeCalibrationManager, processor.calibrator)
+    np.testing.assert_allclose(reco_particle.depositions, [11.0, 13.0])
+    np.testing.assert_allclose(data["depositions"], [11.0, 3.0, 13.0, 5.0])
+    np.testing.assert_allclose(reco_interaction.depositions, [11.0, 3.0, 13.0, 5.0])
+    np.testing.assert_allclose(truth_particle.depositions_q, [21.0])
+    np.testing.assert_allclose(data["depositions_q_label"], [11.0, 21.0, 31.0])
+    np.testing.assert_allclose(truth_interaction.depositions_q, [11.0, 21.0, 31.0])
+    assert calibrator.cfg == {"scale": 2.0}
+    assert any(call["track"] for call in calibrator.calls)
+    assert all(call["run_id"] == 7 for call in calibrator.calls)
+
+
+def test_calibration_processor_skips_empty_particles(monkeypatch):
+    monkeypatch.setattr(calo_mod, "CalibrationManager", FakeCalibrationManager)
+    particle = SimpleNamespace(
+        is_truth=False,
+        units="cm",
+        shape=TRACK_SHP,
+        index=np.empty(0, dtype=np.int64),
+        points=np.empty((0, 3), dtype=np.float32),
+        depositions=np.empty(0, dtype=np.float32),
+        sources=np.empty((0, 2), dtype=np.int64),
+    )
+    data = {
+        "points": np.empty((0, 3), dtype=np.float32),
+        "depositions": np.empty(0, dtype=np.float32),
+        "sources": np.empty((0, 2), dtype=np.int64),
+        "reco_particles": [particle],
+        "reco_interactions": [],
+    }
+    processor = CalibrationProcessor(run_mode="reco")
+
+    processor.process(data)
+
+    assert len(cast(FakeCalibrationManager, processor.calibrator).calls) == 1

--- a/test/test_post/test_calorimetric_direction.py
+++ b/test/test_post/test_calorimetric_direction.py
@@ -1,5 +1,7 @@
 """Tests for calorimetric interaction direction reconstruction."""
 
+from types import SimpleNamespace
+
 import numpy as np
 
 from spine.data.out import (
@@ -39,3 +41,61 @@ def test_calorimetric_direction_sets_reco_and_truth_direction_attributes():
     np.testing.assert_allclose(reco_inter.reco_dir, [1.0, 0.0, 0.0])
     np.testing.assert_allclose(truth_inter.dir, [0.0, 0.0, 1.0])
     np.testing.assert_allclose(truth_inter.reco_dir, [0.0, 1.0, 0.0])
+
+
+def test_calorimetric_direction_skips_degenerate_inputs():
+    processor = CalorimetricDirectionProcessor(run_mode="reco")
+    data = {
+        "points": np.zeros((1, 3), dtype=np.float32),
+        "depositions": np.ones(1, dtype=np.float32),
+    }
+
+    inter = SimpleNamespace(
+        is_truth=False,
+        vertex=None,
+        dir=None,
+        particles=[RecoParticle(index=np.array([0]))],
+    )
+    processor._reconstruct_direction(inter, data, "points")
+    assert inter.dir is None
+
+    inter = SimpleNamespace(
+        is_truth=False,
+        vertex=np.zeros(3),
+        dir=None,
+        particles=[],
+    )
+    processor._reconstruct_direction(inter, data, "points")
+    assert inter.dir is None
+
+    inter = SimpleNamespace(
+        is_truth=False,
+        vertex=np.zeros(3),
+        dir=None,
+        particles=[SimpleNamespace(size=0, index=np.empty(0, dtype=np.int64))],
+    )
+    processor._reconstruct_direction(inter, data, "points")
+    assert inter.dir is None
+
+    inter = SimpleNamespace(
+        is_truth=False,
+        vertex=np.zeros(3),
+        dir=None,
+        particles=[SimpleNamespace(size=1, index=np.empty(0, dtype=np.int64))],
+    )
+    processor._reconstruct_direction(inter, data, "points")
+    assert inter.dir is None
+
+    inter = SimpleNamespace(
+        is_truth=False,
+        vertex=np.zeros(3),
+        dir=None,
+        particles=[RecoParticle(index=np.array([0]))],
+    )
+    processor._reconstruct_direction(inter, data, "points")
+    assert inter.dir is None
+
+    data["points"] = np.array([[1.0, 0.0, 0.0]], dtype=np.float32)
+    data["depositions"] = np.zeros(1, dtype=np.float32)
+    processor._reconstruct_direction(inter, data, "points")
+    assert inter.dir is None

--- a/test/test_post/test_cathode_cross.py
+++ b/test/test_post/test_cathode_cross.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from spine.constants import TRACK_SHP
+from spine.post.reco import cathode_cross as cathode_mod
+
+
+class FakeChamber:
+    def __init__(self, drift_sign, boundaries):
+        self.drift_sign = drift_sign
+        self.drift_axis = 0
+        self.cathode_pos = 0.0
+        self.anode_pos = boundaries[0]
+        self.boundaries = np.asarray([boundaries, [-1.0, 1.0], [-1.0, 1.0]])
+
+
+class FakeModule:
+    drift_axis = 0
+    cathode_pos = 0.0
+
+    def __init__(self):
+        self.chambers = [FakeChamber(1, (-10.0, 0.0)), FakeChamber(-1, (0.0, 10.0))]
+
+    def __getitem__(self, idx):
+        return self.chambers[idx]
+
+
+class FakeTPC:
+    def __init__(self):
+        self.modules = [FakeModule()]
+
+    def __getitem__(self, idx):
+        return self.modules[idx]
+
+
+class FakeGeo:
+    def __init__(self):
+        self.tpc = FakeTPC()
+
+    def get_contributors(self, sources):
+        sources = np.asarray(sources, dtype=np.int64)
+        pairs = np.unique(sources, axis=0)
+        return pairs[:, 0], pairs[:, 1]
+
+    def get_volume_index(self, sources, module, tpc):
+        sources = np.asarray(sources, dtype=np.int64)
+        return np.where((sources[:, 0] == module) & (sources[:, 1] == tpc))[0]
+
+    def get_min_volume_offset(self, points, module, tpc):
+        return np.zeros(3, dtype=np.float32)
+
+
+def make_particle(
+    id=0,
+    interaction_id=0,
+    sources=((0, 0), (0, 0), (0, 1), (0, 1)),
+    points=((-2.0, 0.0, 0.0), (-1.0, 0.0, 0.0), (1.0, 0.0, 0.0), (2.0, 0.0, 0.0)),
+    shape=TRACK_SHP,
+    is_truth=False,
+):
+    points = np.asarray(points, dtype=np.float32)
+    particle = SimpleNamespace(
+        id=id,
+        interaction_id=interaction_id,
+        is_truth=is_truth,
+        units="cm",
+        shape=shape,
+        index=np.arange(len(points), dtype=np.int64),
+        points=points.copy(),
+        sources=np.asarray(sources, dtype=np.int64),
+        start_point=points[0].copy(),
+        end_point=points[-1].copy(),
+        start_dir=np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        end_dir=np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        is_cathode_crosser=False,
+        cathode_offset=0.0,
+    )
+
+    def reset_cathode_crosser():
+        particle.is_cathode_crosser = False
+        particle.cathode_offset = 0.0
+
+    def reset_match():
+        particle.is_matched = False
+
+    def merge(other):
+        particle.points = np.vstack([particle.points, other.points])
+        particle.sources = np.vstack([particle.sources, other.sources])
+        particle.index = np.arange(len(particle.points), dtype=np.int64)
+
+    particle.reset_cathode_crosser = reset_cathode_crosser
+    particle.reset_match = reset_match
+    particle.merge = merge
+    return particle
+
+
+def make_interaction(id=0):
+    inter = SimpleNamespace(
+        id=id,
+        is_cathode_crosser=False,
+        cathode_offset=0.0,
+        points=np.empty((0, 3), dtype=np.float32),
+    )
+
+    def reset_cathode_crosser():
+        inter.is_cathode_crosser = False
+        inter.cathode_offset = 0.0
+
+    def reset_match():
+        inter.is_matched = False
+
+    inter.reset_cathode_crosser = reset_cathode_crosser
+    inter.reset_match = reset_match
+    return inter
+
+
+@pytest.fixture(autouse=True)
+def patch_geo(monkeypatch):
+    monkeypatch.setattr(cathode_mod.GeoManager, "get_instance", lambda: FakeGeo())
+
+
+def test_cathode_crosser_processor_validates_adjust_method():
+    with pytest.raises(AssertionError, match="adjust cathode"):
+        cathode_mod.CathodeCrosserProcessor(1.0, 1.0, 1.0, adjust_method="bad")
+
+
+def test_cathode_crosser_processor_tags_offsets_and_adjusts_positions():
+    processor = cathode_mod.CathodeCrosserProcessor(1.0, 1.0, 1.0, merge_crossers=False)
+    particle = make_particle()
+    interaction = make_interaction()
+    data = {
+        "points": particle.points.copy(),
+        "reco_particles": [particle],
+        "reco_interactions": [interaction],
+    }
+
+    result = processor.process(data)
+
+    assert result["reco_particles"] == [particle]
+    assert particle.is_cathode_crosser is True
+    assert particle.cathode_offset == pytest.approx(1.0)
+    np.testing.assert_allclose(particle.points[:, 0], [-1.0, 0.0, 0.0, 1.0])
+    np.testing.assert_allclose(data["points"][:, 0], [-1.0, 0.0, 0.0, 1.0])
+    assert interaction.is_cathode_crosser is True
+    assert interaction.cathode_offset == pytest.approx(1.0)
+    np.testing.assert_allclose(interaction.points[:, 0], [-1.0, 0.0, 0.0, 1.0])
+
+
+def test_cathode_crosser_processor_process_branches(monkeypatch):
+    both = cathode_mod.CathodeCrosserProcessor(
+        1.0, 1.0, 1.0, merge_crossers=False, run_mode="both"
+    )
+    assert "points_label" in both.keys
+
+    processor = cathode_mod.CathodeCrosserProcessor(1.0, 1.0, 1.0, merge_crossers=False)
+    non_track = make_particle(shape=999)
+    single_tpc = make_particle(
+        sources=((0, 0), (0, 0)), points=((-1.0, 0, 0), (-0.5, 0, 0))
+    )
+    data = {
+        "points": np.vstack([non_track.points, single_tpc.points]),
+        "reco_particles": [non_track, single_tpc],
+        "reco_interactions": [make_interaction()],
+    }
+
+    processor.process(data)
+
+    assert non_track.is_cathode_crosser is False
+    assert single_tpc.is_cathode_crosser is False
+
+    merge_processor = cathode_mod.CathodeCrosserProcessor(
+        1.0, 1.0, 1.0, merge_crossers=True, adjust_crossers=False
+    )
+    merged = make_particle(
+        sources=((0, 0), (0, 0)), points=((-1.0, 0, 0), (-0.5, 0, 0))
+    )
+    monkeypatch.setattr(
+        merge_processor,
+        "find_matches",
+        lambda particles: (particles, [make_interaction()]),
+    )
+
+    merge_processor.process(
+        {
+            "points": merged.points.copy(),
+            "reco_particles": [merged],
+            "reco_interactions": [make_interaction()],
+        }
+    )
+
+    assert merged.is_matched is False
+
+    bad_direction = make_particle(
+        sources=((0, 0), (0, 0)), points=((-1.0, 0, 0), (-0.5, 0, 0))
+    )
+    bad_direction.start_dir[0] = -np.inf
+    with pytest.raises(AssertionError, match="direction"):
+        merge_processor.process(
+            {
+                "points": bad_direction.points.copy(),
+                "reco_particles": [bad_direction],
+                "reco_interactions": [make_interaction()],
+            }
+        )
+
+
+def test_cathode_crosser_processor_skips_empty_particles_and_requires_sources():
+    processor = cathode_mod.CathodeCrosserProcessor(1.0, 1.0, 1.0, merge_crossers=False)
+    interactions = [make_interaction()]
+    result = processor.process(
+        {
+            "points": np.empty((0, 3)),
+            "reco_particles": [],
+            "reco_interactions": interactions,
+        }
+    )
+    assert result["reco_particles"] == []
+    assert result["reco_interactions"] == interactions
+
+    particle = make_particle(sources=np.empty((0, 2), dtype=np.int64))
+    with pytest.raises(AssertionError, match="sources"):
+        processor.process(
+            {
+                "points": particle.points.copy(),
+                "reco_particles": [particle],
+                "reco_interactions": [make_interaction()],
+            }
+        )
+
+
+def test_cathode_crosser_processor_offset_helpers(monkeypatch):
+    points = np.array([[1.0, 1.0, 2.0], [2.0, 2.0, 4.0]], dtype=np.float32)
+    dirs = np.array([[1.0, 1.0, 0.0], [-1.0, -1.0, 0.0]], dtype=np.float32)
+    assert np.isfinite(
+        cathode_mod.CathodeCrosserProcessor.projection_offset(points, dirs)
+    )
+    assert np.isfinite(cathode_mod.CathodeCrosserProcessor.dot_offset(points, dirs))
+
+    with pytest.raises(AssertionError, match="projection method"):
+        cathode_mod.CathodeCrosserProcessor.projection_offset(
+            points, np.array([[0.0, 1.0, 0.0], [1.0, 0.0, 0.0]])
+        )
+
+    with pytest.raises(AssertionError, match="projection method"):
+        cathode_mod.CathodeCrosserProcessor.dot_offset(
+            points, np.array([[0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+        )
+
+    monkeypatch.setattr(
+        cathode_mod,
+        "cluster_direction",
+        lambda points, start: np.array([-1.0, 0.1, 0.0], dtype=np.float32),
+    )
+    processor = cathode_mod.CathodeCrosserProcessor(
+        1.0, 1.0, 1.0, merge_crossers=False, adjust_method="projection"
+    )
+    assert np.isfinite(processor.get_cathode_offset(make_particle()))
+
+    processor = cathode_mod.CathodeCrosserProcessor(
+        1.0, 1.0, 1.0, merge_crossers=False, adjust_method="dot"
+    )
+    assert np.isfinite(processor.get_cathode_offset(make_particle()))
+
+
+def test_cathode_crosser_processor_find_matches_skip_paths(monkeypatch):
+    class FakeRecoInteraction:
+        @classmethod
+        def from_particles(cls, particles):
+            return SimpleNamespace(
+                particles=particles,
+                particle_ids=np.array([p.id for p in particles], dtype=np.int64),
+            )
+
+    monkeypatch.setattr(cathode_mod, "RecoInteraction", FakeRecoInteraction)
+    processor = cathode_mod.CathodeCrosserProcessor(
+        crossing_point_tolerance=0.1,
+        offset_tolerance=0.1,
+        angle_tolerance=0.1,
+        merge_crossers=True,
+        adjust_crossers=False,
+    )
+    multi_tpc = make_particle(id=0)
+    same_tpc = make_particle(
+        id=1,
+        sources=((0, 0), (0, 0)),
+        points=((-1.0, 0.0, 0.0), (-0.5, 0.0, 0.0)),
+    )
+    same_tpc_other = make_particle(
+        id=2,
+        sources=((0, 0), (0, 0)),
+        points=((-0.2, 0.0, 0.0), (-0.1, 0.0, 0.0)),
+    )
+    far_tpc = make_particle(
+        id=3,
+        sources=((0, 1), (0, 1)),
+        points=((10.0, 10.0, 0.0), (11.0, 10.0, 0.0)),
+    )
+
+    particles, interactions = processor.find_matches(
+        [multi_tpc, same_tpc, same_tpc_other, far_tpc]
+    )
+
+    assert len(particles) == 4
+    assert all(not part.is_cathode_crosser for part in particles)
+    assert len(interactions) == 1
+
+
+def test_cathode_crosser_processor_merges_particles(monkeypatch):
+    class FakeRecoInteraction:
+        @classmethod
+        def from_particles(cls, particles):
+            return SimpleNamespace(
+                particles=particles,
+                particle_ids=np.array([p.id for p in particles], dtype=np.int64),
+            )
+
+    monkeypatch.setattr(cathode_mod, "RecoInteraction", FakeRecoInteraction)
+    processor = cathode_mod.CathodeCrosserProcessor(
+        crossing_point_tolerance=1.0,
+        offset_tolerance=3.0,
+        angle_tolerance=np.pi,
+        merge_crossers=True,
+        adjust_crossers=False,
+    )
+    left = make_particle(
+        id=0,
+        interaction_id=0,
+        sources=((0, 0), (0, 0)),
+        points=((-2.0, 0.0, 0.0), (-1.0, 0.0, 0.0)),
+    )
+    right = make_particle(
+        id=1,
+        interaction_id=1,
+        sources=((0, 1), (0, 1)),
+        points=((1.0, 0.0, 0.0), (2.0, 0.0, 0.0)),
+    )
+    right.start_dir = np.array([-1.0, 0.0, 0.0], dtype=np.float32)
+
+    particles, interactions = processor.find_matches([left, right])
+
+    assert len(particles) == 1
+    assert particles[0].is_cathode_crosser is True
+    assert particles[0].interaction_id == 0
+    assert len(interactions) == 1
+
+    left = make_particle(
+        id=0,
+        interaction_id=0,
+        sources=((0, 0), (0, 0)),
+        points=((-2.0, 0.0, 0.0), (-1.0, 0.0, 0.0)),
+    )
+    right = make_particle(
+        id=1,
+        interaction_id=1,
+        sources=((0, 1), (0, 1)),
+        points=((1.0, 0.0, 0.0), (2.0, 0.0, 0.0)),
+    )
+    right.start_dir = np.array([-1.0, 0.0, 0.0], dtype=np.float32)
+    particles, _ = processor.find_matches([left, right, make_particle(id=2)])
+    assert len(particles) == 2
+
+
+def test_cathode_crosser_processor_merge_particles_directly():
+    processor = cathode_mod.CathodeCrosserProcessor(1.0, 1.0, 1.0, merge_crossers=False)
+    first = make_particle(
+        id=0,
+        interaction_id=0,
+        sources=((0, 0), (0, 0)),
+        points=((-1.0, 0.0, 0.0), (-0.5, 0.0, 0.0)),
+    )
+    second = make_particle(
+        id=1,
+        interaction_id=1,
+        sources=((0, 1), (0, 1)),
+        points=((0.5, 0.0, 0.0), (1.0, 0.0, 0.0)),
+    )
+    sister = make_particle(
+        id=2,
+        interaction_id=1,
+        sources=((0, 1), (0, 1)),
+        points=((2.0, 0.0, 0.0), (3.0, 0.0, 0.0)),
+    )
+
+    particles = processor.merge_particles([first, second, sister], 0, 1)
+
+    assert len(particles) == 2
+    assert particles[0].is_cathode_crosser is True
+    assert [part.id for part in particles] == [0, 1]
+    assert particles[1].interaction_id == 0
+
+
+def test_cathode_crosser_processor_adjusts_sister_particles():
+    processor = cathode_mod.CathodeCrosserProcessor(1.0, 1.0, 1.0, merge_crossers=False)
+    crosser = make_particle(id=0, interaction_id=0)
+    sister = make_particle(
+        id=1,
+        interaction_id=0,
+        sources=((0, 0), (0, 0)),
+        points=((-3.0, 0.0, 0.0), (-2.0, 0.0, 0.0)),
+    )
+    interaction = make_interaction()
+    data = {
+        "points": np.vstack([crosser.points, sister.points]),
+        "reco_particles": [crosser, sister],
+        "reco_interactions": [interaction],
+    }
+    sister.index = np.array([4, 5], dtype=np.int64)
+
+    processor.adjust_positions(data, [crosser, sister], [interaction], 0, 1.0)
+
+    np.testing.assert_allclose(sister.points[:, 0], [-2.0, -1.0])
+    np.testing.assert_allclose(sister.start_point[0], -2.0)
+    np.testing.assert_allclose(sister.end_point[0], -1.0)

--- a/test/test_post/test_cluster.py
+++ b/test/test_post/test_cluster.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from spine.post.reco.cluster import TrackClusterer
+
+
+def test_track_clusterer_validates_configuration():
+    with pytest.raises(AssertionError):
+        TrackClusterer(split_volume="detector")
+
+    with pytest.raises(AssertionError):
+        TrackClusterer(particle_type="particle")
+
+
+def test_track_clusterer_processes_points_without_volume_split():
+    processor = TrackClusterer(eps=0.5, min_size=2, max_rel_spread=0.01)
+    points = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.1, 0.0, 0.0],
+            [10.0, 0.0, 0.0],
+            [10.1, 0.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+    depositions = np.arange(len(points), dtype=np.float32)
+
+    result = processor.process({"points": points, "depositions": depositions})
+
+    particles = result["reco_particles"]
+    assert len(particles) == 2
+    assert [part.size for part in particles] == [2, 2]
+    assert np.array_equal(particles[0].index, np.array([0, 1]))
+    assert np.array_equal(particles[1].index, np.array([2, 3]))
+
+
+def test_track_clusterer_processes_points_with_volume_split():
+    processor = TrackClusterer(
+        eps=0.5, min_size=2, max_rel_spread=0.01, split_volume="tpc"
+    )
+    points = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.1, 0.0, 0.0],
+            [10.0, 0.0, 0.0],
+            [10.1, 0.0, 0.0],
+            [20.0, 0.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+    depositions = np.arange(len(points), dtype=np.float32)
+    sources = np.array([[0, 0], [0, 0], [0, 1], [0, 1], [0, 2]], dtype=np.int64)
+
+    result = processor.process(
+        {"points": points, "depositions": depositions, "sources": sources}
+    )
+
+    particles = result["reco_particles"]
+    assert len(particles) == 2
+    assert np.array_equal(particles[0].sources, sources[[0, 1]])
+    assert np.array_equal(particles[1].sources, sources[[2, 3]])
+
+
+def test_track_clusterer_processes_points_with_module_split():
+    processor = TrackClusterer(
+        eps=0.5, min_size=2, max_rel_spread=0.01, split_volume="module"
+    )
+    points = np.array(
+        [[0.0, 0.0, 0.0], [0.1, 0.0, 0.0], [10.0, 0.0, 0.0]],
+        dtype=np.float32,
+    )
+    depositions = np.ones(len(points), dtype=np.float32)
+    sources = np.array([[0, 0], [0, 1], [1, 0]], dtype=np.int64)
+
+    result = processor.process(
+        {"points": points, "depositions": depositions, "sources": sources}
+    )
+
+    assert len(result["reco_particles"]) == 1
+
+
+def test_track_clusterer_process_volume_quality_cuts():
+    processor = TrackClusterer(eps=1.0, min_size=2, max_rel_spread=0.01)
+
+    assert processor.process_volume(np.array([[0.0, 0.0, 0.0]], dtype=np.float32)) == []
+
+    processor = TrackClusterer(
+        eps=2.0, min_size=2, max_rel_spread=1.0, max_axis_dist=0.01
+    )
+    points = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.5, 1.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+
+    assert processor.process_volume(points) == []
+
+    processor = TrackClusterer(eps=0.5, min_size=1, max_rel_spread=1.0)
+    processor.dbscan = cast(
+        Any,
+        SimpleNamespace(fit_predict=lambda points: np.full(len(points), -1)),
+    )
+    assert processor.process_volume(np.zeros((2, 3), dtype=np.float32)) == []
+
+    processor = TrackClusterer(eps=2.0, min_size=2, max_rel_spread=0.01)
+    points = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.5, 1.0, 0.0]],
+        dtype=np.float32,
+    )
+    assert processor.process_volume(points) == []

--- a/test/test_post/test_crt_match.py
+++ b/test/test_post/test_crt_match.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from spine.constants import SHOWR_SHP, TRACK_SHP
+from spine.post.crt import match as match_mod
+
+
+class FakeCRT:
+    def __init__(self, normal):
+        self.normal = np.asarray(normal, dtype=np.float32)
+
+    def get_plane(self, position, plane):
+        return self
+
+
+class FakeGeo:
+    def __init__(self, has_crt=True, multi_tpc=False, drift_sign=1):
+        self.crt = FakeCRT([1.0, 0.0, 0.0]) if has_crt else None
+        self.multi_tpc = multi_tpc
+        chamber = SimpleNamespace(
+            drift_sign=drift_sign,
+            drift_axis=0,
+            anode_pos=10.0,
+            cathode_pos=0.0,
+        )
+        self.tpc = [[chamber]]
+
+    def get_contributors(self, sources):
+        if self.multi_tpc and len(sources) > 1:
+            return np.array([0, 0]), np.array([0, 1])
+        return np.array([0]), np.array([0])
+
+
+def make_particle(**overrides):
+    data = {
+        "id": 0,
+        "shape": TRACK_SHP,
+        "size": 3,
+        "points": np.array(
+            [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0], [1.0, 0.0, 0.0]],
+            dtype=np.float32,
+        ),
+        "sources": np.array([[0, 0], [0, 0], [0, 0]], dtype=np.int64),
+        "start_point": np.array([0.0, 0.0, 0.0], dtype=np.float32),
+        "end_point": np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        "start_dir": np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        "end_dir": np.array([1.0, 0.0, 0.0], dtype=np.float32),
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+def test_crt_matcher_validates_configuration(monkeypatch):
+    monkeypatch.setattr(match_mod.GeoManager, "get_instance", lambda: FakeGeo())
+
+    with pytest.raises(ValueError, match="not recognized"):
+        match_mod.CRTMatcher(driftv=0.1, match_method="closest")
+
+    with pytest.raises(AssertionError, match="match_distance"):
+        match_mod.CRTMatcher(driftv=0.1, match_method="threshold")
+
+
+def test_crt_matcher_restricts_objects_and_line_plane_intercepts(monkeypatch):
+    monkeypatch.setattr(match_mod.GeoManager, "get_instance", lambda: FakeGeo())
+    matcher = match_mod.CRTMatcher(
+        driftv=0.1,
+        match_method="threshold",
+        match_distance=1.0,
+        time_window=(0.0, 10.0),
+        min_part_size=2,
+    )
+    track = make_particle(size=3)
+    small_track = make_particle(size=1)
+    shower = make_particle(shape=SHOWR_SHP)
+    early_hit = SimpleNamespace(time=-1.0)
+    good_hit = SimpleNamespace(time=1.0)
+
+    particles, hits = matcher.restrict_objects(
+        [track, small_track, shower], [early_hit, good_hit]
+    )
+
+    assert particles == [track]
+    assert hits == [good_hit]
+    assert np.array_equal(
+        matcher.line_plane_intercept(
+            np.zeros(3),
+            np.array([1.0, 0.0, 0.0]),
+            np.ones(3),
+            np.array([1.0, 0.0, 0.0]),
+        ),
+        np.array([1.0, 0.0, 0.0]),
+    )
+    assert np.all(
+        np.isneginf(
+            matcher.line_plane_intercept(
+                np.zeros(3),
+                np.array([0.0, 1.0, 0.0]),
+                np.ones(3),
+                np.array([1.0, 0.0, 0.0]),
+            )
+        )
+    )
+
+
+def test_crt_matcher_finds_matches(monkeypatch):
+    monkeypatch.setattr(match_mod.GeoManager, "get_instance", lambda: FakeGeo())
+    matcher = match_mod.CRTMatcher(
+        driftv=0.1, match_method="threshold", match_distance=0.1
+    )
+    particle = make_particle()
+    hit = SimpleNamespace(
+        id=0,
+        time=0.0,
+        center=np.array([2.0, 0.0, 0.0], dtype=np.float32),
+        position=np.array([2.0, 0.0, 0.0], dtype=np.float32),
+        plane=0,
+    )
+
+    matches = matcher.get_matches([particle], [hit])
+
+    assert matches[0][0] is particle
+    assert matches[0][1] is hit
+    assert matches[0][2] == pytest.approx(0.0)
+
+
+def test_crt_matcher_handles_negative_drift_sign(monkeypatch):
+    monkeypatch.setattr(
+        match_mod.GeoManager, "get_instance", lambda: FakeGeo(drift_sign=-1)
+    )
+    matcher = match_mod.CRTMatcher(
+        driftv=0.1, match_method="threshold", match_distance=0.1
+    )
+    particle = make_particle(
+        points=np.array(
+            [[1.0, 0.0, 0.0], [1.5, 0.0, 0.0], [2.0, 0.0, 0.0]],
+            dtype=np.float32,
+        ),
+        start_point=np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        end_point=np.array([2.0, 0.0, 0.0], dtype=np.float32),
+    )
+    hit = SimpleNamespace(
+        id=0,
+        time=0.0,
+        center=np.array([2.0, 0.0, 0.0], dtype=np.float32),
+        position=np.array([2.0, 0.0, 0.0], dtype=np.float32),
+        plane=0,
+    )
+
+    assert matcher.get_matches([particle], [hit]) == []
+
+
+def test_crt_matcher_handles_empty_and_invalid_geometry(monkeypatch):
+    monkeypatch.setattr(match_mod.GeoManager, "get_instance", lambda: FakeGeo())
+    matcher = match_mod.CRTMatcher(
+        driftv=0.1, match_method="threshold", match_distance=0.1
+    )
+    assert (
+        matcher.get_matches([make_particle(shape=SHOWR_SHP)], [SimpleNamespace()]) == []
+    )
+
+    monkeypatch.setattr(match_mod.GeoManager, "get_instance", lambda: FakeGeo(False))
+    matcher = match_mod.CRTMatcher(
+        driftv=0.1, match_method="threshold", match_distance=0.1
+    )
+    with pytest.raises(AssertionError, match="crt"):
+        matcher.get_matches([make_particle()], [SimpleNamespace()])
+
+
+def test_crt_matcher_handles_multi_tpc_particle(monkeypatch):
+    monkeypatch.setattr(
+        match_mod.GeoManager, "get_instance", lambda: FakeGeo(multi_tpc=True)
+    )
+    matcher = match_mod.CRTMatcher(
+        driftv=0.1, match_method="threshold", match_distance=0.1
+    )
+    particle = make_particle(sources=np.array([[0, 0], [0, 1], [0, 1]], dtype=np.int64))
+    hit = SimpleNamespace(
+        id=0,
+        time=0.0,
+        center=np.array([2.0, 0.0, 0.0], dtype=np.float32),
+        position=np.array([2.0, 0.0, 0.0], dtype=np.float32),
+        plane=0,
+    )
+
+    assert len(matcher.get_matches([particle], [hit])) == 1

--- a/test/test_post/test_crt_matching.py
+++ b/test/test_post/test_crt_matching.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import numpy as np
+
+from spine.post.crt import crt_matching as crt_matching_mod
+
+
+class FakeMatcher:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def get_matches(self, particles, crthits):
+        return [(particles[0], crthits[0], 0.25)]
+
+
+def make_particle():
+    particle = SimpleNamespace(
+        id=0,
+        units="cm",
+        is_crt_matched=True,
+        crt_ids=np.array([99], dtype=np.int32),
+        crt_times=np.array([99.0], dtype=np.float32),
+        crt_scores=np.array([99.0], dtype=np.float32),
+    )
+
+    def reset_crt_match():
+        particle.is_crt_matched = False
+        particle.crt_ids = np.empty(0, dtype=np.int32)
+        particle.crt_times = np.empty(0, dtype=np.float32)
+        particle.crt_scores = np.empty(0, dtype=np.float32)
+
+    particle.reset_crt_match = reset_crt_match
+    return particle
+
+
+def test_crt_match_processor_updates_particle_matches(monkeypatch):
+    monkeypatch.setattr(crt_matching_mod, "CRTMatcher", FakeMatcher)
+    processor = crt_matching_mod.CRTMatchProcessor("crthits", driftv=0.1)
+    particle = make_particle()
+    crthit = SimpleNamespace(id=5, time=12.0)
+
+    processor.process({"reco_particles": [particle], "crthits": [crthit]})
+
+    assert particle.is_crt_matched is True
+    assert np.array_equal(particle.crt_ids, np.array([5], dtype=np.int32))
+    assert np.array_equal(particle.crt_times, np.array([12.0], dtype=np.float32))
+    assert np.array_equal(particle.crt_scores, np.array([0.25], dtype=np.float32))
+    assert cast(FakeMatcher, processor.matcher).kwargs == {"driftv": 0.1}
+
+
+def test_crt_match_processor_skips_empty_inputs(monkeypatch):
+    monkeypatch.setattr(crt_matching_mod, "CRTMatcher", FakeMatcher)
+    processor = crt_matching_mod.CRTMatchProcessor("crthits", driftv=0.1)
+    particle = make_particle()
+
+    assert processor.process({"reco_particles": [particle], "crthits": []}) is None
+    assert particle.is_crt_matched is True
+
+    processor.process({"reco_particles": [], "crthits": [SimpleNamespace()]})

--- a/test/test_post/test_direction.py
+++ b/test/test_post/test_direction.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+import spine.post.reco.direction as direction_mod
+from spine.constants import TRACK_SHP
+from spine.post.reco.direction import DirectionProcessor
+
+
+def test_direction_processor_assigns_track_start_and_end_dirs(monkeypatch):
+    monkeypatch.setattr(
+        direction_mod,
+        "get_cluster_directions",
+        lambda points, ref_points, clusts, **kwargs: np.asarray(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32
+        ),
+    )
+    particle = SimpleNamespace(
+        id=0,
+        is_truth=False,
+        shape=TRACK_SHP,
+        index=np.asarray([0, 1], dtype=np.int32),
+        start_point=np.asarray([0.0, 0.0, 0.0], dtype=np.float32),
+        end_point=np.asarray([1.0, 0.0, 0.0], dtype=np.float32),
+        start_dir=np.zeros(3, dtype=np.float32),
+        end_dir=np.zeros(3, dtype=np.float32),
+    )
+    processor = DirectionProcessor(obj_type="particle", run_mode="reco")
+
+    processor.process(
+        {
+            "reco_particles": [particle],
+            "points": np.zeros((2, 3), dtype=np.float32),
+        }
+    )
+
+    assert np.allclose(particle.start_dir, [1.0, 0.0, 0.0])
+    assert np.allclose(particle.end_dir, [-0.0, -1.0, -0.0])
+
+
+def test_direction_processor_skips_empty_objects(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        direction_mod,
+        "get_cluster_directions",
+        lambda *args, **kwargs: calls.append(args),
+    )
+    particle = SimpleNamespace(
+        id=0,
+        is_truth=False,
+        shape=TRACK_SHP,
+        index=np.empty(0, dtype=np.int32),
+        start_point=np.zeros(3, dtype=np.float32),
+        end_point=np.ones(3, dtype=np.float32),
+    )
+    processor = DirectionProcessor(obj_type="particle", run_mode="reco")
+
+    processor.process(
+        {
+            "reco_particles": [particle],
+            "points": np.zeros((0, 3), dtype=np.float32),
+        }
+    )
+
+    assert calls == []
+
+
+def test_direction_processor_assigns_truth_reco_dirs(monkeypatch):
+    monkeypatch.setattr(
+        direction_mod,
+        "get_cluster_directions",
+        lambda points, ref_points, clusts, **kwargs: np.asarray(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32
+        ),
+    )
+    particle = SimpleNamespace(
+        id=0,
+        is_truth=True,
+        shape=TRACK_SHP,
+        index=np.asarray([0, 1], dtype=np.int32),
+        points=np.zeros((2, 3), dtype=np.float32),
+        start_point=np.asarray([0.0, 0.0, 0.0], dtype=np.float32),
+        end_point=np.asarray([1.0, 0.0, 0.0], dtype=np.float32),
+        reco_start_dir=np.zeros(3, dtype=np.float32),
+        reco_end_dir=np.zeros(3, dtype=np.float32),
+    )
+    processor = DirectionProcessor(obj_type="particle", run_mode="truth")
+
+    processor.process(
+        {
+            "truth_particles": [particle],
+            "points_label": np.zeros((2, 3), dtype=np.float32),
+        }
+    )
+
+    assert np.allclose(particle.reco_start_dir, [-1.0, -0.0, -0.0])
+    assert np.allclose(particle.reco_end_dir, [-0.0, -1.0, -0.0])
+
+
+def test_direction_processor_skips_shower_end_dir(monkeypatch):
+    monkeypatch.setattr(
+        direction_mod,
+        "get_cluster_directions",
+        lambda points, ref_points, clusts, **kwargs: np.asarray(
+            [[1.0, 0.0, 0.0]], dtype=np.float32
+        ),
+    )
+    particle = SimpleNamespace(
+        id=0,
+        is_truth=False,
+        shape=0,
+        index=np.asarray([0, 1], dtype=np.int32),
+        start_point=np.asarray([0.0, 0.0, 0.0], dtype=np.float32),
+        end_point=np.asarray([1.0, 0.0, 0.0], dtype=np.float32),
+        start_dir=np.zeros(3, dtype=np.float32),
+        end_dir=np.zeros(3, dtype=np.float32),
+    )
+    processor = DirectionProcessor(obj_type="particle", run_mode="reco")
+
+    processor.process(
+        {"reco_particles": [particle], "points": np.zeros((2, 3), dtype=np.float32)}
+    )
+
+    np.testing.assert_allclose(particle.start_dir, [1.0, 0.0, 0.0])
+    np.testing.assert_allclose(particle.end_dir, [0.0, 0.0, 0.0])

--- a/test/test_post/test_factories.py
+++ b/test/test_post/test_factories.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import spine.post.factories as factories
+
+
+class DummyPost:
+    name = "dummy"
+    provide_parent_path = True
+
+    def __init__(self, value=0, parent_path=None):
+        self.value = value
+        self.parent_path = parent_path
+
+
+def test_post_processor_factory_does_not_mutate_config(monkeypatch):
+    monkeypatch.setattr(factories, "POST_DICT", {"dummy": DummyPost})
+    cfg = {"value": 3}
+
+    module = factories.post_processor_factory("dummy", cfg, parent_path="config")
+
+    assert cfg == {"value": 3}
+    assert module.value == 3
+    assert module.parent_path == "config"

--- a/test/test_post/test_factories.py
+++ b/test/test_post/test_factories.py
@@ -12,6 +12,10 @@ class DummyPost:
         self.parent_path = parent_path
 
 
+class DummyPostNoParent(DummyPost):
+    provide_parent_path = False
+
+
 def test_post_processor_factory_does_not_mutate_config(monkeypatch):
     monkeypatch.setattr(factories, "POST_DICT", {"dummy": DummyPost})
     cfg = {"value": 3}
@@ -21,3 +25,14 @@ def test_post_processor_factory_does_not_mutate_config(monkeypatch):
     assert cfg == {"value": 3}
     assert module.value == 3
     assert module.parent_path == "config"
+
+
+def test_post_processor_factory_skips_parent_path(monkeypatch):
+    monkeypatch.setattr(factories, "POST_DICT", {"dummy": DummyPostNoParent})
+
+    module = factories.post_processor_factory(
+        "dummy", {"value": 4}, parent_path="config"
+    )
+
+    assert module.value == 4
+    assert module.parent_path is None

--- a/test/test_post/test_flash_matching.py
+++ b/test/test_post/test_flash_matching.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import pytest
+
+from spine.post.optical.flash_matching import FlashMatchProcessor
+
+
+def test_flash_match_processor_validates_volume():
+    with pytest.raises(ValueError, match="volume"):
+        FlashMatchProcessor(flash_key="flashes", volume="bad")

--- a/test/test_post/test_flash_matching.py
+++ b/test/test_post/test_flash_matching.py
@@ -1,10 +1,280 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
 import pytest
 
+from spine.post.optical import flash_matching as flash_matching_mod
 from spine.post.optical.flash_matching import FlashMatchProcessor
+
+
+class FakeTPC:
+    num_chambers_per_module = 2
+
+
+class FakeGeo:
+    name = "demo"
+    tpc = FakeTPC()
+
+    def get_volume_index(self, sources, *volume_ids):
+        sources = np.asarray(sources)
+        if len(volume_ids) == 1:
+            return np.where(sources[:, 0] == volume_ids[0])[0]
+        return np.where(
+            (sources[:, 0] == volume_ids[0]) & (sources[:, 1] == volume_ids[1])
+        )[0]
+
+    def translate(self, points, volume_id, ref_volume_id):
+        return points + float(ref_volume_id - volume_id)
+
+
+class FakeBarycenterMatcher:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.calls = []
+
+    def get_matches(self, interactions, flashes):
+        self.calls.append((interactions, flashes))
+        if not interactions or not flashes:
+            return []
+
+        if flashes[0].time == 10.0:
+            return [
+                (
+                    interactions[0],
+                    flashes[0],
+                    SimpleNamespace(hypothesis=[1.0, 2.0], score=0.75),
+                )
+            ]
+
+        return [(interactions[0], flashes[0], 0.5)]
+
+
+class FakeLikelihoodMatcher(FakeBarycenterMatcher):
+    def __init__(self, detector, parent_path=None, **kwargs):
+        super().__init__(detector=detector, parent_path=parent_path, **kwargs)
+
+
+class FakeMerger:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def __call__(self, flashes):
+        merged = [
+            SimpleNamespace(
+                id=0,
+                volume_id=flashes[0].volume_id,
+                time=10.0,
+                total_pe=sum(f.total_pe for f in flashes),
+            )
+        ]
+        return merged, np.asarray([[0, 1]], dtype=object)
+
+
+def make_interaction(
+    id=0,
+    sources=((0, 0), (0, 0)),
+    time_contained=True,
+    cathode_crosser=False,
+    cathode_offset=0.0,
+):
+    inter = SimpleNamespace(
+        id=id,
+        is_truth=False,
+        units="cm",
+        points=np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float32),
+        depositions=np.array([1.0, 2.0], dtype=np.float32),
+        sources=np.asarray(sources, dtype=np.int64),
+        is_time_contained=time_contained,
+        is_cathode_crosser=cathode_crosser,
+        cathode_offset=cathode_offset,
+        is_flash_matched=True,
+        flash_total_pe=99.0,
+        flash_hypo_pe=99.0,
+    )
+
+    def reset_flash_match():
+        inter.is_flash_matched = False
+        inter.flash_total_pe = 0.0
+        inter.flash_hypo_pe = 0.0
+        inter.flash_ids = np.empty(0, dtype=np.int32)
+        inter.flash_volume_ids = np.empty(0, dtype=np.int32)
+        inter.flash_times = np.empty(0, dtype=np.float32)
+        inter.flash_scores = np.empty(0, dtype=np.float32)
+
+    inter.reset_flash_match = reset_flash_match
+    return inter
+
+
+def make_flash(id=0, volume_id=0, time=1.0, total_pe=10.0):
+    return SimpleNamespace(id=id, volume_id=volume_id, time=time, total_pe=total_pe)
+
+
+@pytest.fixture(autouse=True)
+def patch_flash_matching(monkeypatch):
+    monkeypatch.setattr(
+        flash_matching_mod.GeoManager, "get_instance", lambda: FakeGeo()
+    )
+    monkeypatch.setattr(
+        flash_matching_mod, "BarycenterFlashMatcher", FakeBarycenterMatcher
+    )
+    monkeypatch.setattr(
+        flash_matching_mod, "LikelihoodFlashMatcher", FakeLikelihoodMatcher
+    )
+    monkeypatch.setattr(flash_matching_mod, "FlashMerger", FakeMerger)
 
 
 def test_flash_match_processor_validates_volume():
     with pytest.raises(ValueError, match="volume"):
         FlashMatchProcessor(flash_key="flashes", volume="bad")
+
+
+def test_flash_match_processor_validates_method_and_initializes_likelihood():
+    processor = FlashMatchProcessor(
+        flash_key="flashes",
+        volume="module",
+        method="likelihood",
+        parent_path="cfg",
+        foo="bar",
+    )
+
+    matcher = cast(FakeLikelihoodMatcher, processor.matcher)
+    assert matcher.kwargs == {"detector": "demo", "parent_path": "cfg", "foo": "bar"}
+
+    with pytest.raises(ValueError, match="method"):
+        FlashMatchProcessor(flash_key="flashes", volume="module", method="closest")
+
+
+def test_flash_match_processor_skips_empty_interactions():
+    processor = FlashMatchProcessor(
+        flash_key="flashes", volume="module", method="barycenter"
+    )
+
+    assert (
+        processor.process({"flashes": [make_flash()], "reco_interactions": []}) is None
+    )
+
+
+def test_flash_match_processor_matches_module_volume_with_scalar_score():
+    processor = FlashMatchProcessor(
+        flash_key="flashes", volume="module", method="barycenter"
+    )
+    inter = make_interaction()
+    flash = make_flash(id=4, volume_id=0, time=3.0, total_pe=12.0)
+
+    result = processor.process({"flashes": [flash], "reco_interactions": [inter]})
+
+    assert result is None
+    assert inter.is_flash_matched is True
+    assert inter.flash_total_pe == 12.0
+    assert inter.flash_hypo_pe == -1.0
+    assert np.array_equal(inter.flash_ids, np.array([4], dtype=np.int32))
+    assert np.array_equal(inter.flash_volume_ids, np.array([0], dtype=np.int32))
+    assert np.array_equal(inter.flash_times, np.array([3.0], dtype=np.float32))
+    assert np.array_equal(inter.flash_scores, np.array([0.5], dtype=np.float32))
+
+    processor.volume = "detector"
+    with pytest.raises(ValueError, match="Volume"):
+        processor.process({"flashes": [flash], "reco_interactions": [inter]})
+
+
+def test_flash_match_processor_filters_and_matches_tpc_volume_with_translation():
+    processor = FlashMatchProcessor(
+        flash_key="flashes",
+        volume="tpc",
+        ref_volume_id=3,
+        method="barycenter",
+        time_contained=True,
+        max_cathode_offset=2.0,
+    )
+    matched = make_interaction(sources=((0, 1), (0, 1)))
+    skipped_time = make_interaction(id=1, sources=((0, 1),), time_contained=False)
+    skipped_cathode = make_interaction(
+        id=2, sources=((0, 1),), cathode_crosser=True, cathode_offset=5.0
+    )
+    no_points = make_interaction(id=3, sources=((1, 0),))
+    flash = make_flash(id=1, volume_id=1)
+
+    processor.process(
+        {
+            "flashes": [flash],
+            "reco_interactions": [matched, skipped_time, skipped_cathode, no_points],
+        }
+    )
+
+    matcher = cast(FakeBarycenterMatcher, processor.matcher)
+    interactions_v, _ = matcher.calls[0]
+    np.testing.assert_allclose(interactions_v[0].points, matched.points + 2.0)
+    assert matched.is_flash_matched is True
+    assert skipped_time.is_flash_matched is False
+    assert skipped_cathode.is_flash_matched is False
+    assert no_points.is_flash_matched is False
+    assert "time_containment" in processor._upstream
+    assert "cathode_crosser" in processor._upstream
+
+
+def test_flash_match_processor_expands_merged_flashes_and_object_score():
+    processor = FlashMatchProcessor(
+        flash_key="flashes",
+        volume="module",
+        method="barycenter",
+        merge={"window": 1.0},
+    )
+    inter = make_interaction()
+    flashes = [
+        make_flash(id=0, volume_id=0, time=1.0, total_pe=10.0),
+        make_flash(id=1, volume_id=0, time=2.0, total_pe=5.0),
+    ]
+
+    processor.process({"flashes": flashes, "reco_interactions": [inter]})
+
+    assert inter.flash_total_pe == 15.0
+    assert inter.flash_hypo_pe == pytest.approx(3.0)
+    assert np.array_equal(inter.flash_ids, np.array([0, 1], dtype=np.int32))
+    assert np.array_equal(inter.flash_volume_ids, np.array([0, 0], dtype=np.int32))
+    assert np.array_equal(inter.flash_times, np.array([1.0, 2.0], dtype=np.float32))
+    assert np.array_equal(inter.flash_scores, np.array([0.75, 0.75], dtype=np.float32))
+
+
+def test_flash_match_processor_accumulates_multiple_matches():
+    class MultiMatch(FakeBarycenterMatcher):
+        def get_matches(self, interactions, flashes):
+            return [(interactions[0], flash, 0.5) for flash in flashes]
+
+    processor = FlashMatchProcessor(
+        flash_key="flashes", volume="module", method="barycenter"
+    )
+    processor.matcher = cast(Any, MultiMatch())
+    inter = make_interaction()
+    flashes = [
+        make_flash(id=0, volume_id=0, total_pe=10.0),
+        make_flash(id=1, volume_id=0, total_pe=5.0),
+    ]
+
+    processor.process({"flashes": flashes, "reco_interactions": [inter]})
+
+    assert inter.flash_total_pe == 15.0
+    assert inter.flash_hypo_pe == -2.0
+
+
+def test_flash_match_processor_returns_updated_flashes_when_requested():
+    processor = FlashMatchProcessor(
+        flash_key="flashes",
+        volume="module",
+        method="barycenter",
+        merge={"window": 1.0},
+        update_flashes=True,
+    )
+    inter = make_interaction()
+    flashes = [
+        make_flash(id=0, volume_id=0, total_pe=10.0),
+        make_flash(id=1, volume_id=0, total_pe=5.0),
+    ]
+
+    result = processor.process({"flashes": flashes, "reco_interactions": [inter]})
+
+    assert result is not None
+    assert len(result["flashes"]) == 1
+    assert inter.flash_ids.tolist() == [0]

--- a/test/test_post/test_geometry.py
+++ b/test/test_post/test_geometry.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from spine.post.reco import geometry as geometry_mod
+
+
+class FakeGeo:
+    def __init__(self):
+        self.definitions = []
+        self.checks = []
+
+    def define_containment_volumes(
+        self, margin, cathode_margin=None, mode="module", include_limits=True
+    ):
+        definition = {
+            "margin": margin,
+            "cathode_margin": cathode_margin,
+            "mode": mode,
+            "include_limits": include_limits,
+        }
+        self.definitions.append(definition)
+        return definition
+
+    def check_containment(
+        self, definition, points, sources=None, allow_multi_module=False
+    ):
+        self.checks.append(
+            {
+                "definition": definition,
+                "points": points,
+                "sources": sources,
+                "allow_multi_module": allow_multi_module,
+            }
+        )
+        return bool(np.all(points >= 0.0))
+
+
+def test_containment_processor_meta_mode_particles_and_interactions():
+    processor = geometry_mod.ContainmentProcessor(
+        margin=1.0,
+        mode="meta",
+        run_mode="reco",
+        obj_type=("particle", "interaction"),
+        exclude_pids=[4],
+        min_particle_sizes=cast(Any, {2: 5, "default": 0}),
+    )
+    contained = SimpleNamespace(
+        is_truth=False,
+        units="cm",
+        points=np.array([[2.0, 2.0, 2.0]], dtype=np.float32),
+        sources=np.empty((1, 2), dtype=np.int64),
+        pid=2,
+        size=10,
+        is_contained=False,
+    )
+    empty = SimpleNamespace(
+        is_truth=False,
+        units="cm",
+        points=np.empty((0, 3), dtype=np.float32),
+        sources=np.empty((0, 2), dtype=np.int64),
+        pid=2,
+        size=0,
+        is_contained=False,
+    )
+    outside_excluded = SimpleNamespace(pid=4, size=10, is_contained=False)
+    outside_small = SimpleNamespace(pid=2, size=1, is_contained=False)
+    outside_large = SimpleNamespace(pid=2, size=10, is_contained=False)
+    data = {
+        "meta": SimpleNamespace(
+            lower=np.zeros(3, dtype=np.float32),
+            upper=np.full(3, 10.0, dtype=np.float32),
+        ),
+        "reco_particles": [contained, empty],
+        "reco_interactions": [
+            SimpleNamespace(particles=[contained]),
+            SimpleNamespace(particles=[outside_excluded]),
+            SimpleNamespace(particles=[outside_small]),
+            SimpleNamespace(particles=[outside_large]),
+        ],
+    }
+
+    processor.process(data)
+
+    assert bool(contained.is_contained) is True
+    assert bool(empty.is_contained) is True
+    assert [inter.is_contained for inter in data["reco_interactions"]] == [
+        True,
+        True,
+        True,
+        False,
+    ]
+
+
+def test_containment_processor_uses_geometry_and_truth_g4(monkeypatch):
+    fake_geo = FakeGeo()
+    monkeypatch.setattr(geometry_mod.GeoManager, "get_instance", lambda: fake_geo)
+    processor = geometry_mod.ContainmentProcessor(
+        margin=1.0,
+        mode="module",
+        run_mode="truth",
+        obj_type="particle",
+        truth_point_mode="points_g4",
+        allow_multi_module=True,
+    )
+    particle = SimpleNamespace(
+        is_truth=True,
+        units="cm",
+        points_g4=np.array([[1.0, 1.0, 1.0]], dtype=np.float32),
+        sources_g4=np.array([[0, 0]], dtype=np.int64),
+    )
+
+    processor.process({"truth_particles": [particle]})
+
+    assert particle.is_contained is True
+    assert len(fake_geo.definitions) == 2
+    assert fake_geo.checks[0]["sources"] is None
+    assert fake_geo.checks[0]["allow_multi_module"] is True
+
+
+def test_containment_processor_uses_reco_geometry_sources(monkeypatch):
+    fake_geo = FakeGeo()
+    monkeypatch.setattr(geometry_mod.GeoManager, "get_instance", lambda: fake_geo)
+    processor = geometry_mod.ContainmentProcessor(
+        margin=1.0,
+        mode="module",
+        run_mode="reco",
+        obj_type="particle",
+        min_particle_sizes=cast(Any, {}),
+    )
+    particle = SimpleNamespace(
+        is_truth=False,
+        units="cm",
+        points=np.array([[1.0, 1.0, 1.0]], dtype=np.float32),
+        sources=np.array([[0, 0]], dtype=np.int64),
+    )
+
+    processor.process({"reco_particles": [particle]})
+
+    assert particle.is_contained is True
+    assert np.array_equal(fake_geo.checks[0]["sources"], particle.sources)
+    assert processor.min_particle_sizes[0] == 0
+
+
+def test_containment_processor_validates_logical_mode(monkeypatch):
+    monkeypatch.setattr(geometry_mod.GeoManager, "get_instance", lambda: FakeGeo())
+
+    with pytest.raises(AssertionError, match="logical containment"):
+        geometry_mod.ContainmentProcessor(margin=1.0, mode="module", logical=True)
+
+
+def test_fiducial_processor_meta_and_geometry_modes(monkeypatch):
+    meta_processor = geometry_mod.FiducialProcessor(
+        margin=1.0, mode="meta", run_mode="both", truth_vertex_mode="reco_vertex"
+    )
+    reco_inter = SimpleNamespace(
+        is_truth=False,
+        units="cm",
+        vertex=np.array([2.0, 2.0, 2.0], dtype=np.float32),
+    )
+    truth_inter = SimpleNamespace(
+        is_truth=True,
+        units="cm",
+        vertex=np.array([-1.0, -1.0, -1.0], dtype=np.float32),
+        reco_vertex=np.array([9.5, 2.0, 2.0], dtype=np.float32),
+    )
+
+    meta_processor.process(
+        {
+            "meta": SimpleNamespace(
+                lower=np.zeros(3, dtype=np.float32),
+                upper=np.full(3, 10.0, dtype=np.float32),
+            ),
+            "reco_interactions": [reco_inter],
+            "truth_interactions": [truth_inter],
+        }
+    )
+
+    assert bool(reco_inter.is_fiducial) is True
+    assert bool(truth_inter.is_fiducial) is False
+
+    fake_geo = FakeGeo()
+    monkeypatch.setattr(geometry_mod.GeoManager, "get_instance", lambda: fake_geo)
+    geo_processor = geometry_mod.FiducialProcessor(
+        margin=1.0, mode="module", run_mode="reco"
+    )
+    geo_processor.process({"reco_interactions": [reco_inter]})
+
+    assert reco_inter.is_fiducial is True
+    assert fake_geo.definitions[0]["include_limits"] is False
+
+
+def test_fiducial_processor_validates_truth_vertex_mode():
+    with pytest.raises(AssertionError, match="truth_vertex_mode"):
+        geometry_mod.FiducialProcessor(
+            margin=1.0, mode="meta", truth_vertex_mode="truth_start"
+        )

--- a/test/test_post/test_kinematics.py
+++ b/test/test_post/test_kinematics.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from spine.constants import (
+    ELEC_PID,
+    MICHL_SHP,
+    MUON_PID,
+    PHOT_PID,
+    PID_MASSES,
+    PION_PID,
+    SHOWR_SHP,
+    TRACK_SHP,
+)
+from spine.post.reco.kinematics import (
+    InteractionTopologyProcessor,
+    ParticleNeutrinoLogicProcessor,
+    ParticleShapeLogicProcessor,
+    ParticleThresholdProcessor,
+)
+
+
+def make_particle(**overrides):
+    data = {
+        "shape": SHOWR_SHP,
+        "pid": PHOT_PID,
+        "pid_scores": np.array([0.1, 0.6, 0.1, 0.1, 0.05, 0.05], dtype=np.float32),
+        "primary_scores": np.array([0.2, 0.8], dtype=np.float32),
+        "is_primary": True,
+        "ke": 0.0,
+        "size": 1,
+        "interaction_id": 0,
+        "is_valid": True,
+        "energy_deposit": 0.0,
+        "energy_init": 0.0,
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+def test_particle_shape_logic_enforces_pid_primary_and_michel_ke():
+    particle = make_particle(shape=MICHL_SHP, pid=ELEC_PID, ke=10.0)
+    processor = ParticleShapeLogicProcessor(maximum_michel_ke=5.0)
+
+    processor.process({"reco_particles": [particle]})
+
+    assert particle.shape == SHOWR_SHP
+    assert particle.pid == ELEC_PID
+    assert np.count_nonzero(particle.pid_scores[2:]) == 0
+    assert particle.is_primary is True
+
+
+def test_particle_threshold_updates_pid_and_primary():
+    shower = make_particle(
+        shape=SHOWR_SHP,
+        pid_scores=np.array([0.7, 0.3, 0.0, 0.0, 0.0, 0.0], dtype=np.float32),
+        primary_scores=np.array([0.6, 0.4], dtype=np.float32),
+    )
+    track = make_particle(
+        shape=TRACK_SHP,
+        pid_scores=np.array([0.0, 0.0, 0.2, 0.8, 0.0, 0.0], dtype=np.float32),
+        primary_scores=np.array([0.1, 0.9], dtype=np.float32),
+    )
+    processor = ParticleThresholdProcessor(
+        shower_pid_thresholds={PHOT_PID: 0.5},
+        track_pid_thresholds={PION_PID: 0.5},
+        primary_threshold=0.5,
+    )
+
+    processor.process({"reco_particles": [shower, track]})
+
+    assert shower.pid == PHOT_PID
+    assert shower.is_primary is False
+    assert track.pid == PION_PID
+    assert track.is_primary is True
+
+
+def test_particle_threshold_validates_configuration_and_complete_thresholds():
+    with pytest.raises(ValueError, match="Specify one"):
+        ParticleThresholdProcessor()
+
+    particle = make_particle(
+        shape=SHOWR_SHP,
+        pid_scores=np.array([0.4, 0.6, 0.0, 0.0, 0.0, 0.0], dtype=np.float32),
+    )
+    processor = ParticleThresholdProcessor(shower_pid_thresholds={PHOT_PID: 0.5})
+
+    with pytest.raises(AssertionError, match="all or no"):
+        processor.process({"reco_particles": [particle]})
+
+
+def test_particle_neutrino_logic_promotes_or_demotes_mips():
+    with pytest.raises(AssertionError, match="not recognized"):
+        ParticleNeutrinoLogicProcessor(method="energy")
+
+    pion = make_particle(
+        shape=TRACK_SHP,
+        pid=PION_PID,
+        size=10,
+        pid_scores=np.array([0.0, 0.0, 0.2, 0.8, 0.0, 0.0], dtype=np.float32),
+    )
+    processor = ParticleNeutrinoLogicProcessor(method="size")
+    processor.process({"reco_particles": [pion]})
+    assert pion.pid == MUON_PID
+    assert pion.pid_scores[PION_PID] == -1.0
+
+    muon = make_particle(
+        shape=TRACK_SHP,
+        pid=MUON_PID,
+        size=5,
+        pid_scores=np.array([0.0, 0.0, 0.9, 0.1, 0.0, 0.0], dtype=np.float32),
+    )
+    smaller_muon = make_particle(
+        shape=TRACK_SHP,
+        pid=MUON_PID,
+        size=1,
+        pid_scores=np.array([0.0, 0.0, 0.8, 0.2, 0.0, 0.0], dtype=np.float32),
+    )
+    processor.process({"reco_particles": [muon, smaller_muon]})
+    assert muon.pid == MUON_PID
+    assert smaller_muon.pid == PION_PID
+    assert smaller_muon.pid_scores[MUON_PID] == -1.0
+
+
+def test_particle_neutrino_logic_can_select_by_score():
+    pion = make_particle(
+        shape=TRACK_SHP,
+        pid=PION_PID,
+        size=10,
+        pid_scores=np.array([0.0, 0.0, 0.2, 0.8, 0.0, 0.0], dtype=np.float32),
+    )
+    better_pion = make_particle(
+        shape=TRACK_SHP,
+        pid=PION_PID,
+        size=1,
+        pid_scores=np.array([0.0, 0.0, 0.7, 0.3, 0.0, 0.0], dtype=np.float32),
+    )
+    processor = ParticleNeutrinoLogicProcessor(method="score")
+
+    processor.process({"reco_particles": [pion, better_pion]})
+
+    assert pion.pid == PION_PID
+    assert better_pion.pid == MUON_PID
+
+    muon = make_particle(
+        shape=TRACK_SHP,
+        pid=MUON_PID,
+        pid_scores=np.array([0.0, 0.0, 0.4, 0.1, 0.0, 0.0], dtype=np.float32),
+    )
+    better_muon = make_particle(
+        shape=TRACK_SHP,
+        pid=MUON_PID,
+        pid_scores=np.array([0.0, 0.0, 0.9, 0.1, 0.0, 0.0], dtype=np.float32),
+    )
+    processor.process({"reco_particles": [muon, better_muon]})
+    assert muon.pid == PION_PID
+    assert better_muon.pid == MUON_PID
+
+
+def test_interaction_topology_applies_ke_thresholds():
+    reco_ke_particle = make_particle(pid=MUON_PID, ke=5.0)
+    reco_low_particle = make_particle(pid=PION_PID, ke=1.0)
+    truth_init_particle = make_particle(
+        pid=MUON_PID, energy_init=PID_MASSES[MUON_PID] + 5.0
+    )
+    truth_unknown_particle = make_particle(pid=-1, energy_deposit=0.0)
+    processor = InteractionTopologyProcessor(
+        ke_thresholds={MUON_PID: 3.0, "default": 2.0},
+        truth_ke_mode="energy_init",
+    )
+
+    processor.process(
+        {
+            "reco_interactions": [
+                SimpleNamespace(particles=[reco_ke_particle, reco_low_particle])
+            ],
+            "truth_interactions": [
+                SimpleNamespace(particles=[truth_init_particle, truth_unknown_particle])
+            ],
+        }
+    )
+
+    assert reco_ke_particle.is_valid is True
+    assert reco_low_particle.is_valid is False
+    assert truth_init_particle.is_valid is True
+    assert truth_unknown_particle.is_valid is True
+
+    scalar_processor = InteractionTopologyProcessor(ke_thresholds=2.0, run_mode="reco")
+    assert scalar_processor.ke_thresholds[MUON_PID] == 2.0
+
+    sparse_processor = InteractionTopologyProcessor(
+        ke_thresholds={MUON_PID: 2.0}, run_mode="reco"
+    )
+    assert sparse_processor.ke_thresholds[PION_PID] == 0.0

--- a/test/test_post/test_label.py
+++ b/test/test_post/test_label.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from spine.constants import GHOST_SHP
+from spine.post.truth.label import ChildrenProcessor
+
+
+def test_children_processor_counts_shape_children():
+    parent = SimpleNamespace(
+        orig_id=10,
+        parent_id=10,
+        shape=1,
+        children_counts=np.zeros(GHOST_SHP, dtype=np.int32),
+    )
+    child_a = SimpleNamespace(
+        orig_id=11,
+        parent_id=10,
+        shape=2,
+        children_counts=np.zeros(GHOST_SHP, dtype=np.int32),
+    )
+    child_b = SimpleNamespace(
+        orig_id=12,
+        parent_id=10,
+        shape=2,
+        children_counts=np.zeros(GHOST_SHP, dtype=np.int32),
+    )
+    processor = ChildrenProcessor(mode="shape")
+
+    processor.process({"truth_particles": [parent, child_a, child_b]})
+
+    assert parent.children_counts[2] == 2
+    assert child_a.children_counts.sum() == 0
+
+
+def test_children_processor_counts_pid_children():
+    parent = SimpleNamespace(
+        orig_id=10,
+        parent_id=10,
+        pid=1,
+        children_counts=np.zeros(6, dtype=np.int32),
+    )
+    child = SimpleNamespace(
+        orig_id=11,
+        parent_id=10,
+        pid=2,
+        children_counts=np.zeros(6, dtype=np.int32),
+    )
+    processor = ChildrenProcessor(mode="pid")
+
+    processor.process({"truth_particles": [parent, child]})
+
+    assert parent.children_counts[2] == 1
+
+
+def test_children_processor_validates_mode():
+    with pytest.raises(ValueError, match="not recognized"):
+        ChildrenProcessor(mode="bad")

--- a/test/test_post/test_likelihood.py
+++ b/test/test_post/test_likelihood.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from spine.post.optical import likelihood as likelihood_mod
+
+
+class FakeVector:
+    def __init__(self):
+        self.values = []
+
+    def push_back(self, value):
+        self.values.append(value)
+
+
+class FakePoint:
+    def __init__(self):
+        self.x = 1.0
+        self.y = 2.0
+        self.z = 3.0
+
+
+class FakeMatch:
+    def __init__(self, tpc_id=0, flash_id: int | None = 0):
+        self.tpc_id = tpc_id
+        self.flash_id = flash_id
+        self.tpc_point = FakePoint()
+        self.score = 0.5
+        self.hypothesis = [1.0, 2.0]
+
+
+class FakeQCluster:
+    def __init__(self):
+        self.idx = -1
+        self.time = -1
+        self.payload = []
+
+    def __iadd__(self, other):
+        self.payload.append(other)
+        return self
+
+
+class FakeFlash:
+    def __init__(self):
+        self.idx = -1
+        self.time = -1.0
+        self.pe_v = FakeVector()
+        self.pe_err_v = FakeVector()
+
+
+class FakeManager:
+    def __init__(self):
+        self.objects = []
+        self.config = None
+        self.reset = False
+
+    def Configure(self, cfg):
+        self.config = cfg
+
+    def Reset(self):
+        self.reset = True
+        self.objects.clear()
+
+    def Add(self, obj):
+        self.objects.append(obj)
+
+    def Match(self):
+        return [FakeMatch()]
+
+
+class FakeLightPath:
+    def __init__(self):
+        self.config = None
+        self.calls = []
+
+    def Configure(self, cfg):
+        self.config = cfg
+
+    def MakeQCluster(self, *args):
+        self.calls.append(args)
+        return {"args": args}
+
+
+class FakeFactory:
+    def __init__(self, light_path):
+        self.light_path = light_path
+
+    def create(self, *args):
+        return self.light_path
+
+
+class FakeFactoryGetter:
+    def __init__(self, light_path):
+        self.factory = FakeFactory(light_path)
+
+    def get(self):
+        return self.factory
+
+
+class FakeCfgGetter:
+    def __getitem__(self, key):
+        return lambda name: {"key": key, "name": name}
+
+
+class FakeCfg:
+    get = FakeCfgGetter()
+
+
+class FakeDetectorSpecs:
+    loaded = None
+
+    @classmethod
+    def GetME(cls, path):
+        cls.loaded = path
+
+
+class FakeFlashMatch:
+    def __init__(self):
+        self.light_path = FakeLightPath()
+        self.DetectorSpecs = FakeDetectorSpecs
+        self.CustomAlgoFactory = FakeFactoryGetter(self.light_path)
+        self.manager = FakeManager()
+        self.created_cfg = None
+
+    def CreateFMParamsFromFile(self, path):
+        self.created_cfg = path
+        return FakeCfg()
+
+    def FlashMatchManager(self):
+        return self.manager
+
+    def QCluster_t(self):
+        return FakeQCluster()
+
+    def Flash_t(self):
+        return FakeFlash()
+
+    def as_geoalgo_trajectory(self, array):
+        return array
+
+    def as_ndarray(self, obj):
+        return np.array([obj.idx], dtype=np.float32)
+
+
+def configure_fake_backend(monkeypatch, tmp_path):
+    basedir = tmp_path / "fmatch"
+    (basedir / "dat").mkdir(parents=True)
+    (basedir / "build" / "lib").mkdir(parents=True)
+    (basedir / "dat" / "detector_specs_demo.cfg").write_text("detector")
+    cfg = tmp_path / "flash.cfg"
+    cfg.write_text("cfg")
+    monkeypatch.setenv("FMATCH_BASEDIR", str(basedir))
+    monkeypatch.setenv("LD_LIBRARY_PATH", "")
+    monkeypatch.delenv("FMATCH_DATADIR", raising=False)
+    fake = FakeFlashMatch()
+    monkeypatch.setattr(likelihood_mod, "get_flashmatch", lambda: fake)
+    return fake, cfg
+
+
+def make_matcher(monkeypatch, tmp_path, **kwargs):
+    fake, cfg = configure_fake_backend(monkeypatch, tmp_path)
+    matcher = likelihood_mod.LikelihoodFlashMatcher(
+        cfg=str(cfg),
+        detector="demo",
+        scaling=cast(Any, "2.0"),
+        alpha=cast(Any, "0.2"),
+        recombination_mip=cast(Any, "0.6"),
+        **kwargs,
+    )
+    return matcher, fake
+
+
+def test_likelihood_flash_matcher_backend_validation(monkeypatch, tmp_path):
+    monkeypatch.delenv("FMATCH_BASEDIR", raising=False)
+    with pytest.raises(ValueError, match="FMATCH_BASEDIR"):
+        likelihood_mod.LikelihoodFlashMatcher(cfg="missing.cfg", detector="demo")
+
+    basedir = tmp_path / "fmatch"
+    (basedir / "dat").mkdir(parents=True)
+    (basedir / "build" / "lib").mkdir(parents=True)
+    monkeypatch.setenv("FMATCH_BASEDIR", str(basedir))
+    monkeypatch.setenv("LD_LIBRARY_PATH", "")
+    with pytest.raises(FileNotFoundError, match="detector"):
+        likelihood_mod.LikelihoodFlashMatcher(cfg="missing.cfg", detector="demo")
+
+    (basedir / "dat" / "detector_specs_demo.cfg").write_text("detector")
+    monkeypatch.setattr(likelihood_mod, "get_flashmatch", lambda: FakeFlashMatch())
+    with pytest.raises(FileNotFoundError, match="flash-matcher"):
+        likelihood_mod.LikelihoodFlashMatcher(cfg="missing.cfg", detector="demo")
+
+
+def test_get_flashmatch_loads_optional_module(monkeypatch):
+    fake = SimpleNamespace(flashmatch=FakeFlashMatch())
+    monkeypatch.setitem(sys.modules, "flashmatch", fake)
+
+    assert likelihood_mod.get_flashmatch() is fake.flashmatch
+
+
+def test_likelihood_flash_matcher_initializes_backend(monkeypatch, tmp_path):
+    fake, cfg = configure_fake_backend(monkeypatch, tmp_path)
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    rel_cfg = cfg_dir / "rel.cfg"
+    rel_cfg.write_text("cfg")
+
+    matcher = likelihood_mod.LikelihoodFlashMatcher(
+        cfg="rel.cfg", detector="demo", parent_path=str(cfg_dir)
+    )
+
+    assert fake.DetectorSpecs.loaded is not None
+    assert fake.DetectorSpecs.loaded.endswith("detector_specs_demo.cfg")
+    assert fake.created_cfg == str(rel_cfg)
+    assert matcher.mgr is fake.manager
+    assert fake.light_path.config == {
+        "key": "flashmatch::FMParams",
+        "name": "LightPath",
+    }
+
+
+def test_likelihood_flash_matcher_uses_default_detector_specs(monkeypatch, tmp_path):
+    basedir = tmp_path / "fmatch"
+    (basedir / "dat").mkdir(parents=True)
+    (basedir / "build" / "lib").mkdir(parents=True)
+    (basedir / "dat" / "detector_specs.cfg").write_text("detector")
+    cfg = tmp_path / "flash.cfg"
+    cfg.write_text("cfg")
+    monkeypatch.setenv("FMATCH_BASEDIR", str(basedir))
+    monkeypatch.setenv("LD_LIBRARY_PATH", "")
+    fake = FakeFlashMatch()
+    monkeypatch.setattr(likelihood_mod, "get_flashmatch", lambda: fake)
+
+    likelihood_mod.LikelihoodFlashMatcher(cfg=str(cfg), detector=None)
+
+    assert fake.DetectorSpecs.loaded is not None
+    assert fake.DetectorSpecs.loaded.endswith("detector_specs.cfg")
+
+
+def test_likelihood_flash_matcher_makes_qclusters_and_flashes(monkeypatch, tmp_path):
+    matcher, fake = make_matcher(monkeypatch, tmp_path)
+    interactions = [
+        SimpleNamespace(
+            points=np.array(
+                [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+                dtype=np.float32,
+            ),
+            depositions=np.array([1.0, -1.0, 2.0], dtype=np.float32),
+        ),
+        SimpleNamespace(
+            points=np.array([[0.0, 0.0, 0.0]], dtype=np.float32),
+            depositions=np.array([1.0], dtype=np.float32),
+        ),
+    ]
+    flashes = [SimpleNamespace(time=4.0, pe_per_ch=np.array([1.0, 2.0]))]
+
+    qclusters = matcher.make_qcluster_list(interactions)
+    flash_v, returned_flashes = matcher.make_flash_list(flashes)
+
+    assert len(qclusters) == 1
+    assert qclusters[0].idx == 0
+    assert len(fake.light_path.calls) == 1
+    assert flash_v[0].idx == 0
+    assert flash_v[0].time == 4.0
+    assert flash_v[0].pe_v.values == [1.0, 2.0]
+    assert returned_flashes is flashes
+
+
+def test_likelihood_flash_matcher_legacy_qcluster(monkeypatch, tmp_path):
+    matcher, fake = make_matcher(monkeypatch, tmp_path, legacy=True)
+    interactions = [
+        SimpleNamespace(
+            points=np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float32),
+            depositions=np.array([1.0, 2.0], dtype=np.float32),
+        )
+    ]
+
+    matcher.make_qcluster_list(interactions)
+
+    assert len(fake.light_path.calls[0]) == 2
+
+
+def test_likelihood_flash_matcher_runs_and_fetches_results(monkeypatch, tmp_path):
+    matcher, fake = make_matcher(monkeypatch, tmp_path)
+    interactions = [
+        SimpleNamespace(
+            points=np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float32),
+            depositions=np.array([1.0, 2.0], dtype=np.float32),
+        )
+    ]
+    flashes = [SimpleNamespace(time=4.0, pe_per_ch=np.array([1.0]))]
+
+    result = matcher.get_matches(interactions, flashes)
+
+    assert result[0][0] is interactions[0]
+    assert result[0][1] is flashes[0]
+    assert fake.manager.reset is True
+    assert len(fake.manager.objects) == 2
+    assert matcher.qcluster_v is not None
+    assert matcher.flash_v is not None
+    assert matcher.matches is not None
+    assert matcher.get_qcluster(0) is matcher.qcluster_v[0]
+    assert np.array_equal(matcher.get_qcluster(0, array=True), np.array([0.0]))
+    assert matcher.get_flash(0) is matcher.flash_v[0]
+    assert np.array_equal(matcher.get_flash(0, array=True), np.array([0.0]))
+    assert matcher.get_match(0) is matcher.matches[0]
+    assert matcher.get_matched_flash(0) is matcher.flash_v[0]
+    assert matcher.get_t0(0) == 4.0
+
+
+def test_likelihood_flash_matcher_getter_errors(monkeypatch, tmp_path):
+    matcher, _ = make_matcher(monkeypatch, tmp_path)
+
+    assert matcher.get_matches([], []) == []
+
+    with pytest.raises(ValueError, match="qcluster_v"):
+        matcher.get_qcluster(0)
+    with pytest.raises(ValueError, match="flash_v"):
+        matcher.get_flash(0)
+    with pytest.raises(ValueError, match="run flash matching"):
+        matcher.get_match(0)
+    with pytest.raises(ValueError, match="run flash matching"):
+        matcher.get_matched_flash(0)
+    with pytest.raises(ValueError, match="make_qcluster_list"):
+        matcher.run_flash_matching()
+
+    matcher.qcluster_v = [FakeQCluster()]
+    matcher.qcluster_v[0].idx = 3
+    matcher.flash_v = [FakeFlash()]
+    matcher.flash_v[0].idx = 4
+    matcher.matches = [FakeMatch(tpc_id=0, flash_id=None)]
+
+    with pytest.raises(IndexError, match="TPC"):
+        matcher.get_qcluster(0)
+    with pytest.raises(IndexError, match="Flash"):
+        matcher.get_flash(0)
+    assert matcher.get_match(0) is None
+    assert matcher.get_matched_flash(0) is None
+    assert matcher.get_t0(0) is None
+
+    matcher.qcluster_v[0].idx = 0
+    assert matcher.get_matched_flash(0) is None
+
+    matcher.qcluster_v[0].idx = 3
+    matcher.matches = [FakeMatch(tpc_id=0, flash_id=10)]
+    with pytest.raises(IndexError, match="Flash"):
+        matcher.get_matched_flash(3)

--- a/test/test_post/test_manager.py
+++ b/test/test_post/test_manager.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 import spine.post.manager as manager_mod
@@ -37,7 +39,10 @@ def test_post_manager_parses_priority_names_and_keeps_config_clean(monkeypatch):
     manager = PostManager(cfg, parent_path="config")
 
     assert list(manager.modules) == ["high", "low"]
-    assert manager.modules["high"].cfg == {"offset": 2, "parent_path": "config"}
+    assert cast(FakePostModule, manager.modules["high"]).cfg == {
+        "offset": 2,
+        "parent_path": "config",
+    }
     assert cfg["high"]["priority"] == 3
     assert cfg["high"]["name"] == "processor"
 

--- a/test/test_post/test_manager.py
+++ b/test/test_post/test_manager.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+
+import spine.post.manager as manager_mod
+from spine.post.manager import PostManager
+
+
+class FakePostModule:
+    def __init__(self, name, cfg, calls):
+        self.name = name
+        self.cfg = cfg
+        self.calls = calls
+        self._upstream = tuple(cfg.get("upstream", ()))
+
+    def __call__(self, data, entry=None):
+        self.calls.append((self.name, entry))
+        if entry is None:
+            return {"value": data["index"] + self.cfg.get("offset", 0)}
+        return {"value": data["index"][entry] + self.cfg.get("offset", 0)}
+
+
+def test_post_manager_parses_priority_names_and_keeps_config_clean(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        manager_mod,
+        "post_processor_factory",
+        lambda name, cfg, parent_path=None: FakePostModule(
+            name, {**cfg, "parent_path": parent_path}, calls
+        ),
+    )
+    cfg = {
+        "low": {"name": "processor", "priority": 1, "offset": 1},
+        "high": {"name": "processor", "priority": 3, "offset": 2},
+    }
+
+    manager = PostManager(cfg, parent_path="config")
+
+    assert list(manager.modules) == ["high", "low"]
+    assert manager.modules["high"].cfg == {"offset": 2, "parent_path": "config"}
+    assert cfg["high"]["priority"] == 3
+    assert cfg["high"]["name"] == "processor"
+
+
+def test_post_manager_runs_batches(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        manager_mod,
+        "post_processor_factory",
+        lambda name, cfg, parent_path=None: FakePostModule(name, cfg, calls),
+    )
+    manager = PostManager({"demo": {"offset": 10}})
+    data = {"index": [1, 2, 3]}
+
+    manager(data)
+
+    assert data["value"] == [11, 12, 13]
+    assert calls == [("demo", 0), ("demo", 1), ("demo", 2)]
+
+
+def test_post_manager_checks_dependencies_against_labels_and_names(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        manager_mod,
+        "post_processor_factory",
+        lambda name, cfg, parent_path=None: FakePostModule(name, cfg, calls),
+    )
+
+    PostManager(
+        {
+            "custom_source": {"name": "source"},
+            "custom_child": {"name": "child", "upstream": ("source",)},
+        },
+        post_list=[],
+    )
+    PostManager(
+        {
+            "custom_source": {"name": "source"},
+            "custom_child": {"name": "child", "upstream": ("custom_source",)},
+        },
+        post_list=[],
+    )
+
+    with pytest.raises(ValueError, match="missing an essential upstream"):
+        PostManager(
+            {"custom_child": {"name": "child", "upstream": ("source",)}},
+            post_list=[],
+        )

--- a/test/test_post/test_match.py
+++ b/test/test_post/test_match.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from spine.post.truth.match import MatchProcessor
+
+
+def make_obj(
+    index=(0,),
+    points=((0.0, 0.0, 0.0),),
+    is_truth=False,
+    units="px",
+    orig_index=None,
+):
+    index = np.asarray(index, dtype=np.int64)
+    points = np.asarray(points, dtype=np.float32)
+    obj = SimpleNamespace(
+        is_truth=is_truth,
+        units=units,
+        index=index,
+        points=points,
+        points_g4=points,
+        points_adapt=points,
+        orig_index=(
+            index if orig_index is None else np.asarray(orig_index, dtype=np.int64)
+        ),
+    )
+    return obj
+
+
+class FakeMeta:
+    def to_px(self, coords, floor=True):
+        return np.floor(coords).astype(np.int64) if floor else coords
+
+    def index(self, coords):
+        coords = np.asarray(coords, dtype=np.int64)
+        return coords[:, 0] + 10 * coords[:, 1] + 100 * coords[:, 2]
+
+
+def test_match_processor_validates_configuration():
+    with pytest.raises(AssertionError, match="Must specify"):
+        MatchProcessor()
+
+    with pytest.raises(AssertionError, match="Invalid matching mode"):
+        MatchProcessor(particle={"match_mode": "closest"})
+
+    with pytest.raises(AssertionError, match="Invalid overlap"):
+        MatchProcessor(particle={"overlap_mode": "distance"})
+
+    with pytest.raises(AssertionError, match="Only IoU"):
+        MatchProcessor(particle={"overlap_mode": "count", "weight_overlap": True})
+
+
+def test_prepare_overlap_index_preserves_sorted_and_uniques_unsorted():
+    sorted_index = np.array([1, 3, 5], dtype=np.int32)
+    unsorted_index = np.array([3, 1, 3], dtype=np.int32)
+
+    assert np.array_equal(MatchProcessor.prepare_overlap_index(sorted_index), [1, 3, 5])
+    assert np.array_equal(MatchProcessor.prepare_overlap_index(unsorted_index), [1, 3])
+
+
+def test_match_processor_matches_particles_by_index():
+    reco = make_obj(index=(0, 1), is_truth=False)
+    truth = make_obj(index=(1, 2), is_truth=True)
+    processor = MatchProcessor(particle=True)
+
+    result = processor.process({"reco_particles": [reco], "truth_particles": [truth]})
+
+    assert result["particle_matches_r2t"] == [(reco, truth)]
+    assert result["particle_matches_t2r"] == [(truth, reco)]
+    assert reco.is_matched is True
+    assert np.array_equal(reco.match_ids, np.array([0], dtype=np.int32))
+    assert reco.match_overlaps[0] > 0.0
+
+
+def test_match_processor_handles_empty_and_directional_modes():
+    reco = make_obj(index=(0,), is_truth=False)
+    processor = MatchProcessor(particle={"match_mode": "reco_to_truth"})
+
+    result = processor.process({"reco_particles": [reco], "truth_particles": []})
+
+    assert result["particle_matches_r2t"] == [(reco, None)]
+    assert result["particle_matches_r2t_overlap"] == [-1.0]
+    assert "particle_matches_t2r" not in result
+    assert reco.is_matched is False
+
+    truth = make_obj(index=(0,), is_truth=True)
+    processor = MatchProcessor(particle={"match_mode": "truth_to_reco"})
+    result = processor.process({"reco_particles": [], "truth_particles": [truth]})
+    assert result["particle_matches_t2r"] == [(truth, None)]
+    assert "particle_matches_r2t" not in result
+
+
+def test_match_processor_uses_g4_points_and_meta():
+    reco = make_obj(
+        points=((1.2, 0.0, 0.0),),
+        is_truth=False,
+        units="cm",
+    )
+    truth = make_obj(
+        points=((1.0, 0.0, 0.0),),
+        is_truth=True,
+        units="cm",
+    )
+    processor = MatchProcessor(particle=True, truth_point_mode="points_g4")
+
+    with pytest.raises(AssertionError, match="metadata"):
+        processor.process({"reco_particles": [reco], "truth_particles": [truth]})
+
+    result = processor.process(
+        {"reco_particles": [reco], "truth_particles": [truth], "meta": FakeMeta()}
+    )
+
+    assert result["particle_matches_r2t"] == [(reco, truth)]
+
+
+def test_match_processor_handles_ghost_orig_index_and_meta_fallback():
+    reco = make_obj(index=(0,), orig_index=(5,), is_truth=False)
+    truth = make_obj(index=(0,), orig_index=(5,), is_truth=True)
+    processor = MatchProcessor(particle={"ghost": True})
+
+    result = processor.process({"reco_particles": [reco], "truth_particles": [truth]})
+
+    assert result["particle_matches_r2t"] == [(reco, truth)]
+
+    bad = make_obj(index=(0, 1), orig_index=(5,), is_truth=False)
+    with pytest.raises(AssertionError, match="orig_index"):
+        processor.process({"reco_particles": [bad], "truth_particles": [truth]})
+
+    processor = MatchProcessor(particle={"ghost": True, "use_orig_index": False})
+    with pytest.raises(AssertionError, match="metadata"):
+        processor.process({"reco_particles": [reco], "truth_particles": [truth]})
+
+    reco.units = "cm"
+    truth.units = "cm"
+    result = processor.process(
+        {"reco_particles": [reco], "truth_particles": [truth], "meta": FakeMeta()}
+    )
+    assert result["particle_matches_r2t"] == [(reco, truth)]
+
+
+def test_match_processor_chamfer_distance_mode():
+    reco = make_obj(points=((0.0, 0.0, 0.0),), is_truth=False)
+    truth = make_obj(points=((0.0, 0.0, 0.0),), is_truth=True)
+    far_truth = make_obj(points=((10.0, 0.0, 0.0),), is_truth=True)
+    processor = MatchProcessor(particle={"overlap_mode": "chamfer", "min_overlap": 1.0})
+    processor.matchers["particle"].fn = lambda reco, truth: np.array(
+        [[0.0, 10.0]], dtype=np.float32
+    )
+
+    result = processor.process(
+        {"reco_particles": [reco], "truth_particles": [truth, far_truth]}
+    )
+
+    assert result["particle_matches_r2t"] == [(reco, truth)]
+    assert reco.match_overlaps[0] == pytest.approx(0.0)

--- a/test/test_post/test_mcs.py
+++ b/test/test_post/test_mcs.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+import spine.post.reco.mcs as mcs_mod
 from spine.constants import MUON_PID, TRACK_SHP
 from spine.data.out import RecoParticle
 from spine.post.reco.mcs import MCSEnergyProcessor
@@ -26,3 +27,73 @@ def test_mcs_skips_one_point_track():
     processor.process({"reco_particles": [particle]})
 
     assert np.isnan(particle.mcs_ke)
+
+
+def test_mcs_assigns_energy_and_pid_hypotheses(monkeypatch):
+    monkeypatch.setattr(
+        mcs_mod,
+        "get_track_segments",
+        lambda points, segment_length, start_point, **kwargs: (
+            [np.asarray([0]), np.asarray([1])],
+            np.asarray([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32),
+            np.asarray([1.0, 1.0], dtype=np.float32),
+        ),
+    )
+    monkeypatch.setattr(mcs_mod, "mcs_angles", lambda dirs, method: np.asarray([0.1]))
+    monkeypatch.setattr(mcs_mod, "mcs_fit", lambda *args, **kwargs: 42.0)
+    processor = MCSEnergyProcessor(
+        run_mode="reco", include_pids=(MUON_PID,), fill_per_pid=True
+    )
+    particle = RecoParticle(
+        shape=TRACK_SHP,
+        pid=MUON_PID,
+        points=np.asarray([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float32),
+        start_point=np.asarray([0.0, 0.0, 0.0], dtype=np.float32),
+    )
+
+    processor.process({"reco_particles": [particle]})
+
+    assert particle.mcs_ke == 42.0
+    assert particle.mcs_ke_per_pid[MUON_PID] > 0.0
+
+
+def test_mcs_skips_unwanted_contained_and_angleless_tracks(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        mcs_mod,
+        "get_track_segments",
+        lambda points, segment_length, start_point, **kwargs: (
+            None,
+            np.asarray([[1.0, 0.0, 0.0]], dtype=np.float32),
+            None,
+        ),
+    )
+    monkeypatch.setattr(mcs_mod, "mcs_angles", lambda dirs, method: np.empty(0))
+    monkeypatch.setattr(mcs_mod, "mcs_fit", lambda *args, **kwargs: calls.append(args))
+    processor = MCSEnergyProcessor(
+        run_mode="reco", include_pids=(MUON_PID,), only_uncontained=True
+    )
+    nontrack = RecoParticle(
+        shape=0,
+        pid=MUON_PID,
+        points=np.asarray([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float32),
+        start_point=np.asarray([0.0, 0.0, 0.0], dtype=np.float32),
+    )
+    contained = RecoParticle(
+        shape=TRACK_SHP,
+        pid=MUON_PID,
+        is_contained=True,
+        points=np.asarray([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float32),
+        start_point=np.asarray([0.0, 0.0, 0.0], dtype=np.float32),
+    )
+    angleless = RecoParticle(
+        shape=TRACK_SHP,
+        pid=MUON_PID,
+        is_contained=False,
+        points=np.asarray([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float32),
+        start_point=np.asarray([0.0, 0.0, 0.0], dtype=np.float32),
+    )
+
+    processor.process({"reco_particles": [nontrack, contained, angleless]})
+
+    assert calls == []

--- a/test/test_post/test_mcs.py
+++ b/test/test_post/test_mcs.py
@@ -1,8 +1,17 @@
 import numpy as np
+import pytest
 
 from spine.constants import MUON_PID, TRACK_SHP
 from spine.data.out import RecoParticle
 from spine.post.reco.mcs import MCSEnergyProcessor
+
+
+def test_mcs_validates_configuration():
+    with pytest.raises(ValueError, match="tracking algorithm"):
+        MCSEnergyProcessor(tracking_mode="bad")
+
+    with pytest.raises(ValueError, match="Angular reconstruction"):
+        MCSEnergyProcessor(angle_method="bad")
 
 
 def test_mcs_skips_one_point_track():

--- a/test/test_post/test_pid.py
+++ b/test/test_post/test_pid.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+import spine.post.reco.pid as pid_mod
+from spine.constants import TRACK_SHP
+from spine.post.reco.pid import PIDTemplateProcessor
+
+
+class FakeIdentifier:
+    include_pids = (1, 3)
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def __call__(self, points, values, end_point, start_point):
+        return 3, np.asarray([1.5, 0.25], dtype=np.float32)
+
+
+def _track_particle(points):
+    return SimpleNamespace(
+        is_truth=False,
+        shape=TRACK_SHP,
+        units="cm",
+        points=np.asarray(points, dtype=np.float32),
+        depositions=np.ones(len(points), dtype=np.float32),
+        start_point=np.asarray([0.0, 0.0, 0.0], dtype=np.float32),
+        end_point=np.asarray([1.0, 0.0, 0.0], dtype=np.float32),
+        chi2_pid=-1,
+        chi2_per_pid=np.full(5, -1.0, dtype=np.float32),
+    )
+
+
+def test_pid_template_processor_assigns_pid_and_scores(monkeypatch):
+    monkeypatch.setattr(pid_mod, "TemplateParticleIdentifier", FakeIdentifier)
+    processor = PIDTemplateProcessor(run_mode="reco", fill_per_pid=True)
+    particle = _track_particle([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+
+    processor.process({"reco_particles": [particle]})
+
+    assert particle.chi2_pid == 3
+    assert particle.chi2_per_pid[1] == 1.5
+    assert particle.chi2_per_pid[3] == 0.25
+
+
+def test_pid_template_processor_skips_empty_tracks(monkeypatch):
+    monkeypatch.setattr(pid_mod, "TemplateParticleIdentifier", FakeIdentifier)
+    processor = PIDTemplateProcessor(run_mode="reco")
+    particle = _track_particle([])
+
+    processor.process({"reco_particles": [particle]})
+
+    assert particle.chi2_pid == -1
+
+
+def test_pid_template_processor_skips_non_tracks(monkeypatch):
+    monkeypatch.setattr(pid_mod, "TemplateParticleIdentifier", FakeIdentifier)
+    processor = PIDTemplateProcessor(run_mode="reco")
+    particle = _track_particle([[0.0, 0.0, 0.0]])
+    particle.shape = 0
+
+    processor.process({"reco_particles": [particle]})
+
+    assert particle.chi2_pid == -1

--- a/test/test_post/test_points.py
+++ b/test/test_post/test_points.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import spine.post.reco.points as points_mod
+from spine.constants import TRACK_SHP
+from spine.post.reco.points import TrackExtremaProcessor
+
+
+def _track_particle():
+    return SimpleNamespace(
+        shape=TRACK_SHP,
+        points=np.asarray([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float32),
+        depositions=np.asarray([1.0, 2.0], dtype=np.float32),
+        start_point=np.asarray([0.0, 0.0, 0.0], dtype=np.float32),
+        end_point=np.asarray([1.0, 0.0, 0.0], dtype=np.float32),
+        start_dir=np.asarray([1.0, 0.0, 0.0], dtype=np.float32),
+        end_dir=np.asarray([1.0, 0.0, 0.0], dtype=np.float32),
+    )
+
+
+def test_track_extrema_processor_flips_local_orientation(monkeypatch):
+    monkeypatch.setattr(
+        points_mod, "check_track_orientation", lambda *args, **kwargs: False
+    )
+    particle = _track_particle()
+    processor = TrackExtremaProcessor(method="local")
+
+    processor.process({"reco_particles": [particle]})
+
+    assert np.allclose(particle.start_point, [1.0, 0.0, 0.0])
+    assert np.allclose(particle.end_point, [0.0, 0.0, 0.0])
+    assert np.allclose(particle.start_dir, [-1.0, -0.0, -0.0])
+
+
+def test_track_extrema_processor_uses_ppn_candidates(monkeypatch):
+    monkeypatch.setattr(
+        points_mod, "check_track_orientation_ppn", lambda start, end, candidates: True
+    )
+    particle = _track_particle()
+    processor = TrackExtremaProcessor(method="ppn")
+
+    processor.process({"reco_particles": [particle], "ppn_candidates": [object()]})
+
+    assert np.allclose(particle.start_point, [0.0, 0.0, 0.0])
+
+
+def test_track_extrema_processor_reports_missing_ppn_candidates():
+    processor = TrackExtremaProcessor(method="ppn")
+
+    with pytest.raises(KeyError, match="ppn"):
+        processor.process({"reco_particles": [_track_particle()]})
+
+
+def test_track_extrema_processor_rejects_unknown_method():
+    processor = TrackExtremaProcessor(method="bad")
+
+    with pytest.raises(ValueError, match="not recognized"):
+        processor.process({"reco_particles": [_track_particle()]})

--- a/test/test_post/test_ppn.py
+++ b/test/test_post/test_ppn.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import numpy as np
+
+from spine.constants import COORD_COLS, PPN_SHAPE_COL, TRACK_SHP
+from spine.post.reco import ppn as ppn_mod
+
+
+class FakePPNPredictor:
+    def __init__(self, **cfg):
+        self.cfg = cfg
+
+    def __call__(self, **data):
+        prediction = np.zeros((2, PPN_SHAPE_COL + 1), dtype=np.float32)
+        prediction[0, COORD_COLS] = [0.0, 0.0, 0.0]
+        prediction[0, PPN_SHAPE_COL] = TRACK_SHP
+        prediction[1, COORD_COLS] = [10.0, 0.0, 0.0]
+        prediction[1, PPN_SHAPE_COL] = TRACK_SHP + 1
+        return [prediction]
+
+
+def test_ppn_processor_builds_candidates(monkeypatch):
+    monkeypatch.setattr(ppn_mod, "PPNPredictor", FakePPNPredictor)
+    processor = ppn_mod.PPNProcessor(foo="bar")
+
+    result = processor.process(
+        {
+            "segmentation": np.empty((0, 1)),
+            "ppn_points": np.empty((0, 1)),
+            "ppn_coords": np.empty((0, 1)),
+            "ppn_masks": np.empty((0, 1)),
+        }
+    )
+
+    assert np.asarray(result["ppn_pred"]).shape == (2, PPN_SHAPE_COL + 1)
+    assert cast(FakePPNPredictor, processor.ppn_predictor).cfg == {"foo": "bar"}
+
+
+def test_ppn_processor_assigns_candidates_to_particles(monkeypatch):
+    monkeypatch.setattr(ppn_mod, "PPNPredictor", FakePPNPredictor)
+    processor = ppn_mod.PPNProcessor(
+        assign_to_particles=True, restrict_shape=True, match_threshold=1.0
+    )
+    particle = SimpleNamespace(
+        shape=TRACK_SHP,
+        points=np.array([[0.1, 0.0, 0.0]], dtype=np.float32),
+    )
+
+    processor.process(
+        {
+            "segmentation": np.empty((0, 1)),
+            "ppn_points": np.empty((0, 1)),
+            "ppn_coords": np.empty((0, 1)),
+            "ppn_masks": np.empty((0, 1)),
+            "reco_particles": [particle],
+        }
+    )
+
+    assert np.array_equal(particle.ppn_points, np.array([[0.0, 0.0, 0.0]]))
+    assert np.array_equal(particle.ppn_ids, np.array([0]))
+
+
+def test_ppn_processor_assigns_unrestricted_candidate_ids(monkeypatch):
+    monkeypatch.setattr(ppn_mod, "PPNPredictor", FakePPNPredictor)
+    processor = ppn_mod.PPNProcessor(assign_to_particles=True, match_threshold=20.0)
+    particle = SimpleNamespace(
+        shape=TRACK_SHP,
+        points=np.array([[0.1, 0.0, 0.0]], dtype=np.float32),
+    )
+
+    processor.process(
+        {
+            "segmentation": np.empty((0, 1)),
+            "ppn_points": np.empty((0, 1)),
+            "ppn_coords": np.empty((0, 1)),
+            "ppn_masks": np.empty((0, 1)),
+            "reco_particles": [particle],
+        }
+    )
+
+    assert np.array_equal(particle.ppn_ids, np.array([0, 1]))

--- a/test/test_post/test_shower.py
+++ b/test/test_post/test_shower.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import numpy as np
+import pytest
+
+from spine.constants import PION_PID, PROT_PID, SHOWR_SHP, TRACK_SHP
+from spine.post.reco import shower as shower_mod
+
+
+class FakeTPC:
+    def __init__(self):
+        self.modules = [
+            SimpleNamespace(boundaries=np.array([[0.0, 1.0]] * 3)),
+            SimpleNamespace(boundaries=np.array([[1.0, 2.0]] * 3)),
+        ]
+        self.chambers = [
+            SimpleNamespace(boundaries=np.array([[0.0, 1.0]] * 3)),
+            SimpleNamespace(boundaries=np.array([[1.0, 2.0]] * 3)),
+        ]
+        self.num_modules = 2
+        self.num_chambers = 2
+
+
+class FakeGeo:
+    def __init__(self):
+        self.boundaries = np.array([[0.0, 10.0]] * 3)
+        self.tpc = FakeTPC()
+
+    def get_closest_module(self, points):
+        return np.asarray(points[:, 0] > 0.5, dtype=np.int64)
+
+    def get_closest_tpc(self, points):
+        return np.asarray(points[:, 0] > 0.5, dtype=np.int64)
+
+
+class FakeFitter:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.calls = []
+
+    def fit(self, **kwargs):
+        self.calls.append(kwargs)
+        return float(np.sum(kwargs["reco_box_energy"]) + 1.0)
+
+
+def make_particle(**overrides):
+    data = {
+        "id": 0,
+        "shape": SHOWR_SHP,
+        "pid": 0,
+        "is_primary": True,
+        "is_truth": False,
+        "units": "cm",
+        "points": np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+            dtype=np.float32,
+        ),
+        "depositions": np.array([1.0, 2.0, 3.0], dtype=np.float32),
+        "start_point": np.array([0.0, 0.0, 0.0], dtype=np.float32),
+        "start_dir": np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        "length": 1.0,
+        "calo_ke": 6.0,
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+def test_shower_parametric_energy_processor_validates_and_fits(monkeypatch):
+    monkeypatch.setattr(shower_mod.GeoManager, "get_instance", lambda: FakeGeo())
+    monkeypatch.setattr(shower_mod, "ShowerEnergyFitter", FakeFitter)
+
+    with pytest.raises(ValueError, match="geometry mode"):
+        shower_mod.ShowerParametricEnergyProcessor(mode="volume")
+
+    shower = make_particle()
+    low_energy = make_particle(calo_ke=0.5)
+    track = make_particle(shape=TRACK_SHP, calo_ke=6.0)
+    processor = shower_mod.ShowerParametricEnergyProcessor(
+        mode="module", energy_bounds=(1.0, 100.0)
+    )
+
+    processor.process({"reco_particles": [shower, low_energy, track]})
+
+    assert shower.calo_ke == pytest.approx(7.0)
+    assert low_energy.calo_ke == 0.5
+    assert track.calo_ke == 6.0
+    fitter = cast(FakeFitter, processor.fitter)
+    np.testing.assert_allclose(fitter.calls[0]["reco_box_energy"], [1.0, 5.0])
+
+
+def test_shower_parametric_energy_processor_detector_mode(monkeypatch):
+    monkeypatch.setattr(shower_mod.GeoManager, "get_instance", lambda: FakeGeo())
+    monkeypatch.setattr(shower_mod, "ShowerEnergyFitter", FakeFitter)
+    shower = make_particle(calo_ke=4.0)
+    processor = shower_mod.ShowerParametricEnergyProcessor(mode="detector")
+
+    processor.process({"reco_particles": [shower]})
+
+    assert shower.calo_ke == pytest.approx(5.0)
+
+
+def test_shower_parametric_energy_processor_tpc_mode(monkeypatch):
+    monkeypatch.setattr(shower_mod.GeoManager, "get_instance", lambda: FakeGeo())
+    monkeypatch.setattr(shower_mod, "ShowerEnergyFitter", FakeFitter)
+    shower = make_particle()
+    processor = shower_mod.ShowerParametricEnergyProcessor(mode="tpc")
+
+    processor.process({"reco_particles": [shower]})
+
+    assert shower.calo_ke == pytest.approx(7.0)
+
+
+def test_shower_conversion_distance_processor_rejects_corrupt_mode():
+    shower = make_particle()
+    inter = SimpleNamespace(
+        vertex=np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        particles=[shower],
+    )
+    processor = shower_mod.ShowerConversionDistanceProcessor(mode="vertex_to_start")
+    processor.mode = "corrupt"
+
+    with pytest.raises(ValueError, match="not recognized"):
+        processor.process({"reco_interactions": [inter]})
+
+
+def test_shower_conversion_distance_processor_modes():
+    with pytest.raises(AssertionError, match="Conversion distance"):
+        shower_mod.ShowerConversionDistanceProcessor(mode="bad")
+
+    shower = make_particle()
+    proton = make_particle(
+        shape=TRACK_SHP,
+        pid=PROT_PID,
+        points=np.array([[3.0, 0.0, 0.0]], dtype=np.float32),
+    )
+    pion = make_particle(
+        shape=TRACK_SHP,
+        pid=PION_PID,
+        points=np.array([[2.5, 0.0, 0.0]], dtype=np.float32),
+    )
+    secondary = make_particle(is_primary=False)
+    inter = SimpleNamespace(
+        vertex=np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        particles=[shower, proton, pion, secondary],
+    )
+
+    processor = shower_mod.ShowerConversionDistanceProcessor(mode="vertex_to_start")
+    processor.process({"reco_interactions": [inter]})
+    assert shower.vertex_distance == pytest.approx(1.0)
+
+    processor = shower_mod.ShowerConversionDistanceProcessor(mode="vertex_to_points")
+    processor.process({"reco_interactions": [inter]})
+    assert shower.vertex_distance == pytest.approx(0.0)
+
+    processor = shower_mod.ShowerConversionDistanceProcessor(mode="protons_to_points")
+    processor.process({"reco_interactions": [inter]})
+    assert shower.vertex_distance == pytest.approx(0.5)
+
+    no_proton_inter = SimpleNamespace(vertex=inter.vertex, particles=[shower])
+    assert processor.get_protons_to_points(no_proton_inter, shower) == -1
+
+
+def test_shower_start_merge_processor_merges_tracks(monkeypatch):
+    monkeypatch.setattr(shower_mod, "cluster_dedx", lambda *args, **kwargs: 1.0)
+    shower = make_particle(id=0)
+    merged_track = make_particle(
+        id=1,
+        shape=TRACK_SHP,
+        points=np.array([[0.2, 0.0, 0.0]], dtype=np.float32),
+        start_point=np.array([0.2, 0.0, 0.0], dtype=np.float32),
+        length=1.0,
+    )
+    long_track = make_particle(id=2, shape=TRACK_SHP, length=100.0)
+    secondary_track = make_particle(id=3, shape=TRACK_SHP, is_primary=False)
+    shower.merged = []
+    shower.merge = lambda part: shower.merged.append(part.id)
+    inter = SimpleNamespace(
+        particles=[shower, merged_track, long_track, secondary_track],
+        leading_shower=shower,
+    )
+    no_shower = SimpleNamespace(
+        particles=[make_particle(id=5, shape=TRACK_SHP)],
+        leading_shower=None,
+    )
+    processor = shower_mod.ShowerStartMergeProcessor(track_dedx_limit=2.0)
+
+    result = processor.process({"reco_interactions": [inter, no_shower]})
+
+    assert shower.merged == [1]
+    assert [part.id for part in inter.particles] == [0, 1, 2]
+    assert np.array_equal(inter.particle_ids, np.array([0, 1, 2]))
+    assert len(result["reco_particles"]) == 4
+
+
+def test_shower_start_merge_processor_rejects_bad_candidates(monkeypatch):
+    monkeypatch.setattr(shower_mod, "cluster_dedx", lambda *args, **kwargs: 10.0)
+    processor = shower_mod.ShowerStartMergeProcessor(track_dedx_limit=2.0)
+    shower = make_particle()
+    track = make_particle(shape=TRACK_SHP)
+
+    assert processor.check_merge(shower, track) is False
+
+    processor = shower_mod.ShowerStartMergeProcessor(angle_threshold=0.1)
+    track.start_dir = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+    assert processor.check_merge(shower, track) is False
+
+    processor = shower_mod.ShowerStartMergeProcessor(distance_threshold=0.1)
+    track.start_dir = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+    track.points = np.array([[10.0, 0.0, 0.0]], dtype=np.float32)
+    assert processor.check_merge(shower, track) is False
+
+
+def test_shower_start_correction_processor_updates_start_and_direction(monkeypatch):
+    monkeypatch.setattr(
+        shower_mod,
+        "cluster_direction",
+        lambda points, start, max_dist, optimize: np.array([0.0, 1.0, 0.0]),
+    )
+    shower = make_particle(
+        points=np.array([[5.0, 0.0, 0.0], [0.2, 0.0, 0.0]], dtype=np.float32),
+        start_point=np.array([5.0, 0.0, 0.0], dtype=np.float32),
+    )
+    track = make_particle(shape=TRACK_SHP, points=np.array([[0.0, 0.0, 0.0]]))
+    secondary = make_particle(is_primary=False)
+    inter = SimpleNamespace(particles=[shower, track, secondary])
+    processor = shower_mod.ShowerStartCorrectionProcessor(radius=2, optimize=False)
+
+    processor.process({"reco_interactions": [inter]})
+
+    np.testing.assert_allclose(shower.start_point, [0.2, 0.0, 0.0])
+    np.testing.assert_allclose(shower.start_dir, [0.0, 1.0, 0.0])
+
+    no_track = SimpleNamespace(particles=[shower])
+    assert np.array_equal(
+        processor.correct_shower_start(no_track, shower), shower.start_point
+    )

--- a/test/test_post/test_source.py
+++ b/test/test_post/test_source.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import numpy as np
+
+import spine.post.reco.source as source_mod
+from spine.post.reco.source import SourceAssigner
+
+
+class FakeGeo:
+    def get_closest_module(self, points):
+        return np.arange(len(points), dtype=np.int32)
+
+    def get_closest_tpc(self, points):
+        return np.arange(len(points), dtype=np.int32) + 10
+
+
+def test_source_assigner_assigns_reco_and_truth_sources(monkeypatch):
+    monkeypatch.setattr(source_mod.GeoManager, "get_instance", lambda: FakeGeo())
+    processor = SourceAssigner(run_mode="both", truth_point_mode="points")
+    points = np.zeros((2, 3), dtype=np.float32)
+
+    result = processor.process({"points": points, "points_label": points})
+
+    assert np.array_equal(result["sources"], [[0, 10], [1, 11]])
+    assert np.array_equal(result["sources_label"], [[0, 10], [1, 11]])
+
+
+def test_source_assigner_respects_run_mode(monkeypatch):
+    monkeypatch.setattr(source_mod.GeoManager, "get_instance", lambda: FakeGeo())
+    processor = SourceAssigner(run_mode="reco")
+
+    result = processor.process({"points": np.zeros((1, 3), dtype=np.float32)})
+
+    assert set(result) == {"sources"}

--- a/test/test_post/test_template.py
+++ b/test/test_post/test_template.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from spine.post.template import TemplateProcessor
+
+
+def test_template_processor_registers_prod_and_processes_objects():
+    processor = TemplateProcessor("a", "b", obj_type="particle", run_mode="reco")
+    obj = SimpleNamespace(
+        is_truth=False,
+        points=np.zeros((1, 3), dtype=np.float32),
+        sources=np.zeros((1, 2), dtype=np.int32),
+    )
+
+    result = processor({"prod": {"reco_particles": [obj]}, "reco_particles": [obj]})
+
+    assert processor.keys["prod"] is True
+    assert result == {}
+
+
+def test_template_processor_loops_over_all_object_key_groups():
+    processor = TemplateProcessor(
+        "a", "b", obj_type=("fragment", "particle", "interaction"), run_mode="reco"
+    )
+    obj = SimpleNamespace(
+        is_truth=False,
+        points=np.zeros((1, 3), dtype=np.float32),
+        sources=np.zeros((1, 2), dtype=np.int32),
+    )
+
+    result = processor(
+        {
+            "prod": {
+                "reco_fragments": [obj],
+                "reco_particles": [obj],
+                "reco_interactions": [obj],
+            },
+            "reco_fragments": [obj],
+            "reco_particles": [obj],
+            "reco_interactions": [obj],
+        }
+    )
+
+    assert result == {}

--- a/test/test_post/test_topology.py
+++ b/test/test_post/test_topology.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from spine.constants import ELEC_PID, PHOT_PID, SHOWR_SHP, TRACK_SHP
+from spine.post.reco import topology as topology_mod
+
+
+def make_particle(**overrides):
+    data = {
+        "shape": TRACK_SHP,
+        "pid": ELEC_PID,
+        "is_primary": True,
+        "points": np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+            dtype=np.float32,
+        ),
+        "depositions": np.ones(3, dtype=np.float32),
+        "start_point": np.array([0.0, 0.0, 0.0], dtype=np.float32),
+        "end_point": np.array([2.0, 0.0, 0.0], dtype=np.float32),
+        "start_dir": np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        "end_dir": np.array([1.0, 0.0, 0.0], dtype=np.float32),
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+def test_particle_dedx_processor_validates_mode_and_uses_default(monkeypatch):
+    with pytest.raises(AssertionError, match="not recognized"):
+        topology_mod.ParticleDEDXProcessor(mode="cone")
+
+    monkeypatch.setattr(topology_mod, "cluster_dedx", lambda *args, **kwargs: 1.5)
+    particle = make_particle(
+        points=np.array(
+            [[0.0, 0.0, 0.0], [1.0, 0.2, 0.0], [2.0, 0.0, 0.0]],
+            dtype=np.float32,
+        )
+    )
+    skipped = make_particle(is_primary=False)
+    processor = topology_mod.ParticleDEDXProcessor(mode="default")
+
+    processor.process({"reco_particles": [particle, skipped]})
+
+    assert particle.start_dedx == 1.5
+    assert particle.end_dedx == 1.5
+    assert not hasattr(skipped, "start_dedx")
+
+
+def test_particle_dedx_processor_uses_direction_and_skips_shower_end(monkeypatch):
+    monkeypatch.setattr(
+        topology_mod, "cluster_dedx_dir", lambda *args, **kwargs: (2.5, None)
+    )
+    particle = make_particle(shape=SHOWR_SHP, pid=PHOT_PID)
+    processor = topology_mod.ParticleDEDXProcessor(mode="direction")
+
+    processor.process({"reco_particles": [particle]})
+
+    assert particle.start_dedx == 2.5
+    assert not hasattr(particle, "end_dedx")
+
+    skipped = make_particle(pid=99)
+    processor.process({"reco_particles": [skipped]})
+    assert not hasattr(skipped, "start_dedx")
+
+
+def test_particle_start_straightness_processor_branches():
+    with pytest.raises(AssertionError, match="PCA components"):
+        topology_mod.ParticleStartStraightnessProcessor(n_components=4)
+
+    particle = make_particle()
+    secondary = make_particle(is_primary=False)
+    skipped = make_particle(pid=99)
+    processor = topology_mod.ParticleStartStraightnessProcessor(radius=3.0)
+
+    processor.process({"reco_particles": [particle, secondary, skipped]})
+
+    assert particle.start_straightness == pytest.approx(1.0)
+    assert not hasattr(secondary, "start_straightness")
+    assert not hasattr(skipped, "start_straightness")
+
+    sparse = make_particle(points=np.array([[0.0, 0.0, 0.0]], dtype=np.float32))
+    assert processor.get_start_straightness(sparse) == -1.0
+
+    flat = make_particle(points=np.zeros((3, 3), dtype=np.float32))
+    assert processor.get_start_straightness(flat) == 0.0
+
+
+@pytest.mark.filterwarnings(
+    "ignore:An input array is constant:scipy.stats.ConstantInputWarning"
+)
+def test_particle_spread_processor_validates_mode_and_processes_interactions():
+    with pytest.raises(AssertionError, match="not recognized"):
+        topology_mod.ParticleSpreadProcessor(start_mode="centroid")
+
+    particle = make_particle(
+        points=np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [2.0, 1.0, 0.0],
+                [4.0, 0.5, 0.0],
+                [8.0, 3.0, 0.0],
+            ],
+            dtype=np.float32,
+        )
+    )
+    skipped = make_particle(is_primary=False)
+    skipped_pid = make_particle(pid=99)
+    inter = SimpleNamespace(
+        vertex=np.array([0.0, 0.0, 0.0], dtype=np.float32),
+        particles=[particle, skipped, skipped_pid],
+    )
+    processor = topology_mod.ParticleSpreadProcessor(
+        start_mode="vertex", use_start_dir=True
+    )
+
+    processor.process({"reco_interactions": [inter]})
+
+    assert particle.directional_spread >= 0.0
+    assert np.isfinite(particle.axial_spread)
+    assert not hasattr(skipped, "directional_spread")
+    assert not hasattr(skipped_pid, "directional_spread")
+
+    particle = make_particle()
+    inter = SimpleNamespace(vertex=np.zeros(3, dtype=np.float32), particles=[particle])
+    processor = topology_mod.ParticleSpreadProcessor(start_mode="start_point")
+    processor.process({"reco_interactions": [inter]})
+    assert hasattr(particle, "directional_spread")
+
+
+def test_particle_spread_processor_helper_degenerate_cases():
+    processor = topology_mod.ParticleSpreadProcessor(
+        start_mode="start_point", use_start_dir=True
+    )
+    points = np.zeros((2, 3), dtype=np.float32)
+    ref_point = np.zeros(3, dtype=np.float32)
+
+    assert processor.get_dir_spread(points, ref_point) == -1.0
+    assert processor.get_axial_spread(points, np.array([1.0, 0.0, 0.0]), ref_point) == (
+        -np.inf
+    )
+
+    points = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.1, 0.0], [2.0, 0.0, 0.0]], dtype=np.float32
+    )
+    processor = topology_mod.ParticleSpreadProcessor(
+        start_mode="start_point", use_start_dir=True
+    )
+    assert np.isfinite(
+        processor.get_axial_spread(points, np.array([1.0, 0.0, 0.0]), ref_point)
+    )
+
+    processor = topology_mod.ParticleSpreadProcessor(start_mode="start_point")
+    assert np.isfinite(
+        processor.get_axial_spread(points, np.array([-1.0, 0.0, 0.0]), ref_point)
+    )

--- a/test/test_post/test_tracking.py
+++ b/test/test_post/test_tracking.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+import spine.post.reco.tracking as tracking_mod
+from spine.constants import MUON_PID, PION_PID, TRACK_SHP
+from spine.post.reco.tracking import CSDAEnergyProcessor
+
+
+def _track_particle(points):
+    return SimpleNamespace(
+        is_truth=False,
+        shape=TRACK_SHP,
+        pid=MUON_PID,
+        units="cm",
+        points=np.asarray(points, dtype=np.float32),
+        start_point=np.asarray([0.0, 0.0, 0.0], dtype=np.float32),
+        length=-1.0,
+        csda_ke=-1.0,
+        csda_ke_per_pid=np.full(6, -1.0, dtype=np.float32),
+    )
+
+
+def test_csda_energy_processor_assigns_length_and_energy(monkeypatch):
+    monkeypatch.setattr(
+        tracking_mod,
+        "csda_table_spline",
+        lambda pid: lambda length: np.asarray(pid + length),
+    )
+    monkeypatch.setattr(tracking_mod, "get_track_length", lambda *args, **kwargs: 4.0)
+    processor = CSDAEnergyProcessor(
+        run_mode="reco", include_pids=(MUON_PID, PION_PID), fill_per_pid=True
+    )
+    particle = _track_particle([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+
+    processor.process({"reco_particles": [particle]})
+
+    assert particle.length == 4.0
+    assert particle.csda_ke == MUON_PID + 4.0
+    assert particle.csda_ke_per_pid[PION_PID] == PION_PID + 4.0
+
+
+def test_csda_energy_processor_sets_zero_for_zero_length(monkeypatch):
+    monkeypatch.setattr(
+        tracking_mod, "csda_table_spline", lambda pid: lambda length: np.asarray(1.0)
+    )
+    monkeypatch.setattr(tracking_mod, "get_track_length", lambda *args, **kwargs: 0.0)
+    processor = CSDAEnergyProcessor(run_mode="reco", fill_per_pid=True)
+    particle = _track_particle([[0.0, 0.0, 0.0]])
+
+    processor.process({"reco_particles": [particle]})
+
+    assert particle.csda_ke == 0.0
+    assert np.all(particle.csda_ke_per_pid[list(processor.include_pids)] == 0.0)
+
+
+def test_csda_energy_processor_skips_nontracks_and_empty_tracks(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        tracking_mod, "csda_table_spline", lambda pid: lambda length: np.asarray(1.0)
+    )
+    monkeypatch.setattr(
+        tracking_mod, "get_track_length", lambda *args, **kwargs: calls.append(args)
+    )
+    processor = CSDAEnergyProcessor(run_mode="reco")
+    nontrack = _track_particle([[0.0, 0.0, 0.0]])
+    nontrack.shape = 0
+    empty = _track_particle([])
+
+    processor.process({"reco_particles": [nontrack, empty]})
+
+    assert calls == []
+
+
+def test_csda_energy_processor_assigns_truth_reco_length(monkeypatch):
+    monkeypatch.setattr(
+        tracking_mod, "csda_table_spline", lambda pid: lambda length: np.asarray(2.0)
+    )
+    monkeypatch.setattr(tracking_mod, "get_track_length", lambda *args, **kwargs: 3.0)
+    processor = CSDAEnergyProcessor(run_mode="truth")
+    particle = _track_particle([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    particle.is_truth = True
+    particle.reco_length = -1.0
+    particle.reco_ke = -1.0
+
+    processor.process({"truth_particles": [particle]})
+
+    assert particle.reco_length == 3.0
+    assert particle.csda_ke == 2.0

--- a/test/test_post/test_trigger.py
+++ b/test/test_post/test_trigger.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pandas as pd
 import pytest
 
@@ -24,6 +26,9 @@ def test_trigger_processor_validates_flash_keys(tmp_path):
     with pytest.raises(ValueError, match="flash keys"):
         TriggerProcessor(str(path), correct_flash_times=True, flash_keys=None)
 
+    with pytest.raises(FileNotFoundError):
+        TriggerProcessor(str(tmp_path / "missing.csv"), correct_flash_times=False)
+
 
 def test_trigger_processor_builds_trigger(tmp_path):
     path = tmp_path / "triggers.csv"
@@ -47,3 +52,58 @@ def test_trigger_processor_builds_trigger(tmp_path):
     result = processor.process({"run_info": run_info})
 
     assert result["trigger"].type == 3
+
+
+def test_trigger_processor_rejects_missing_or_duplicate_triggers(tmp_path):
+    path = tmp_path / "triggers.csv"
+    pd.DataFrame(
+        [
+            {
+                "run_number": 1,
+                "event_no": 2,
+                "wr_seconds": 10,
+                "wr_nanoseconds": 20,
+                "beam_seconds": 9,
+                "beam_nanoseconds": 10,
+            },
+            {
+                "run_number": 1,
+                "event_no": 2,
+                "wr_seconds": 11,
+                "wr_nanoseconds": 20,
+                "beam_seconds": 9,
+                "beam_nanoseconds": 10,
+            },
+        ]
+    ).to_csv(path, index=False)
+    processor = TriggerProcessor(str(path), correct_flash_times=False)
+
+    with pytest.raises(KeyError, match="Could not find"):
+        processor.process({"run_info": SimpleNamespace(run=9, event=9)})
+
+    with pytest.raises(KeyError, match="more than one"):
+        processor.process({"run_info": SimpleNamespace(run=1, event=2)})
+
+
+def test_trigger_processor_corrects_flash_times(tmp_path):
+    path = tmp_path / "triggers.csv"
+    pd.DataFrame(
+        [
+            {
+                "run_number": 1,
+                "event_no": 2,
+                "wr_seconds": 10,
+                "wr_nanoseconds": 2000,
+                "beam_seconds": 9,
+                "beam_nanoseconds": 1000,
+            }
+        ]
+    ).to_csv(path, index=False)
+    processor = TriggerProcessor(
+        str(path), flash_keys=["flashes"], flash_time_corr_us=4
+    )
+    flash = SimpleNamespace(time=1.0)
+
+    processor.process({"run_info": SimpleNamespace(run=1, event=2), "flashes": [flash]})
+
+    assert flash.time == pytest.approx(999998.0)

--- a/test/test_post/test_trigger.py
+++ b/test/test_post/test_trigger.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from spine.post.trigger.trigger import TriggerProcessor
+
+
+def test_trigger_processor_validates_flash_keys(tmp_path):
+    path = tmp_path / "triggers.csv"
+    pd.DataFrame(
+        [
+            {
+                "run_number": 1,
+                "event_no": 2,
+                "wr_seconds": 10,
+                "wr_nanoseconds": 20,
+                "beam_seconds": 9,
+                "beam_nanoseconds": 10,
+            }
+        ]
+    ).to_csv(path, index=False)
+
+    with pytest.raises(ValueError, match="flash keys"):
+        TriggerProcessor(str(path), correct_flash_times=True, flash_keys=None)
+
+
+def test_trigger_processor_builds_trigger(tmp_path):
+    path = tmp_path / "triggers.csv"
+    pd.DataFrame(
+        [
+            {
+                "run_number": 1,
+                "event_no": 2,
+                "wr_seconds": 10,
+                "wr_nanoseconds": 20,
+                "beam_seconds": 9,
+                "beam_nanoseconds": 10,
+                "trigger_type": 3,
+            }
+        ]
+    ).to_csv(path, index=False)
+
+    processor = TriggerProcessor(str(path), correct_flash_times=False)
+    run_info = type("RunInfo", (), {"run": 1, "event": 2})()
+
+    result = processor.process({"run_info": run_info})
+
+    assert result["trigger"].type == 3

--- a/test/test_post/test_vertex.py
+++ b/test/test_post/test_vertex.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from spine.constants import SHOWR_SHP, TRACK_SHP
+from spine.post.reco import vertex as vertex_mod
+
+
+def make_particle(
+    shape=TRACK_SHP,
+    start_point=(0.0, 0.0, 0.0),
+    end_point=(1.0, 0.0, 0.0),
+    start_dir=(1.0, 0.0, 0.0),
+    is_primary=True,
+):
+    start_point = np.asarray(start_point, dtype=np.float32)
+    end_point = np.asarray(end_point, dtype=np.float32)
+    start_dir = np.asarray(start_dir, dtype=np.float32)
+    return SimpleNamespace(
+        size=2,
+        shape=shape,
+        is_primary=is_primary,
+        start_point=start_point,
+        end_point=end_point,
+        start_dir=start_dir,
+        end_dir=-start_dir,
+    )
+
+
+def test_vertex_processor_reconstructs_reco_vertex_and_updates_tracks(monkeypatch):
+    monkeypatch.setattr(
+        vertex_mod,
+        "get_vertex",
+        lambda *args, **kwargs: (np.array([0.0, 0.0, 0.0], dtype=np.float32), "track"),
+    )
+    track = make_particle(start_point=(5.0, 0.0, 0.0), end_point=(0.0, 0.0, 0.0))
+    shower = make_particle(shape=SHOWR_SHP, start_point=(0.5, 0.0, 0.0))
+    other = make_particle(shape=99)
+    inter = SimpleNamespace(
+        is_truth=False,
+        particles=[track, shower, other],
+        vertex=np.full(3, -1.0, dtype=np.float32),
+    )
+    processor = vertex_mod.VertexProcessor(
+        run_mode="reco", update_orientations=True, update_primaries=True
+    )
+
+    processor.process({"reco_interactions": [inter]})
+
+    assert np.array_equal(inter.vertex, np.zeros(3, dtype=np.float32))
+    assert np.array_equal(track.start_point, np.zeros(3, dtype=np.float32))
+    assert track.is_primary is True
+    assert shower.is_primary is True
+    assert other.is_primary is False
+
+
+def test_vertex_processor_reconstructs_truth_vertex(monkeypatch):
+    monkeypatch.setattr(
+        vertex_mod,
+        "get_vertex",
+        lambda *args, **kwargs: (np.array([1.0, 2.0, 3.0], dtype=np.float32), "track"),
+    )
+    inter = SimpleNamespace(
+        is_truth=True,
+        particles=[make_particle()],
+        reco_vertex=np.full(3, -1.0, dtype=np.float32),
+    )
+    processor = vertex_mod.VertexProcessor(run_mode="truth")
+
+    processor.process({"truth_interactions": [inter]})
+
+    assert np.array_equal(inter.reco_vertex, np.array([1.0, 2.0, 3.0]))
+
+
+def test_vertex_processor_falls_back_to_nonprimary_particles(monkeypatch):
+    monkeypatch.setattr(
+        vertex_mod,
+        "get_vertex",
+        lambda *args, **kwargs: (np.array([2.0, 0.0, 0.0], dtype=np.float32), "track"),
+    )
+    particle = make_particle(is_primary=False)
+    inter = SimpleNamespace(
+        is_truth=False,
+        particles=[particle],
+        vertex=np.full(3, -1.0, dtype=np.float32),
+    )
+    processor = vertex_mod.VertexProcessor(run_mode="reco")
+
+    processor.reconstruct_vertex_single(inter)
+
+    assert np.array_equal(inter.vertex, np.array([2.0, 0.0, 0.0]))
+
+
+def test_vertex_processor_skips_empty_interaction():
+    inter = SimpleNamespace(
+        is_truth=False,
+        particles=[SimpleNamespace(size=0, shape=TRACK_SHP)],
+        vertex=np.full(3, -1.0, dtype=np.float32),
+    )
+    processor = vertex_mod.VertexProcessor(run_mode="reco")
+
+    processor.reconstruct_vertex_single(inter)
+
+    assert np.array_equal(inter.vertex, np.full(3, -1.0, dtype=np.float32))
+
+
+def test_vertex_processor_updates_shower_primary_by_angle(monkeypatch):
+    monkeypatch.setattr(
+        vertex_mod,
+        "get_vertex",
+        lambda *args, **kwargs: (np.array([0.0, 0.0, 0.0], dtype=np.float32), "track"),
+    )
+    shower = make_particle(
+        shape=SHOWR_SHP,
+        start_point=(2.0, 0.0, 0.0),
+        start_dir=(1.0, 0.0, 0.0),
+        is_primary=False,
+    )
+    inter = SimpleNamespace(
+        is_truth=False,
+        particles=[shower],
+        vertex=np.full(3, -1.0, dtype=np.float32),
+    )
+    processor = vertex_mod.VertexProcessor(
+        run_mode="reco",
+        update_primaries=True,
+        touching_threshold=1.0,
+        angle_threshold=0.5,
+    )
+
+    processor.reconstruct_vertex_single(inter)
+
+    assert shower.is_primary is True

--- a/test/test_utils/test_factory.py
+++ b/test/test_utils/test_factory.py
@@ -49,6 +49,22 @@ def test_parse_module_config_can_sort_lower_priority_first():
     assert list(parsed) == ["early", "late", "default_order"]
 
 
+def test_parse_module_config_can_sort_higher_priority_first():
+    parsed = parse_module_config(
+        OrderedDict(
+            [
+                ("late", {"name": "alpha", "priority": 10}),
+                ("early", {"name": "beta", "priority": 20}),
+                ("default_order", {"name": "alpha"}),
+            ]
+        ),
+        sort_by_priority=True,
+        priority_descending=True,
+    )
+
+    assert list(parsed) == ["early", "late", "default_order"]
+
+
 def test_parse_module_config_validates_blocks():
     with pytest.raises(TypeError, match="must be a mapping"):
         parse_module_config([])


### PR DESCRIPTION
## Summary

Modernizes the analysis and post-processing module infrastructure, consolidates duplicated manager logic, strengthens configuration handling, adds type annotations, and substantially expands unit-test coverage.

## Main changes

- Added a shared `ModuleManager` for executing ordered modules on single entries and batches.
- Updated `AnaManager` and `PostManager` to use the shared manager implementation.
- Typed managers directly against `AnaBase` and `PostBase`.
- Added reusable module-configuration parsing with:
  - deterministic priority ordering;
  - support for repeated module instances through an explicit `name`;
  - preservation of the input configuration;
  - optional `None` entries;
  - validation of malformed module blocks.
- Updated analysis and post-processing factories so they no longer mutate caller-provided configurations.
- Added modern type annotations and clearer documentation throughout the analysis and post-processing packages.
- Replaced configuration-related assertions with explicit `ValueError`, `TypeError`, and `KeyError` exceptions.

## Behavioral fixes

- Correctly expands semantic-segmentation logits and scores from deghosted points back onto the original point set.
- Prevents meaningless per-shape clustering metrics from being produced for interactions.
- Corrects mixed-shape indexing and distance lookup in graph-edge diagnostics.
- Corrects detailed ghost-score construction.
- Corrects charge-weighted barycenter calculation and optical-coordinate indexing.
- Records scalar barycenter match distances as flash-match scores.
- Enables the `protons_to_points` shower conversion-distance mode.
- Safely handles interactions containing no nonempty particles during calorimetric direction reconstruction.
- Produces deterministic CSV attribute ordering.
- Covers propagation of field-corrected coordinates to truth particles, interactions, and reference tensors.

## Configuration impact

Existing module configurations remain supported. Modules may now also be instantiated more than once by using distinct labels and specifying the concrete implementation with `name`, for example:

    first_instance:
      name: calibration
      priority: 20

    second_instance:
      name: calibration
      priority: 10

Modules with explicit priorities run in descending priority order. Modules without priorities retain their relative configuration order after prioritized modules.

Invalid configurations now raise specific exceptions rather than relying on assertions.

## Testing

- Added comprehensive tests for analysis bases, managers, factories, metrics, diagnostics, calibration tools, and CSV output.
- Added comprehensive tests for post-processing bases, managers, factories, reconstruction modules, matching, optical processing, triggers, and truth utilities.
- Added regression coverage for deghosted segmentation, interaction clustering metrics, and truth corrected-point propagation.
- Analysis and post-processing suites: 187 passed.
- Broader calibration, analysis, post-processing, conditional-import, and utility suites: 293 passed.
- Black, isort, flake8, pre-commit checks, and `git diff --check` pass.