### PR TITLE
Main

### DIFF
--- a/src/spine/io/augment/jitter.py
+++ b/src/spine/io/augment/jitter.py
@@ -103,10 +103,6 @@ class JitterAugment(AugmentBase):
             Updated data dictionary and unchanged metadata
         """
         # Generate offsets and deduplication index once, shared across all keys.
-        # All coordinate-carrying keys must stay row-aligned after jitter so that
-        # label tensors remain correctly paired with data tensors.  Independent
-        # offsets per key would break that alignment and also produce different
-        # collision patterns, so we compute them from the first valid key.
         offsets = None
         keep_idx = None  # None = no collisions, all rows kept
 

--- a/src/spine/io/augment/jitter.py
+++ b/src/spine/io/augment/jitter.py
@@ -102,18 +102,42 @@ class JitterAugment(AugmentBase):
         Tuple[Dict[str, Any], Meta]
             Updated data dictionary and unchanged metadata
         """
+        # Generate offsets and deduplication index once, shared across all keys.
+        # All coordinate-carrying keys must stay row-aligned after jitter so that
+        # label tensors remain correctly paired with data tensors.  Independent
+        # offsets per key would break that alignment and also produce different
+        # collision patterns, so we compute them from the first valid key.
+        offsets = None
+        keep_idx = None  # None = no collisions, all rows kept
+
         for key in keys:
             if isinstance(data[key], Meta):
                 continue
 
             coords = data[key].coords
-            offsets = self.generate_offsets(len(coords))
-            coords = coords + offsets
+
+            if offsets is None:
+                offsets = self.generate_offsets(len(coords))
+
+            coords = (coords + offsets).astype(data[key].coords.dtype)
 
             if self.clip:
                 coords = np.clip(coords, 0, meta.count - 1)
 
-            data[key].coords = coords.astype(data[key].coords.dtype)
+            # On the first data key, detect coordinate collisions caused by
+            # jitter.  ME will silently deduplicate them later, which breaks
+            # the TensorBatch count invariant.  Deduplicate here instead so
+            # all keys stay consistent.
+            if keep_idx is None:
+                _, unique_idx = np.unique(coords, axis=0, return_index=True)
+                if len(unique_idx) < len(coords):
+                    keep_idx = np.sort(unique_idx)
+
+            if keep_idx is not None:
+                coords = coords[keep_idx]
+                data[key].features = data[key].features[keep_idx]
+
+            data[key].coords = coords
             data[key].meta = meta
 
         return data, meta


### PR DESCRIPTION
## Description
Avoid jittering into the same coords and duplicating per coords keys

## Motivation and Context
The old jitter would cause ME deconv'ed tensor to a different size from the input at the same resolution.
 
Fixes #(issue)

## Type of Change
Please delete options that are not relevant.

- [ Bug fix (non-breaking change which fixes an issue) ]
- [ Documentation update ]

## How Has This Been Tested?
Describe the tests you ran to verify your changes. Provide instructions so reviewers can reproduce.

- [pytest spine/test/test_io/ -v -k "jitter or augment"]

**Test Configuration**:
- OS: ["Ubuntu 22.04.3 LTS]
- Python version: [Python 3.10.12, pytest-8.3.5, pluggy-1.5.0]
- SPINE version: [main branch, commit c4d3b1313df7768b2e815e6378102cd104a339aa]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots / Event Displays (if applicable)
Add any relevant figures, plots, or event displays that demonstrate the changes.

## Additional Notes
Any additional information that reviewers should know.
