### PR TITLE
Add backend-neutral sparse model API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,15 @@ jobs:
             python -m pip install --root-user-action=ignore -e . pytest pytest-cov coverage[toml]
             mkdir -p /tmp/spine-sitecustomize
             printf "import h5py\n" > /tmp/spine-sitecustomize/sitecustomize.py
-            NUMBA_DISABLE_JIT=1 PYTHONPATH="/tmp/spine-sitecustomize:${PYTHONPATH:-}" pytest test \
+            test_paths=()
+            for path in test/*; do
+              if [[ "$path" != "test/test_model" && \
+                    ( -d "$path" || "$path" == test/test_*.py ) ]]; then
+                test_paths+=("$path")
+              fi
+            done
+            test_paths+=("test/test_model/test_sparse")
+            NUMBA_DISABLE_JIT=1 PYTHONPATH="/tmp/spine-sitecustomize:${PYTHONPATH:-}" pytest "${test_paths[@]}" \
               -v \
               --cov=spine \
               --cov-report=xml:coverage.xml \

--- a/bin/output/README.md
+++ b/bin/output/README.md
@@ -1,3 +1,25 @@
 # Output Scripts
 
 Utilities for checking SPINE processing outputs.
+
+## Compare two HDF5 outputs
+
+`output_compare.py` compares two SPINE HDF5 files event by event. HDF5 region
+references are dereferenced before comparison, so differences in file layout or
+dataset order do not affect the result. Integer, boolean, and string values must
+match exactly; floating-point values use relative and absolute tolerances.
+
+```bash
+python3 bin/output/output_compare.py reference.h5 candidate.h5
+```
+
+The default floating-point tolerances are `rtol=1e-4` and `atol=1e-6`. Use
+exact comparison for deterministic CPU validation:
+
+```bash
+python3 bin/output/output_compare.py reference_cpu.h5 candidate_cpu.h5 --exact
+```
+
+Individual products can be selected or omitted with `--keys` and
+`--skip-keys`, respectively. A mismatch returns exit status 1, which makes the
+script suitable for automated validation.

--- a/bin/output/output_compare.py
+++ b/bin/output/output_compare.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+"""Compare the event content of two SPINE HDF5 output files.
+
+The comparison is semantic rather than bytewise. Event region references are
+dereferenced, structured data products are compared field by field, and HDF5
+layout details such as dataset order and object addresses are ignored.
+
+Integer, boolean, and string values must always agree exactly. Floating-point
+values are compared with configurable absolute and relative tolerances, unless
+``--exact`` is requested.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+
+
+@dataclass
+class ComparisonResult:
+    """Accumulate comparison statistics and human-readable differences.
+
+    Attributes
+    ----------
+    num_events : int
+        Number of events compared.
+    num_products : int
+        Number of event-level data products compared.
+    num_values : int
+        Number of scalar leaf values compared.
+    num_mismatches : int
+        Total number of comparison failures. A failure may describe a shape,
+        schema, or one-or-more-value mismatch.
+    max_abs_diff : float
+        Largest absolute floating-point difference observed.
+    max_rel_diff : float
+        Largest relative floating-point difference observed. This is infinite
+        when a nonzero candidate value is compared with a zero reference.
+    differences : list[str]
+        First ``max_differences`` human-readable mismatch descriptions.
+    max_differences : int
+        Maximum number of descriptions retained while counting all failures.
+    """
+
+    num_events: int = 0
+    num_products: int = 0
+    num_values: int = 0
+    num_mismatches: int = 0
+    max_abs_diff: float = 0.0
+    max_rel_diff: float = 0.0
+    differences: list[str] = field(default_factory=list)
+    max_differences: int = 20
+
+    @property
+    def agrees(self) -> bool:
+        """Return whether no comparison failures were found."""
+        return self.num_mismatches == 0
+
+    def add_difference(self, path: str, message: str) -> None:
+        """Record one mismatch while bounding retained report text.
+
+        Parameters
+        ----------
+        path : str
+            Event/product path at which the mismatch occurred.
+        message : str
+            Concise description of the mismatch.
+        """
+        self.num_mismatches += 1
+        if len(self.differences) < self.max_differences:
+            self.differences.append(f"{path}: {message}")
+
+
+def load_event_value(in_file: h5py.File, event: np.void, key: str) -> Any:
+    """Load one event-level value from a SPINE HDF5 file.
+
+    This mirrors the dereferencing performed by
+    :class:`spine.io.read.HDF5Reader`, but deliberately leaves serialized
+    objects as NumPy structured arrays. Avoiding class reconstruction makes
+    the utility usable across SPINE versions and exposes precise field paths
+    in mismatch reports.
+
+    Parameters
+    ----------
+    in_file : h5py.File
+        Open SPINE HDF5 file.
+    event : numpy.void
+        Structured row from the file's ``events`` dataset.
+    key : str
+        Event data-product name.
+
+    Returns
+    -------
+    Any
+        Dereferenced event value.
+    """
+    region_ref = event[key]
+    dataset = in_file[key]
+
+    if isinstance(dataset, h5py.Dataset):
+        value = dataset[region_ref]
+        if bool(dataset.attrs.get("scalar", False)):
+            value = value[0]
+        elif dataset.ndim > 1:
+            value = value.reshape(-1, dataset.shape[1])
+        return value
+
+    if isinstance(dataset, h5py.Group):
+        index = dataset["index"]
+        element_refs = index[region_ref].flatten()
+        if index.ndim == 1:
+            elements = dataset["elements"]
+            values = np.empty(len(element_refs), dtype=object)
+            for idx, reference in enumerate(element_refs):
+                value = elements[reference]
+                if elements.ndim > 1:
+                    value = value.reshape(-1, elements.shape[1])
+                values[idx] = value
+            return values
+
+        values = []
+        for idx, reference in enumerate(element_refs):
+            elements = dataset[f"element_{idx}"]
+            value = elements[reference]
+            if elements.ndim > 1:
+                value = value.reshape(-1, elements.shape[1])
+            values.append(value)
+        return values
+
+    raise TypeError(f"Data product '{key}' is neither a dataset nor a group.")
+
+
+def _format_index(index: tuple[int, ...]) -> str:
+    """Format a NumPy index for inclusion in a comparison path."""
+    return "".join(f"[{value}]" for value in index)
+
+
+def _compare_float_arrays(
+    reference: np.ndarray,
+    candidate: np.ndarray,
+    path: str,
+    result: ComparisonResult,
+    rtol: float,
+    atol: float,
+    exact: bool,
+) -> None:
+    """Compare floating-point arrays and update numeric diagnostics."""
+    result.num_values += reference.size
+    if not reference.size:
+        return
+
+    finite_pairs = np.isfinite(reference) & np.isfinite(candidate)
+    if np.any(finite_pairs):
+        abs_diff = np.abs(candidate[finite_pairs] - reference[finite_pairs])
+        result.max_abs_diff = max(result.max_abs_diff, float(np.max(abs_diff)))
+        denominator = np.abs(reference[finite_pairs])
+        rel_diff = np.divide(
+            abs_diff,
+            denominator,
+            out=np.full(abs_diff.shape, np.inf, dtype=np.float64),
+            where=denominator != 0,
+        )
+        zero_equal = (denominator == 0) & (abs_diff == 0)
+        rel_diff[zero_equal] = 0.0
+        result.max_rel_diff = max(result.max_rel_diff, float(np.max(rel_diff)))
+
+    if exact:
+        matches = (reference == candidate) | (np.isnan(reference) & np.isnan(candidate))
+    else:
+        matches = np.isclose(reference, candidate, rtol=rtol, atol=atol, equal_nan=True)
+
+    if np.all(matches):
+        return
+
+    mismatch_count = int(np.count_nonzero(~matches))
+    mismatch_index = tuple(np.argwhere(~matches)[0])
+    indexed_path = f"{path}{_format_index(mismatch_index)}"
+    ref_value = reference[mismatch_index]
+    candidate_value = candidate[mismatch_index]
+    result.add_difference(
+        indexed_path,
+        (
+            f"floating values differ ({ref_value!r} != {candidate_value!r}); "
+            f"{mismatch_count}/{reference.size} values outside tolerance"
+        ),
+    )
+
+
+def compare_values(
+    reference: Any,
+    candidate: Any,
+    path: str,
+    result: ComparisonResult,
+    rtol: float,
+    atol: float,
+    exact: bool,
+) -> None:
+    """Recursively compare two dereferenced HDF5 values.
+
+    Parameters
+    ----------
+    reference, candidate : Any
+        Values loaded from the reference and candidate files.
+    path : str
+        Human-readable path to the values.
+    result : ComparisonResult
+        Mutable accumulator for statistics and differences.
+    rtol, atol : float
+        Relative and absolute floating-point tolerances.
+    exact : bool
+        If `True`, require bit-for-bit floating-point equality, with NaNs at
+        matching positions treated as equal.
+    """
+    reference = np.asarray(reference)
+    candidate = np.asarray(candidate)
+
+    if reference.shape != candidate.shape:
+        result.add_difference(
+            path, f"shape differs ({reference.shape} != {candidate.shape})"
+        )
+        return
+
+    ref_fields = reference.dtype.names
+    candidate_fields = candidate.dtype.names
+    if ref_fields is not None or candidate_fields is not None:
+        if ref_fields != candidate_fields:
+            result.add_difference(
+                path, f"structured fields differ ({ref_fields} != {candidate_fields})"
+            )
+            return
+        for name in ref_fields or ():
+            compare_values(
+                reference[name],
+                candidate[name],
+                f"{path}.{name}",
+                result,
+                rtol,
+                atol,
+                exact,
+            )
+        return
+
+    if reference.dtype != candidate.dtype:
+        result.add_difference(
+            path, f"dtype differs ({reference.dtype} != {candidate.dtype})"
+        )
+        return
+
+    if reference.dtype.kind == "O":
+        for index in np.ndindex(reference.shape):
+            compare_values(
+                reference[index],
+                candidate[index],
+                f"{path}{_format_index(index)}",
+                result,
+                rtol,
+                atol,
+                exact,
+            )
+        return
+
+    if reference.dtype.kind in "fc" and candidate.dtype.kind in "fc":
+        _compare_float_arrays(reference, candidate, path, result, rtol, atol, exact)
+        return
+
+    result.num_values += reference.size
+    matches = reference == candidate
+    if np.all(matches):
+        return
+
+    mismatch_count = int(np.count_nonzero(~matches))
+    mismatch_index = tuple(np.argwhere(~matches)[0])
+    indexed_path = f"{path}{_format_index(mismatch_index)}"
+    result.add_difference(
+        indexed_path,
+        (
+            f"values differ ({reference[mismatch_index]!r} != "
+            f"{candidate[mismatch_index]!r}); "
+            f"{mismatch_count}/{reference.size} values differ"
+        ),
+    )
+
+
+def compare_files(
+    reference_path: str | Path,
+    candidate_path: str | Path,
+    *,
+    rtol: float = 1.0e-4,
+    atol: float = 1.0e-6,
+    exact: bool = False,
+    keys: list[str] | None = None,
+    skip_keys: list[str] | None = None,
+    max_differences: int = 20,
+) -> ComparisonResult:
+    """Compare the event content of two SPINE HDF5 output files.
+
+    Parameters
+    ----------
+    reference_path, candidate_path : str or pathlib.Path
+        Paths to the reference and candidate SPINE HDF5 files.
+    rtol : float, default 1e-4
+        Relative tolerance for floating-point values.
+    atol : float, default 1e-6
+        Absolute tolerance for floating-point values near zero.
+    exact : bool, default False
+        Require exact floating-point equality. The tolerance arguments are
+        ignored when this option is enabled.
+    keys : list[str], optional
+        Restrict comparison to these event data products.
+    skip_keys : list[str], optional
+        Event data products to omit from the comparison.
+    max_differences : int, default 20
+        Maximum number of mismatch descriptions retained in the result.
+
+    Returns
+    -------
+    ComparisonResult
+        Comparison statistics and mismatch descriptions.
+    """
+    if rtol < 0 or atol < 0:
+        raise ValueError("Floating-point tolerances must be nonnegative.")
+    if max_differences < 0:
+        raise ValueError("max_differences must be nonnegative.")
+
+    result = ComparisonResult(max_differences=max_differences)
+    with (
+        h5py.File(reference_path, "r") as reference_file,
+        h5py.File(candidate_path, "r") as candidate_file,
+    ):
+        for label, in_file in (
+            ("reference", reference_file),
+            ("candidate", candidate_file),
+        ):
+            if "events" not in in_file:
+                result.add_difference(label, "file has no 'events' dataset")
+                return result
+            if not isinstance(in_file["events"], h5py.Dataset):
+                result.add_difference(label, "'events' is not a dataset")
+                return result
+
+        reference_events = reference_file["events"]
+        candidate_events = candidate_file["events"]
+        if len(reference_events) != len(candidate_events):
+            result.add_difference(
+                "events",
+                f"count differs ({len(reference_events)} != {len(candidate_events)})",
+            )
+            return result
+
+        reference_keys = set(reference_events.dtype.names or ())
+        candidate_keys = set(candidate_events.dtype.names or ())
+        requested_keys = set(keys) if keys is not None else reference_keys
+        skipped_keys = set(skip_keys or ())
+        selected_keys = requested_keys - skipped_keys
+
+        missing_reference = selected_keys - reference_keys
+        missing_candidate = selected_keys - candidate_keys
+        if missing_reference:
+            result.add_difference(
+                "events",
+                f"reference is missing products {sorted(missing_reference)}",
+            )
+        if missing_candidate:
+            result.add_difference(
+                "events",
+                f"candidate is missing products {sorted(missing_candidate)}",
+            )
+        if keys is None:
+            extra_candidate = (candidate_keys - reference_keys) - skipped_keys
+            if extra_candidate:
+                result.add_difference(
+                    "events",
+                    f"candidate has extra products {sorted(extra_candidate)}",
+                )
+
+        common_keys = sorted(selected_keys & reference_keys & candidate_keys)
+        result.num_events = len(reference_events)
+        result.num_products = len(reference_events) * len(common_keys)
+        for event_idx, (reference_event, candidate_event) in enumerate(
+            zip(reference_events, candidate_events)
+        ):
+            for key in common_keys:
+                path = f"event[{event_idx}].{key}"
+                try:
+                    reference = load_event_value(reference_file, reference_event, key)
+                    candidate = load_event_value(candidate_file, candidate_event, key)
+                    compare_values(
+                        reference,
+                        candidate,
+                        path,
+                        result,
+                        rtol,
+                        atol,
+                        exact,
+                    )
+                except (KeyError, TypeError, ValueError) as error:
+                    result.add_difference(path, str(error))
+
+    return result
+
+
+def format_result(
+    result: ComparisonResult,
+    reference_path: str | Path,
+    candidate_path: str | Path,
+    *,
+    rtol: float,
+    atol: float,
+    exact: bool,
+) -> str:
+    """Format a complete command-line report for a comparison result."""
+    mode = "exact" if exact else f"rtol={rtol:g}, atol={atol:g}"
+    status = "PASS" if result.agrees else "FAIL"
+    lines = [
+        f"{status}: {reference_path} vs {candidate_path}",
+        f"Mode: {mode}",
+        (
+            f"Compared: {result.num_events} events, "
+            f"{result.num_products} event products, "
+            f"{result.num_values} scalar values"
+        ),
+        (
+            f"Maximum floating difference: abs={result.max_abs_diff:.8g}, "
+            f"rel={result.max_rel_diff:.8g}"
+        ),
+    ]
+    if not result.agrees:
+        lines.append(f"Mismatches: {result.num_mismatches}")
+        lines.extend(f"- {difference}" for difference in result.differences)
+        hidden = result.num_mismatches - len(result.differences)
+        if hidden > 0:
+            lines.append(f"- ... {hidden} additional mismatches not shown")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Compare the event content of two SPINE HDF5 output files."
+    )
+    parser.add_argument("reference", help="Reference SPINE HDF5 file.")
+    parser.add_argument("candidate", help="Candidate SPINE HDF5 file.")
+    parser.add_argument(
+        "--rtol",
+        type=float,
+        default=1.0e-4,
+        help="Relative floating-point tolerance (default: %(default)g).",
+    )
+    parser.add_argument(
+        "--atol",
+        type=float,
+        default=1.0e-6,
+        help="Absolute floating-point tolerance (default: %(default)g).",
+    )
+    parser.add_argument(
+        "--exact",
+        action="store_true",
+        help="Require exact floating-point agreement; ignore tolerances.",
+    )
+    parser.add_argument(
+        "--keys",
+        nargs="+",
+        help="Compare only the listed event data products.",
+    )
+    parser.add_argument(
+        "--skip-keys",
+        nargs="+",
+        help="Omit the listed event data products.",
+    )
+    parser.add_argument(
+        "--max-differences",
+        type=int,
+        default=20,
+        help="Maximum mismatch descriptions to print (default: %(default)d).",
+    )
+    return parser
+
+
+def main() -> int:
+    """Run the command-line HDF5 comparison."""
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        result = compare_files(
+            args.reference,
+            args.candidate,
+            rtol=args.rtol,
+            atol=args.atol,
+            exact=args.exact,
+            keys=args.keys,
+            skip_keys=args.skip_keys,
+            max_differences=args.max_differences,
+        )
+    except (OSError, ValueError) as error:
+        parser.error(str(error))
+
+    print(
+        format_result(
+            result,
+            args.reference,
+            args.candidate,
+            rtol=args.rtol,
+            atol=args.atol,
+            exact=args.exact,
+        )
+    )
+    return 0 if result.agrees else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/spine/bin/cli.py
+++ b/src/spine/bin/cli.py
@@ -5,6 +5,8 @@ import argparse
 import os
 import pathlib
 import sys
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
 from warnings import warn
 
 from spine.banner import ascii_logo
@@ -424,10 +426,8 @@ def check_dependencies():
 
     # Check ML dependencies
     try:
-        import MinkowskiEngine
-
-        deps["minkowski"] = MinkowskiEngine.__version__
-    except ImportError:
+        deps["minkowski"] = package_version("MinkowskiEngine")
+    except PackageNotFoundError:
         deps["minkowski"] = None
 
     return deps

--- a/src/spine/data/batch/__init__.py
+++ b/src/spine/data/batch/__init__.py
@@ -1,5 +1,6 @@
 """Data structures used to store batched data."""
 
+from .base import TensorBatchConvertible
 from .edge_index import EdgeIndexBatch
 from .index import IndexBatch
 from .tensor import TensorBatch

--- a/src/spine/data/batch/base.py
+++ b/src/spine/data/batch/base.py
@@ -4,21 +4,26 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, runtime_checkable
 
 import numpy as np
 
-from spine.utils.conditional import SparseTensorLike, is_sparse_tensor_like, torch
+from spine.utils.conditional import torch
 from spine.utils.docstring import merge_ancestor_docstrings
 
 if TYPE_CHECKING:  # pragma: no cover
     ArrayLike: TypeAlias = np.ndarray | torch.Tensor
-    BatchData: TypeAlias = (
-        ArrayLike | SparseTensorLike | list[np.ndarray] | list[torch.Tensor]
-    )
+    BatchData: TypeAlias = ArrayLike | list[np.ndarray] | list[torch.Tensor]
 else:
     ArrayLike: TypeAlias = Any
     BatchData: TypeAlias = Any
+
+
+@runtime_checkable
+class TensorBatchConvertible(Protocol):
+    """Model-runtime object with a portable tensor-batch representation."""
+
+    def to_tensor_batch(self) -> Any: ...
 
 
 @dataclass(eq=False)
@@ -59,24 +64,21 @@ class BatchBase:
 
     def __init__(
         self,
-        data: ArrayLike | SparseTensorLike,
-        is_sparse: bool = False,
+        data: ArrayLike,
         is_list: bool = False,
     ) -> None:
         """Shared initializations across all types of batched data.
 
         Parameters
         ----------
-        data : Union[np.ndarray, torch.Tensor, ME.SparseTensor]
+        data : Union[np.ndarray, torch.Tensor]
             Batched data
-        is_sparse : bool, default False
-            If initializing from an ME sparse data, flip to True
         is_list : bool, default False
             Whether the underlying data is a list of tensors
         """
         # Store the datatype
-        self.is_numpy = not is_sparse and not isinstance(data, torch.Tensor)
-        self.is_sparse = is_sparse
+        self.is_numpy = not isinstance(data, torch.Tensor)
+        self.is_sparse = False
         self.is_list = is_list
 
         # Store the datatype
@@ -86,13 +88,6 @@ class BatchBase:
         self.device = None
         if isinstance(data, torch.Tensor):
             self.device = data.device
-        elif is_sparse:
-            if not is_sparse_tensor_like(data):
-                raise TypeError(
-                    "Sparse batch data must provide the MinkowskiEngine "
-                    "SparseTensor interface."
-                )
-            self.device = data.F.device
 
     def __len__(self) -> int:
         """Returns the number of entries that make up the batch."""

--- a/src/spine/data/batch/tensor.py
+++ b/src/spine/data/batch/tensor.py
@@ -9,9 +9,9 @@ from typing import Any
 import numpy as np
 
 from spine.constants import BATCH_COL, COORD_COLS
-from spine.utils.conditional import ME, is_sparse_tensor_like, torch
+from spine.utils.conditional import torch
 
-from .base import ArrayLike, BatchBase, SparseTensorLike
+from .base import ArrayLike, BatchBase
 
 __all__ = ["TensorBatch"]
 
@@ -20,33 +20,18 @@ __all__ = ["TensorBatch"]
 class TensorBatch(BatchBase):
     """Batched tensor with the necessary methods to slice it."""
 
-    data: ArrayLike | SparseTensorLike
+    data: ArrayLike
     counts: ArrayLike
     edges: ArrayLike
     batch_size: int
     has_batch_col: bool
     coord_cols: Sequence[int] | np.ndarray | None
 
-    @property
-    def _array_data(self) -> ArrayLike:
-        """Dense tensor data with sparse cases excluded."""
-        if is_sparse_tensor_like(self.data):
-            raise TypeError("TensorBatch data is sparse.")
-        return self.data
-
-    @property
-    def _sparse_data(self) -> SparseTensorLike:
-        """Sparse tensor data with dense cases excluded."""
-        if not is_sparse_tensor_like(self.data):
-            raise TypeError("TensorBatch data is not sparse.")
-        return self.data
-
     def __init__(
         self,
-        data: ArrayLike | SparseTensorLike,
+        data: ArrayLike,
         counts: Sequence[int] | ArrayLike | None = None,
         batch_size: int | None = None,
-        is_sparse: bool = False,
         has_batch_col: bool = False,
         coord_cols: Sequence[int] | np.ndarray | None = None,
     ) -> None:
@@ -54,30 +39,23 @@ class TensorBatch(BatchBase):
 
         Parameters
         ----------
-        data : Union[np.ndarray, torch.Tensor, ME.SparseTensor]
+        data : Union[np.ndarray, torch.Tensor]
             (N, C) Batched tensors
         counts : Union[List[int], np.ndarray, torch.Tensor]
             (B) Number of data rows in each entry
         batch_size : int, optional
             Number of entries that make up the batched data
-        is_sparse : bool, default False
-            If initializing from an ME sparse data, flip to True
         has_batch_col : bool, default False
             Wheather the tensor has a column specifying the batch ID
         coord_cols : Union[List[int], np.ndarray], optional
             List of columns specifying coordinates
         """
         # Initialize the base class
-        super().__init__(data, is_sparse=is_sparse)
+        super().__init__(data)
 
         # Should provide either the counts, or the batch size
         if (counts is not None) == (batch_size is not None):
             raise ValueError("Provide either `counts` or `batch_size`, not both.")
-
-        # If the data is sparse, it must have a batch column and coordinates
-        if is_sparse:
-            has_batch_col = True
-            coord_cols = COORD_COLS
 
         # If the counts are not provided, must build them once
         if counts is None:
@@ -88,17 +66,7 @@ class TensorBatch(BatchBase):
                 raise ValueError("Must provide `batch_size` to infer counts.")
             batch_size_value = batch_size
 
-            if is_sparse:
-                if not is_sparse_tensor_like(data):  # pragma: no cover
-                    raise TypeError(
-                        "Sparse tensor batches must be initialized with "
-                        "MinkowskiEngine-like sparse tensor data."
-                    )
-                ref = data.C
-            else:
-                if is_sparse_tensor_like(data):
-                    raise TypeError("Sparse tensor data must set `is_sparse=True`.")
-                ref = data
+            ref = data
             counts = self.get_counts(ref[:, BATCH_COL], batch_size_value)
         else:
             # If the number of batches is not provided, get it from the counts
@@ -122,7 +90,7 @@ class TensorBatch(BatchBase):
         self.has_batch_col = has_batch_col
         self.coord_cols = coord_cols
 
-    def __getitem__(self, batch_id: int) -> ArrayLike | SparseTensorLike:
+    def __getitem__(self, batch_id: int) -> ArrayLike:
         """Returns a subset of the tensor corresponding to one entry.
 
         Parameters
@@ -139,19 +107,15 @@ class TensorBatch(BatchBase):
 
         # Return
         lower, upper = self.edges[batch_id], self.edges[batch_id + 1]
-        if not self.is_sparse:
-            return self._array_data[lower:upper]
-        else:
-            data = self._sparse_data
-            return ME.SparseTensor(data.F[lower:upper], coordinates=data.C[lower:upper])
+        return self.data[lower:upper]
 
     @property
-    def tensor(self) -> ArrayLike | SparseTensorLike:
+    def tensor(self) -> ArrayLike:
         """Alias for the underlying data stored.
 
         Returns
         -------
-        Union[np.ndarray, torch.Tensor, ME.SparseTensor]
+        Union[np.ndarray, torch.Tensor]
             Underlying tensor of data
         """
         return self.data
@@ -167,7 +131,7 @@ class TensorBatch(BatchBase):
         """
         return self._repeat(self._arange(self.batch_size), self.counts)
 
-    def split(self) -> list[ArrayLike | SparseTensorLike]:
+    def split(self) -> list[ArrayLike]:
         """Breaks up the tensor batch into its constituents.
 
         Returns
@@ -175,16 +139,7 @@ class TensorBatch(BatchBase):
         List[Union[np.ndarray, torch.Tensor]]
             List of one tensor per entry in the batch
         """
-        if not self.is_sparse:
-            return self._split(self._array_data, self.splits)
-        else:
-            data = self._sparse_data
-            coords = self._split(data.C, self.splits)
-            feats = self._split(data.F, self.splits)
-            return [
-                ME.SparseTensor(feats[i], coordinates=coords[i])
-                for i in range(self.batch_size)
-            ]
+        return self._split(self.data, self.splits)
 
     def apply_mask(self, mask: ArrayLike) -> None:
         """Apply a global mask to the underlying tensor, update batching.
@@ -239,12 +194,6 @@ class TensorBatch(BatchBase):
             return self
 
         data = self.data
-        if self.is_sparse:
-            sparse_data = self._sparse_data
-            data = torch.cat(
-                [sparse_data.C.to(dtype=sparse_data.F.dtype), sparse_data.F], dim=1
-            )
-
         data = self._to_numpy(data)
         counts = self._to_numpy(self.counts)
 
@@ -288,7 +237,7 @@ class TensorBatch(BatchBase):
         """
         if not self.is_numpy:
             raise ValueError("Can only convert units of numpy arrays.")
-        data = self._array_data
+        data = self.data
         data[:, COORD_COLS] = meta.to_cm(data[:, COORD_COLS], center=True)
 
     def to_px(self, meta: Any) -> None:
@@ -301,7 +250,7 @@ class TensorBatch(BatchBase):
         """
         if not self.is_numpy:
             raise ValueError("Can only convert units of numpy arrays.")
-        data = self._array_data
+        data = self.data
         data[:, COORD_COLS] = meta.to_px(data[:, COORD_COLS], floor=True)
 
     @classmethod

--- a/src/spine/io/unwrap.py
+++ b/src/spine/io/unwrap.py
@@ -5,7 +5,14 @@ from typing import Any
 import numpy as np
 
 from spine.constants import BATCH_COL
-from spine.data import EdgeIndexBatch, IndexBatch, Meta, ObjectList, TensorBatch
+from spine.data import (
+    EdgeIndexBatch,
+    IndexBatch,
+    Meta,
+    ObjectList,
+    TensorBatch,
+    TensorBatchConvertible,
+)
 from spine.geo import GeoManager
 
 __all__ = ["Unwrapper"]
@@ -101,6 +108,15 @@ class Unwrapper:
             If the input is empty, the batch size is unset, or the type is
             unsupported.
         """
+        if isinstance(data, TensorBatchConvertible):
+            data = data.to_tensor_batch()
+        elif (
+            isinstance(data, list)
+            and len(data)
+            and isinstance(data[0], TensorBatchConvertible)
+        ):
+            data = [value.to_tensor_batch() for value in data]
+
         if isinstance(data, (list, tuple)) and len(data) == 0:
             raise ValueError(f"Batched data for {key} is an empty list, cannot unwrap.")
         if self.batch_size is None:

--- a/src/spine/model/bayes_uresnet.py
+++ b/src/spine/model/bayes_uresnet.py
@@ -1,9 +1,10 @@
 from collections import defaultdict
 
-import MinkowskiEngine as ME
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+from spine.model import sparse
 
 from .experimental.bayes.decoder import MCDropoutDecoder
 from .experimental.bayes.encoder import MCDropoutEncoder
@@ -58,13 +59,11 @@ class BayesianUResNet(torch.nn.Module):
 
         if "edl" in self.model_config.get("loss_fn", "cross_entropy"):
             self.classifier = nn.Sequential(
-                ME.MinkowskiLinear(self.encoder.num_filters, self.num_classes),
-                ME.MinkowskiSoftplus(),
+                sparse.Linear(self.encoder.num_filters, self.num_classes),
+                sparse.Softplus(),
             )
         else:
-            self.classifier = ME.MinkowskiLinear(
-                self.encoder.num_filters, self.num_classes
-            )
+            self.classifier = sparse.Linear(self.encoder.num_filters, self.num_classes)
 
     def mc_forward(self, input, num_samples=None):
         """
@@ -89,7 +88,7 @@ class BayesianUResNet(torch.nn.Module):
 
             device = x.device
 
-            x_sparse = ME.SparseTensor(
+            x_sparse = sparse.SparseTensor(
                 coordinates=x[:, :4].int(), features=x[:, -1].view(-1, 1)
             )
 
@@ -120,7 +119,7 @@ class BayesianUResNet(torch.nn.Module):
         """
         out = defaultdict(list)
         for igpu, x in enumerate(input):
-            x = ME.SparseTensor(
+            x = sparse.SparseTensor(
                 coordinates=x[:, :4].int(), features=x[:, -1].view(-1, 1)
             )
             res_encoder = self.encoder.encoder(x)
@@ -148,7 +147,7 @@ class BayesianUResNet(torch.nn.Module):
         """
         out = defaultdict(list)
         for igpu, x in enumerate(input):
-            x = ME.SparseTensor(
+            x = sparse.SparseTensor(
                 coordinates=x[:, :4].int(), features=x[:, -1].view(-1, 1)
             )
             res_encoder = self.encoder.encoder(x)

--- a/src/spine/model/experimental/bayes/decoder.py
+++ b/src/spine/model/experimental/bayes/decoder.py
@@ -1,7 +1,7 @@
-import MinkowskiEngine as ME
 import torch
 import torch.nn as nn
 
+from spine.model import sparse
 from spine.model.layer.cnn.act_norm import act_factory, norm_factory
 from spine.model.layer.cnn.blocks import DropoutBlock, ResNetBlock
 from spine.model.layer.cnn.configuration import setup_cnn_configuration
@@ -53,7 +53,7 @@ class MCDropoutDecoder(torch.nn.Module):
             m.append(norm_factory(self.norm, self.nPlanes[i + 1], **self.norm_args))
             m.append(act_factory(self.activation_name, **self.activation_args))
             m.append(
-                ME.MinkowskiConvolutionTranspose(
+                sparse.ConvolutionTranspose(
                     in_channels=self.nPlanes[i + 1],
                     out_channels=self.nPlanes[i],
                     kernel_size=2,
@@ -62,7 +62,7 @@ class MCDropoutDecoder(torch.nn.Module):
                 )
             )
             if i in self.dropout_layer_index:
-                m.append(ME.MinkowskiDropout(p=self.dropout_p))
+                m.append(sparse.Dropout(p=self.dropout_p))
             m = nn.Sequential(*m)
             self.decoding_conv.append(m)
             m = []
@@ -113,7 +113,7 @@ class MCDropoutDecoder(torch.nn.Module):
         for i, layer in enumerate(self.decoding_conv):
             eTensor = encoderTensors[-i - 2]
             x = layer(x)
-            x = ME.cat(eTensor, x)
+            x = sparse.cat(eTensor, x)
             x = self.decoding_block[i](x)
             decoderTensors.append(x)
         return decoderTensors

--- a/src/spine/model/experimental/bayes/encoder.py
+++ b/src/spine/model/experimental/bayes/encoder.py
@@ -1,10 +1,9 @@
 from collections import defaultdict
 
-import MinkowskiEngine as ME
-import MinkowskiFunctional as MF
 import torch
 import torch.nn as nn
 
+from spine.model import sparse
 from spine.model.layer.cnn.act_norm import act_factory, norm_factory
 from spine.model.layer.cnn.blocks import DropoutBlock, ResNetBlock
 from spine.model.layer.cnn.configuration import setup_cnn_configuration
@@ -50,7 +49,7 @@ class MCDropoutEncoder(torch.nn.Module):
         # Initialize Input Layer
         if self.coordConv:
             self.input_layer = nn.Sequential(
-                ME.MinkowskiConvolution(
+                sparse.Convolution(
                     in_channels=self.num_input + self.D,
                     out_channels=self.num_filters,
                     kernel_size=self.input_kernel,
@@ -60,7 +59,7 @@ class MCDropoutEncoder(torch.nn.Module):
             )
         else:
             self.input_layer = nn.Sequential(
-                ME.MinkowskiConvolution(
+                sparse.Convolution(
                     in_channels=self.num_input,
                     out_channels=self.num_filters,
                     kernel_size=self.input_kernel,
@@ -109,7 +108,7 @@ class MCDropoutEncoder(torch.nn.Module):
                 m.append(norm_factory(self.norm, F, **self.norm_args))
                 m.append(act_factory(self.activation_name, **self.activation_args))
                 m.append(
-                    ME.MinkowskiConvolution(
+                    sparse.Convolution(
                         in_channels=self.nPlanes[i],
                         out_channels=self.nPlanes[i + 1],
                         kernel_size=2,
@@ -119,7 +118,7 @@ class MCDropoutEncoder(torch.nn.Module):
                     )
                 )
                 if i in self.dropout_layer_index:
-                    m.append(ME.MinkowskiDropout(p=self.dropout_p))
+                    m.append(sparse.Dropout(p=self.dropout_p))
                 else:
                     pass
             m = nn.Sequential(*m)
@@ -128,23 +127,23 @@ class MCDropoutEncoder(torch.nn.Module):
         self.encoding_block = nn.Sequential(*self.encoding_block)
 
         if self.pool_mode == "global_average":
-            self.pool = ME.MinkowskiGlobalPooling()
+            self.pool = sparse.GlobalPooling()
         elif self.pool_mode == "conv":
             self.pool = nn.Sequential(
-                ME.MinkowskiConvolution(
+                sparse.Convolution(
                     in_channels=self.nPlanes[-1],
                     out_channels=self.nPlanes[-1],
                     kernel_size=final_tensor_shape,
                     stride=final_tensor_shape,
                     dimension=self.D,
                 ),
-                ME.MinkowskiDropout(p=self.dropout_p),
-                ME.MinkowskiGlobalPooling(),
+                sparse.Dropout(p=self.dropout_p),
+                sparse.GlobalPooling(),
             )
         elif self.pool_mode == "max":
             self.pool = nn.Sequential(
-                ME.MinkowskiMaxPooling(final_tensor_shape, stride=final_tensor_shape),
-                ME.MinkowskiGlobalPooling(),
+                sparse.MaxPooling(final_tensor_shape, stride=final_tensor_shape),
+                sparse.GlobalPooling(),
             )
         elif self.pool_mode == "no_pooling":
             self.pool = nn.Identity()
@@ -153,8 +152,8 @@ class MCDropoutEncoder(torch.nn.Module):
 
         if self.add_classifier:
             self.linear1 = nn.Sequential(
-                ME.MinkowskiReLU(),
-                ME.MinkowskiLinear(self.nPlanes[-1], self.latent_size),
+                sparse.ReLU(),
+                sparse.Linear(self.nPlanes[-1], self.latent_size),
             )
         else:
             self.linear1 = nn.Identity()
@@ -164,7 +163,7 @@ class MCDropoutEncoder(torch.nn.Module):
         Vanilla UResNet Encoder.
 
         INPUTS:
-            - x (SparseTensor): MinkowskiEngine SparseTensor
+            - x (SparseTensor): SPINE sparse tensor
 
         RETURNS:
             - result (dict): dictionary of encoder output with
@@ -185,7 +184,7 @@ class MCDropoutEncoder(torch.nn.Module):
 
     def forward(self, input_tensor):
 
-        x = ME.SparseTensor(
+        x = sparse.SparseTensor(
             coordinates=input_tensor[:, :4].int(),
             features=input_tensor[:, -1].view(-1, 1).float(),
         )

--- a/src/spine/model/experimental/cluster/transformer_spice.py
+++ b/src/spine/model/experimental/cluster/transformer_spice.py
@@ -1,9 +1,8 @@
-import MinkowskiEngine as ME
-import MinkowskiEngine.MinkowskiOps as me
 import torch
 import torch.nn as nn
 
 from spine.constants import *
+from spine.model import sparse
 from spine.model.experimental.transformers.positional_encodings import (
     FourierEmbeddings,
     get_normalized_coordinates,
@@ -59,7 +58,7 @@ class QueryModule(nn.Module):
         """
         Inputs
         ------
-            x: Input ME.SparseTensor from UResNet output
+            x: Input sparse.SparseTensor from UResNet output
         """
 
         batch_size = len(x.decomposed_coordinates)
@@ -137,7 +136,7 @@ class TransformerSPICE(nn.Module):
         self.spatial_size = torch.Tensor(self.spatial_size).float().to(device)
 
         self.depth = self.model_config.get("depth", 5)
-        self.mask_head = ME.MinkowskiConvolution(
+        self.mask_head = sparse.Convolution(
             num_features,
             self.mask_dim,
             kernel_size=1,
@@ -145,7 +144,7 @@ class TransformerSPICE(nn.Module):
             bias=True,
             dimension=self.D,
         )
-        self.pooling = ME.MinkowskiAvgPooling(kernel_size=2, stride=2, dimension=3)
+        self.pooling = sparse.AvgPooling(kernel_size=2, stride=2, dimension=3)
         self.adc_to_mev = 1.0 / 350.0
 
         # Query Refinement Modules
@@ -190,7 +189,7 @@ class TransformerSPICE(nn.Module):
         Inputs
         ------
             - queries: [B, num_queries, query_dim] torch.Tensor
-            - mask_features: ME.SparseTensor from mask head output
+            - mask_features: sparse.SparseTensor from mask head output
         """
         query_feats = self.layernorm(queries)
         mask_embed = self.instance_to_mask(query_feats)
@@ -209,7 +208,7 @@ class TransformerSPICE(nn.Module):
 
         output_masks = torch.cat(output_masks, dim=0)
         output_coords = torch.cat(coords, dim=0)
-        output_mask = me.SparseTensor(
+        output_mask = sparse.SparseTensor(
             features=output_masks,
             coordinate_manager=mask_features.coordinate_manager,
             coordinate_map_key=mask_features.coordinate_map_key,
@@ -222,7 +221,7 @@ class TransformerSPICE(nn.Module):
                 attn_mask = output_mask
                 for _ in range(num_pooling_steps):
                     attn_mask = self.pooling(attn_mask.float())
-                attn_mask = me.SparseTensor(
+                attn_mask = sparse.SparseTensor(
                     features=(attn_mask.F.detach().sigmoid() < 0.5),
                     coordinate_manager=attn_mask.coordinate_manager,
                     coordinate_map_key=attn_mask.coordinate_map_key,
@@ -310,7 +309,7 @@ class TransformerSPICE(nn.Module):
         normed_coords = get_normalized_coordinates(coords, self.spatial_size)
         normed_feats = feats * self.adc_to_mev
         features = torch.cat([normed_coords, normed_feats], dim=1)
-        x = ME.SparseTensor(
+        x = sparse.SparseTensor(
             coordinates=point_cloud[:, :VALUE_COL].int(), features=features
         )
         encoderOutput = self.encoder(x)

--- a/src/spine/model/experimental/transformers/positional_encodings.py
+++ b/src/spine/model/experimental/transformers/positional_encodings.py
@@ -1,7 +1,8 @@
-import MinkowskiEngine as ME
 import numpy as np
 import torch
 import torch.nn as nn
+
+from spine.model import sparse
 
 """Adapted from https://github.com/JonasSchult/Mask3D with modification."""
 

--- a/src/spine/model/experimental/xai/simple_cnn.py
+++ b/src/spine/model/experimental/xai/simple_cnn.py
@@ -1,6 +1,7 @@
-import MinkowskiEngine as ME
 import torch
 import torch.nn as nn
+
+from spine.model import sparse
 
 
 class ImageClassificationWrapper(nn.Module):

--- a/src/spine/model/graph_spice.py
+++ b/src/spine/model/graph_spice.py
@@ -1,6 +1,5 @@
 """Supervi dense clustering model and its loss."""
 
-import MinkowskiEngine as ME
 import numpy as np
 import torch
 
@@ -14,6 +13,7 @@ from spine.constants import (
 )
 from spine.constants.factory import enum_factory
 from spine.data import IndexBatch, TensorBatch
+from spine.model import sparse
 from spine.utils.cluster.graph import ClusterGraphConstructor
 
 from .layer.cluster import kernel_factory, loss_factory

--- a/src/spine/model/layer/cluster/embeddings.py
+++ b/src/spine/model/layer/cluster/embeddings.py
@@ -1,9 +1,8 @@
-import MinkowskiEngine as ME
-import MinkowskiFunctional as MF
 import numpy as np
 import torch
 import torch.nn as nn
 
+from spine.model import sparse
 from spine.model.layer.cnn.act_norm import act_factory
 from spine.model.layer.cnn.blocks import ResNetBlock
 from spine.model.layer.cnn.configuration import setup_cnn_configuration
@@ -23,7 +22,7 @@ class Attention(nn.Module):
         features = x.F
         features = features * scores
         coords = x.C
-        output = ME.SparseTensor(coordinates=coords, feats=features)
+        output = sparse.SparseTensor(coordinates=coords, feats=features)
         return output
 
 
@@ -31,9 +30,9 @@ class ExpandAs(nn.Module):
     """
     Given a sparse tensor with one dimensional features, expand the
     feature map to given shape and return a newly constructed
-    ME.SparseTensor.
+    sparse.SparseTensor.
 
-        - x (ME.SparseTensor): with x.F.shape[1] == 1
+        - x (sparse.SparseTensor): with x.F.shape[1] == 1
         - shape (tuple)
     """
 
@@ -43,7 +42,7 @@ class ExpandAs(nn.Module):
     def forward(self, x, shape):
         device = x.F.device
         features = x.F.expand(*shape)
-        output = ME.SparseTensor(
+        output = sparse.SparseTensor(
             feats=features, coords_key=x.coords_key, coords_manager=x.coords_man
         )
         return output
@@ -73,13 +72,13 @@ class SPICE(torch.nn.Module):
         self.sigmoid = nn.Sigmoid()
 
         self.outputEmbeddings = nn.Sequential(
-            ME.MinkowskiBatchNorm(self.num_filters, **self.norm_args),
-            ME.MinkowskiLinear(self.num_filters, self.D + self.sigmaDim, bias=False),
+            sparse.BatchNorm(self.num_filters, **self.norm_args),
+            sparse.Linear(self.num_filters, self.D + self.sigmaDim, bias=False),
         )
 
         self.outputSeediness = nn.Sequential(
-            ME.MinkowskiBatchNorm(self.num_filters, **self.norm_args),
-            ME.MinkowskiLinear(self.num_filters, self.seedDim, bias=False),
+            sparse.BatchNorm(self.num_filters, **self.norm_args),
+            sparse.Linear(self.num_filters, self.seedDim, bias=False),
         )
 
         if self.seed_freeze:
@@ -115,7 +114,7 @@ class SPICE(torch.nn.Module):
         if self.coordConv:
             features = torch.cat([normalized_coords, features], dim=1)
 
-        x = ME.SparseTensor(features, coordinates=coords)
+        x = sparse.SparseTensor(features, coordinates=coords)
 
         encoderOutput = self.encoder(x)
         encoderTensors = encoderOutput["encoderTensors"]

--- a/src/spine/model/layer/cluster/graph_spice_embedder.py
+++ b/src/spine/model/layer/cluster/graph_spice_embedder.py
@@ -1,11 +1,11 @@
 """Feature embedding for pixel supervised connected-component clustering."""
 
-import MinkowskiEngine as ME
 import torch
 import torch.nn as nn
 
 from spine.constants import COORD_COLS, VALUE_COL
 from spine.data import TensorBatch
+from spine.model import sparse
 from spine.model.layer.cnn.uresnet_layers import UResNet
 
 __all__ = ["GraphSPICEEmbedder"]
@@ -148,8 +148,8 @@ class GraphSPICEEmbedder(nn.Module):
 
         # Pass it through the backbone UResNet, extract output features
         backbone_data = torch.cat((coords, features), dim=1)
-        result_backbone = self.backbone(backbone_data)
-        output_features = result_backbone["decoder_tensors"][-1].F
+        result_backbone = self.backbone(backbone_data, batch_size=data.batch_size)
+        output_features = result_backbone["decoder_tensors"][-1].aligned_features()
 
         # Convert the output to tensor batches
         coords = TensorBatch(coords, data.counts, coord_cols=COORD_COLS)

--- a/src/spine/model/layer/cnn/act_norm.py
+++ b/src/spine/model/layer/cnn/act_norm.py
@@ -1,7 +1,4 @@
-"""Functions which initialize activation and normalization layers
-used by CNNs. These factories build activations and normalizations layers
-are based on the MinkowskiEngine package.
-"""
+"""Factories for backend-neutral sparse activations and normalizations."""
 
 from copy import deepcopy
 
@@ -12,23 +9,23 @@ __all__ = ["act_factory", "norm_factory"]
 
 def act_dict():
     """Dictionary of valid activation functions."""
-    import MinkowskiEngine as ME
-    import MinkowskiEngine.MinkowskiNonlinearity as MENL
     from torch.nn import Identity
+
+    from spine.model import sparse
 
     from . import nonlinearities
 
     activations = {
         "none": Identity,
-        "relu": ME.MinkowskiReLU,
-        "prelu": ME.MinkowskiPReLU,
-        "selu": ME.MinkowskiSELU,
-        "celu": ME.MinkowskiCELU,
-        "tanh": ME.MinkowskiTanh,
-        "sigmoid": ME.MinkowskiSigmoid,
-        "lrelu": MENL.MinkowskiLeakyReLU,
-        "elu": MENL.MinkowskiELU,
-        "mish": nonlinearities.MinkowskiMish,
+        "relu": sparse.ReLU,
+        "prelu": sparse.PReLU,
+        "selu": sparse.SELU,
+        "celu": sparse.CELU,
+        "tanh": sparse.Tanh,
+        "sigmoid": sparse.Sigmoid,
+        "lrelu": sparse.LeakyReLU,
+        "elu": sparse.ELU,
+        "mish": nonlinearities.Mish,
     }
 
     return activations
@@ -36,16 +33,17 @@ def act_dict():
 
 def norm_dict():
     """Dictionary of valid normalization functions."""
-    import MinkowskiEngine as ME
     from torch.nn import Identity
+
+    from spine.model import sparse
 
     from . import normalizations
 
     norm_layers = {
         "none": Identity,
-        "batch_norm": ME.MinkowskiBatchNorm,
-        "instance_norm": ME.MinkowskiInstanceNorm,
-        "pixel_norm": normalizations.MinkowskiPixelNorm,
+        "batch_norm": sparse.BatchNorm,
+        "instance_norm": sparse.InstanceNorm,
+        "pixel_norm": normalizations.PixelNorm,
     }
 
     return norm_layers

--- a/src/spine/model/layer/cnn/blocks.py
+++ b/src/spine/model/layer/cnn/blocks.py
@@ -1,14 +1,15 @@
 from typing import Union
 
-import MinkowskiEngine as ME
 import numpy as np
 import torch
 import torch.nn as nn
 
+from spine.model import sparse
+
 from .act_norm import act_factory, norm_factory
 
 
-class ConvolutionBlock(ME.MinkowskiNetwork):
+class ConvolutionBlock(sparse.Network):
     """Convolution block which operates a sequence of
     two (convolution + nomalization + activation) steps.
     """
@@ -50,7 +51,7 @@ class ConvolutionBlock(ME.MinkowskiNetwork):
 
         assert dimension > 0
 
-        self.conv1 = ME.MinkowskiConvolution(
+        self.conv1 = sparse.Convolution(
             in_features,
             out_features,
             kernel_size=3,
@@ -62,7 +63,7 @@ class ConvolutionBlock(ME.MinkowskiNetwork):
         self.norm1 = norm_factory(normalization, out_features)
         self.act_fn1 = act_factory(activation)
 
-        self.conv2 = ME.MinkowskiConvolution(
+        self.conv2 = sparse.Convolution(
             out_features,
             out_features,
             kernel_size=3,
@@ -79,12 +80,12 @@ class ConvolutionBlock(ME.MinkowskiNetwork):
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
 
         Returns
         -------
-        ME.SparseTensor
+        sparse.SparseTensor
             Output sparse tensor
         """
         out = self.conv1(x)
@@ -98,7 +99,7 @@ class ConvolutionBlock(ME.MinkowskiNetwork):
         return out
 
 
-class DropoutBlock(ME.MinkowskiNetwork):
+class DropoutBlock(sparse.Network):
     """Convolution block which operates a sequence of
     two (convolution + dropout + nomalization + activation) steps.
     """
@@ -143,7 +144,7 @@ class DropoutBlock(ME.MinkowskiNetwork):
 
         assert dimension > 0
 
-        self.conv1 = ME.MinkowskiConvolution(
+        self.conv1 = sparse.Convolution(
             in_features,
             out_features,
             kernel_size=3,
@@ -152,11 +153,11 @@ class DropoutBlock(ME.MinkowskiNetwork):
             dimension=dimension,
             bias=bias,
         )
-        self.dropout1 = ME.MinkowskiDropout(p=p)
+        self.dropout1 = sparse.Dropout(p=p)
         self.norm1 = norm_factory(normalization, out_features)
         self.act_fn1 = act_factory(activation)
 
-        self.conv2 = ME.MinkowskiConvolution(
+        self.conv2 = sparse.Convolution(
             out_features,
             out_features,
             kernel_size=3,
@@ -165,7 +166,7 @@ class DropoutBlock(ME.MinkowskiNetwork):
             dimension=dimension,
             bias=bias,
         )
-        self.dropout2 = ME.MinkowskiDropout(p=p)
+        self.dropout2 = sparse.Dropout(p=p)
         self.norm2 = norm_factory(normalization, out_features)
         self.act_fn2 = act_factory(activation)
 
@@ -174,12 +175,12 @@ class DropoutBlock(ME.MinkowskiNetwork):
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
 
         Returns
         -------
-        ME.SparseTensor
+        sparse.SparseTensor
             Output sparse tensor
         """
         out = self.conv1(x)
@@ -195,7 +196,7 @@ class DropoutBlock(ME.MinkowskiNetwork):
         return out
 
 
-class ResNetBlock(ME.MinkowskiNetwork):
+class ResNetBlock(sparse.Network):
     """ResNet Block."""
 
     def __init__(
@@ -236,11 +237,11 @@ class ResNetBlock(ME.MinkowskiNetwork):
         assert dimension > 0
 
         if in_features != out_features:
-            self.residual = ME.MinkowskiLinear(in_features, out_features, bias=bias)
+            self.residual = sparse.Linear(in_features, out_features, bias=bias)
         else:
             self.residual = nn.Identity()
 
-        self.conv1 = ME.MinkowskiConvolution(
+        self.conv1 = sparse.Convolution(
             in_features,
             out_features,
             kernel_size=3,
@@ -252,7 +253,7 @@ class ResNetBlock(ME.MinkowskiNetwork):
         self.norm1 = norm_factory(normalization, in_features)
         self.act_fn1 = act_factory(activation)
 
-        self.conv2 = ME.MinkowskiConvolution(
+        self.conv2 = sparse.Convolution(
             out_features,
             out_features,
             kernel_size=3,
@@ -269,12 +270,12 @@ class ResNetBlock(ME.MinkowskiNetwork):
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
 
         Returns
         -------
-        ME.SparseTensor
+        sparse.SparseTensor
             Output sparse tensor
         """
         residual = self.residual(x)
@@ -287,7 +288,7 @@ class ResNetBlock(ME.MinkowskiNetwork):
         return out
 
 
-class AtrousIIBlock(ME.MinkowskiNetwork):
+class AtrousIIBlock(sparse.Network):
     """ResNet-type block with atrous convolutions.
 
     Developed for the ACNN paper: "ACNN: a Full Resolution DCNN for Medical
@@ -327,11 +328,11 @@ class AtrousIIBlock(ME.MinkowskiNetwork):
         self.D = dimension
 
         if in_features != out_features:
-            self.residual = ME.MinkowskiLinear(in_features, out_features)
+            self.residual = sparse.Linear(in_features, out_features)
         else:
             self.residual = nn.Identity()
 
-        self.conv1 = ME.MinkowskiConvolution(
+        self.conv1 = sparse.Convolution(
             in_features,
             out_features,
             kernel_size=3,
@@ -342,7 +343,7 @@ class AtrousIIBlock(ME.MinkowskiNetwork):
         self.norm1 = norm_factory(normalization, out_features)
         self.act_fn1 = act_factory(activation)
 
-        self.conv2 = ME.MinkowskiConvolution(
+        self.conv2 = sparse.Convolution(
             out_features,
             out_features,
             kernel_size=3,
@@ -358,12 +359,12 @@ class AtrousIIBlock(ME.MinkowskiNetwork):
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
 
         Returns
         -------
-        ME.SparseTensor
+        sparse.SparseTensor
             Output sparse tensor
         """
         residual = self.residual(x)
@@ -380,7 +381,7 @@ class AtrousIIBlock(ME.MinkowskiNetwork):
         return out
 
 
-class ResNeXtBlock(ME.MinkowskiNetwork):
+class ResNeXtBlock(sparse.Network):
     """ResNeXt-type block with atrous convolutions.
 
     Notes
@@ -471,11 +472,11 @@ class ResNeXtBlock(ME.MinkowskiNetwork):
         self.paths = []
         for i in range(cardinality):
             m = []
-            m.append(ME.MinkowskiLinear(in_features, num_input))
+            m.append(sparse.Linear(in_features, num_input))
             for j in range(depth):
                 in_C = num_input if j == 0 else num_output
                 m.append(
-                    ME.MinkowskiConvolution(
+                    sparse.Convolution(
                         in_channels=in_C,
                         out_channels=num_output,
                         kernel_size=self.kernels[i],
@@ -489,11 +490,11 @@ class ResNeXtBlock(ME.MinkowskiNetwork):
             m = nn.Sequential(*m)
             self.paths.append(m)
         self.paths = nn.Sequential(*self.paths)
-        self.linear = ME.MinkowskiLinear(out_features, out_features)
+        self.linear = sparse.Linear(out_features, out_features)
 
         # Skip Connection
         if in_features != out_features:
-            self.residual = ME.MinkowskiLinear(in_features, out_features)
+            self.residual = sparse.Linear(in_features, out_features)
         else:
             self.residual = nn.Identity()
 
@@ -502,26 +503,26 @@ class ResNeXtBlock(ME.MinkowskiNetwork):
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
 
         Returns
         -------
-        ME.SparseTensor
+        sparse.SparseTensor
             Output sparse tensor
         """
         residual = self.residual(x)
 
         cat = tuple([layer(x) for layer in self.paths])
 
-        out = ME.cat(cat)
+        out = sparse.cat(cat)
         out = self.linear(out)
         out += residual
 
         return out
 
 
-class SPP(ME.MinkowskiNetwork):
+class SPP(sparse.Network):
     """Spatial Pyramid Pooling.
 
     PSPNet (Pyramid Scene Parsing Network) uses vanilla SPPs, while
@@ -562,20 +563,20 @@ class SPP(ME.MinkowskiNetwork):
         super().__init__(dimension)
 
         if mode == "avg":
-            self.pool_fn = ME.MinkowskiAvgPooling
+            self.pool_fn = sparse.AvgPooling
         elif mode == "max":
-            self.pool_fn = ME.MinkowskiMaxPooling
+            self.pool_fn = sparse.MaxPooling
         elif mode == "sum":
-            self.pool_fn = ME.MinkowskiSumPooling
+            self.pool_fn = sparse.SumPooling
         else:
             raise ValueError("Invalid pooling mode, must be one of \
                 'sum', 'max' or 'average'")
 
-        self.unpool_fn = ME.MinkowskiPoolingTranspose
+        self.unpool_fn = sparse.PoolingTranspose
 
         # Include global pooling as first modules.
-        self.pool = [ME.MinkowskiGlobalPooling(dimension=dimension)]
-        self.unpool = [ME.MinkowskiBroadcast(dimension=dimension)]
+        self.pool = [sparse.GlobalPooling(dimension=dimension)]
+        self.unpool = [sparse.Broadcast(dimension=dimension)]
         multiplier = 1
 
         # Define subregion poolings
@@ -601,19 +602,19 @@ class SPP(ME.MinkowskiNetwork):
                 self.unpool.append(unpooling_layer)
         self.pool = nn.Sequential(*self.pool)
         self.unpool = nn.Sequential(*self.unpool)
-        self.linear = ME.MinkowskiLinear(in_features * multiplier, out_features)
+        self.linear = sparse.Linear(in_features * multiplier, out_features)
 
     def forward(self, input):
         """Pass a tensor through the SPP block.
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
 
         Returns
         -------
-        ME.SparseTensor
+        sparse.SparseTensor
             Output sparse tensor
         """
         cat = []
@@ -625,13 +626,13 @@ class SPP(ME.MinkowskiNetwork):
             else:
                 x = self.unpool[i](x)
             cat.append(x)
-        out = ME.cat(cat)
+        out = sparse.cat(cat)
         out = self.linear(out)
 
         return out
 
 
-class ASPP(ME.MinkowskiNetwork):
+class ASPP(sparse.Network):
     """Atrous Spatial Pyramid Pooling."""
 
     def __init__(
@@ -663,10 +664,10 @@ class ASPP(ME.MinkowskiNetwork):
         assert len(dilations) == width
 
         m = []
-        m.append(ME.MinkowskiLinear(in_features, out_features))
+        m.append(sparse.Linear(in_features, out_features))
         for d in dilations:
             m.append(
-                ME.MinkowskiConvolution(
+                sparse.Convolution(
                     in_features,
                     out_features,
                     kernel_size=3,
@@ -675,18 +676,18 @@ class ASPP(ME.MinkowskiNetwork):
                 )
             )
         self.net = nn.Sequential(*m)
-        self.pool = ME.MinkowskiGlobalPooling(dimension=self.D)
-        self.unpool = ME.MinkowskiBroadcast(dimension=self.D)
+        self.pool = sparse.GlobalPooling(dimension=self.D)
+        self.unpool = sparse.Broadcast(dimension=self.D)
         self.out = nn.Sequential(
-            ME.MinkowskiConvolution(
+            sparse.Convolution(
                 in_features * (2 + width),
                 out_features,
                 kernel_size=3,
                 dilation=1,
                 dimension=self.D,
             ),
-            ME.MinkowskiBatchNorm(out_features),
-            ME.MinkowskiReLU(),
+            sparse.BatchNorm(out_features),
+            sparse.ReLU(),
         )
 
     def forward(self, x):
@@ -694,12 +695,12 @@ class ASPP(ME.MinkowskiNetwork):
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
 
         Returns
         -------
-        ME.SparseTensor
+        sparse.SparseTensor
             Output sparse tensor
         """
         cat = []
@@ -709,11 +710,11 @@ class ASPP(ME.MinkowskiNetwork):
         x_global = self.pool(x)
         x_global = self.unpool(x, x_global)
         cat.append(x_global)
-        out = ME.cat(cat)
+        out = sparse.cat(cat)
         return self.out(out)
 
 
-class CascadeDilationBlock(ME.MinkowskiNetwork):
+class CascadeDilationBlock(sparse.Network):
     """Cascaded Atrous Convolution Block."""
 
     def __init__(
@@ -747,7 +748,7 @@ class CascadeDilationBlock(ME.MinkowskiNetwork):
 
         F = out_features
         m = []
-        self.input_layer = ME.MinkowskiLinear(in_features, F)
+        self.input_layer = sparse.Linear(in_features, F)
         for i in range(depth):
             m.append(ResNetBlock(F, F, dilation=dilations[i], activation=activation))
         self.net = nn.Sequential(*m)
@@ -757,12 +758,12 @@ class CascadeDilationBlock(ME.MinkowskiNetwork):
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
 
         Returns
         -------
-        ME.SparseTensor
+        sparse.SparseTensor
             Output sparse tensor
         """
         x = self.input_layer(x)
@@ -774,7 +775,7 @@ class CascadeDilationBlock(ME.MinkowskiNetwork):
         return sumTensor
 
 
-class MBConv(ME.MinkowskiNetwork):
+class MBConv(sparse.Network):
     """MBConv block."""
 
     def __init__(
@@ -825,7 +826,7 @@ class MBConv(ME.MinkowskiNetwork):
             self.m = nn.Sequential(
                 norm_factory(normalization, in_features),
                 act_factory(activation),
-                ME.MinkowskiConvolution(
+                sparse.Convolution(
                     in_features,
                     out_features,
                     kernel_size=3,
@@ -839,10 +840,10 @@ class MBConv(ME.MinkowskiNetwork):
             self.m = nn.Sequential(
                 norm_factory(normalization, in_features),
                 act_factory(activation),
-                ME.MinkowskiLinear(in_features, self.hidden_dim),
+                sparse.Linear(in_features, self.hidden_dim),
                 norm_factory(normalization, self.hidden_dim),
                 act_factory(activation),
-                ME.MinkowskiChannelwiseConvolution(
+                sparse.ChannelwiseConvolution(
                     self.hidden_dim,
                     kernel_size=kernel_size,
                     stride=stride,
@@ -852,7 +853,7 @@ class MBConv(ME.MinkowskiNetwork):
                 ),
                 norm_factory(normalization, self.hidden_dim),
                 act_factory(activation),
-                ME.MinkowskiLinear(self.hidden_dim, out_features),
+                sparse.Linear(self.hidden_dim, out_features),
             )
 
     def forward(self, x):
@@ -860,12 +861,12 @@ class MBConv(ME.MinkowskiNetwork):
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
 
         Returns
         -------
-        ME.SparseTensor
+        sparse.SparseTensor
             Output sparse tensor
         """
         out = self.m(x)
@@ -873,7 +874,7 @@ class MBConv(ME.MinkowskiNetwork):
         return out
 
 
-class MBResConv(ME.MinkowskiNetwork):
+class MBResConv(sparse.Network):
     """MBResConv block."""
 
     def __init__(
@@ -948,7 +949,7 @@ class MBResConv(ME.MinkowskiNetwork):
             self.connection = nn.Sequential(
                 norm_factory(normalization, in_features),
                 act_factory(activation),
-                ME.MinkowskiLinear(in_features, out_features),
+                sparse.Linear(in_features, out_features),
             )
 
     def forward(self, x):
@@ -956,12 +957,12 @@ class MBResConv(ME.MinkowskiNetwork):
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
 
         Returns
         -------
-        ME.SparseTensor
+        sparse.SparseTensor
             Output sparse tensor
         """
         x_add = self.connection(x)
@@ -972,7 +973,7 @@ class MBResConv(ME.MinkowskiNetwork):
         return out
 
 
-class SEBlock(ME.MinkowskiNetwork):
+class SEBlock(sparse.Network):
     """Squeeze and Excitation block."""
 
     def __init__(self, channels, ratio=8, dimension=3):
@@ -992,24 +993,24 @@ class SEBlock(ME.MinkowskiNetwork):
 
         assert channels // ratio > 0
         assert channels % ratio == 0
-        self.linear1 = ME.MinkowskiLinear(channels, channels // ratio)
-        self.relu = ME.MinkowskiReLU()
-        self.linear2 = ME.MinkowskiLinear(channels // ratio, channels)
-        self.sigmoid = ME.MinkowskiSigmoid()
-        self.pool = ME.MinkowskiGlobalPooling()
-        self.bcst = ME.MinkowskiBroadcastMultiplication()
+        self.linear1 = sparse.Linear(channels, channels // ratio)
+        self.relu = sparse.ReLU()
+        self.linear2 = sparse.Linear(channels // ratio, channels)
+        self.sigmoid = sparse.Sigmoid()
+        self.pool = sparse.GlobalPooling()
+        self.bcst = sparse.BroadcastMultiplication()
 
     def forward(self, x):
         """Pass a tensor through the SE block.
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
 
         Returns
         -------
-        ME.SparseTensor
+        sparse.SparseTensor
             Output sparse tensor
         """
         g = self.pool(x)
@@ -1022,7 +1023,7 @@ class SEBlock(ME.MinkowskiNetwork):
         return x
 
 
-class SEResNetBlock(ME.MinkowskiNetwork):
+class SEResNetBlock(sparse.Network):
     """Squeeze and Excitation ResNet block."""
 
     def __init__(
@@ -1063,11 +1064,11 @@ class SEResNetBlock(ME.MinkowskiNetwork):
         assert dimension > 0
 
         if in_features != out_features:
-            self.residual = ME.MinkowskiLinear(in_features, out_features)
+            self.residual = sparse.Linear(in_features, out_features)
         else:
             self.residual = nn.Identity()
 
-        self.conv1 = ME.MinkowskiConvolution(
+        self.conv1 = sparse.Convolution(
             in_features,
             out_features,
             kernel_size=3,
@@ -1078,7 +1079,7 @@ class SEResNetBlock(ME.MinkowskiNetwork):
         self.norm1 = norm_factory(normalization, out_features)
         self.act_fn1 = act_factory(activation)
 
-        self.conv2 = ME.MinkowskiConvolution(
+        self.conv2 = sparse.Convolution(
             out_features,
             out_features,
             kernel_size=3,
@@ -1096,12 +1097,12 @@ class SEResNetBlock(ME.MinkowskiNetwork):
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
 
         Returns
         -------
-        ME.SparseTensor
+        sparse.SparseTensor
             Output sparse tensor
         """
         residual = self.residual(x)
@@ -1178,7 +1179,7 @@ class MBResConvSE(MBResConv):
             self.connection = nn.Sequential(
                 norm_factory(normalization, in_features),
                 act_factory(activation),
-                ME.MinkowskiLinear(in_features, out_features),
+                sparse.Linear(in_features, out_features),
             )
 
         self.se = SEBlock(out_features, ratio=se_ratio)
@@ -1188,12 +1189,12 @@ class MBResConvSE(MBResConv):
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
 
         Returns
         -------
-        ME.SparseTensor
+        sparse.SparseTensor
             Output sparse tensor
         """
         res = super().forward(x)

--- a/src/spine/model/layer/cnn/encoder.py
+++ b/src/spine/model/layer/cnn/encoder.py
@@ -1,9 +1,9 @@
 """Defines CNN encoder backbones for image feature extraction."""
 
-import MinkowskiEngine as ME
 import torch
 
 from spine.constants import COORD_COLS, VALUE_COL
+from spine.model import sparse
 
 from .uresnet_layers import UResNetEncoder
 
@@ -45,27 +45,27 @@ class SparseResidualEncoder(UResNetEncoder):
 
         if pool_mode == "avg":
             # Average pooling
-            self.pool = ME.MinkowskiGlobalAvgPooling()
+            self.pool = sparse.GlobalAvgPooling()
 
         if pool_mode == "sum":
             # Sum pooling
-            self.pool = ME.MinkowskiGlobalSumPooling()
+            self.pool = sparse.GlobalSumPooling()
 
         elif pool_mode == "max":
             # Max pooling
-            self.pool = ME.MinkowskiGlobalMaxPooling()
+            self.pool = sparse.GlobalMaxPooling()
 
         elif pool_mode == "conv":
             # Strided convolution
             self.pool = torch.nn.Sequential(
-                ME.MinkowskiConvolution(
+                sparse.Convolution(
                     in_channels=self.num_planes[-1],
                     out_channels=self.num_planes[-1],
                     kernel_size=final_tensor_shape,
                     stride=final_tensor_shape,
                     dimension=self.dim,
                 ),
-                ME.MinkowskiGlobalPooling(),
+                sparse.GlobalPooling(),
             )
 
         else:
@@ -76,7 +76,7 @@ class SparseResidualEncoder(UResNetEncoder):
 
         # Initialize the final linear layer
         self.feature_size = feature_size
-        self.linear = ME.MinkowskiLinear(self.num_planes[-1], self.feature_size)
+        self.linear = sparse.Linear(self.num_planes[-1], self.feature_size)
 
     def forward(self, data):
         """Pass one batch of data through the CNN encoder.
@@ -101,7 +101,7 @@ class SparseResidualEncoder(UResNetEncoder):
             features = torch.cat([normalized_coords, features], dim=1)
 
         # Build a sparse tensor
-        x = ME.SparseTensor(coordinates=coords.int(), features=features)
+        x = sparse.SparseTensor(coordinates=coords.int(), features=features)
 
         # Pass through the CNN encoder
         output = super().forward(x)

--- a/src/spine/model/layer/cnn/fpn.py
+++ b/src/spine/model/layer/cnn/fpn.py
@@ -1,12 +1,11 @@
-import MinkowskiEngine as ME
-import MinkowskiFunctional as MF
 import numpy as np
 import torch
 import torch.nn as nn
 
+from spine.model import sparse
+
 from .blocks import *
 from .configuration import setup_cnn_configuration
-from .nonlinearities import MinkowskiLeakyReLU
 
 
 class FPN(torch.nn.Module):
@@ -45,7 +44,7 @@ class FPN(torch.nn.Module):
         self.input_kernel = model_cfg.get("input_kernel", 3)
 
         # Initialize Input Layer
-        self.input_layer = ME.MinkowskiConvolution(
+        self.input_layer = sparse.Convolution(
             in_channels=self.num_input,
             out_channels=self.num_filters,
             kernel_size=self.input_kernel,
@@ -64,10 +63,10 @@ class FPN(torch.nn.Module):
             self.encoding_block.append(m)
             m = []
             if i < self.depth - 1:
-                m.append(ME.MinkowskiBatchNorm(F))
-                m.append(MinkowskiLeakyReLU(negative_slope=self.leakiness))
+                m.append(sparse.BatchNorm(F))
+                m.append(sparse.LeakyReLU(negative_slope=self.leakiness))
                 m.append(
-                    ME.MinkowskiConvolution(
+                    sparse.Convolution(
                         in_channels=self.nPlanes[i],
                         out_channels=self.nPlanes[i + 1],
                         kernel_size=2,
@@ -83,7 +82,7 @@ class FPN(torch.nn.Module):
         # Lateral Connections
         self.lateral = []
         for i, F in enumerate(self.nPlanes[-2::-1]):
-            self.lateral.append(ME.MinkowskiLinear(F, F))
+            self.lateral.append(sparse.Linear(F, F))
         self.lateral = nn.Sequential(*self.lateral)
 
         # Initialize Decoder
@@ -91,10 +90,10 @@ class FPN(torch.nn.Module):
         self.decoding_conv = []
         for i in range(self.depth - 2, -1, -1):
             m = []
-            m.append(ME.MinkowskiBatchNorm(self.nPlanes[i + 1]))
-            m.append(MinkowskiLeakyReLU(negative_slope=self.leakiness))
+            m.append(sparse.BatchNorm(self.nPlanes[i + 1]))
+            m.append(sparse.LeakyReLU(negative_slope=self.leakiness))
             m.append(
-                ME.MinkowskiConvolutionTranspose(
+                sparse.ConvolutionTranspose(
                     in_channels=self.nPlanes[i + 1],
                     out_channels=self.nPlanes[i],
                     kernel_size=2,
@@ -130,7 +129,7 @@ class FPN(torch.nn.Module):
         Vanilla FPN Encoder.
 
         INPUTS:
-            - x (SparseTensor): MinkowskiEngine SparseTensor
+            - x (SparseTensor): SPINE sparse tensor
 
         RETURNS:
             - result (dict): dictionary of encoder output with
@@ -172,7 +171,7 @@ class FPN(torch.nn.Module):
         coords = input[:, 0 : self.D + 1].int()
         features = input[:, self.D + 1 :]
 
-        x = ME.SparseTensor(features, coords=coords)
+        x = sparse.SparseTensor(features, coords=coords)
         encoderOutput = self.encoder(x)
         encoderTensors = encoderOutput["encoderTensors"]
         finalTensor = encoderOutput["finalTensor"]

--- a/src/spine/model/layer/cnn/mobilenet.py
+++ b/src/spine/model/layer/cnn/mobilenet.py
@@ -1,8 +1,8 @@
-import MinkowskiEngine as ME
-import MinkowskiFunctional as MF
 import numpy as np
 import torch
 import torch.nn as nn
+
+from spine.model import sparse
 
 from .act_norm import act_factory
 from .blocks import MBConv, MBResConv, MBResConvSE, SEBlock
@@ -44,7 +44,7 @@ class MobileNetV3(torch.nn.Module):
         self.input_kernel = model_cfg.get("input_kernel", 3)
 
         # Initialize Input Layer
-        self.input_layer = ME.MinkowskiConvolution(
+        self.input_layer = sparse.Convolution(
             in_channels=self.num_input,
             out_channels=self.num_filters,
             kernel_size=self.input_kernel,
@@ -71,10 +71,10 @@ class MobileNetV3(torch.nn.Module):
             self.encoding_block.append(m)
             m = []
             if i < self.depth - 1:
-                m.append(ME.MinkowskiBatchNorm(F))
+                m.append(sparse.BatchNorm(F))
                 m.append(act_factory(self.activation_name, **self.activation_args))
                 m.append(
-                    ME.MinkowskiConvolution(
+                    sparse.Convolution(
                         in_channels=self.nPlanes[i],
                         out_channels=self.nPlanes[i + 1],
                         kernel_size=2,
@@ -92,10 +92,10 @@ class MobileNetV3(torch.nn.Module):
         self.decoding_conv = []
         for i in range(self.depth - 2, -1, -1):
             m = []
-            m.append(ME.MinkowskiBatchNorm(self.nPlanes[i + 1]))
+            m.append(sparse.BatchNorm(self.nPlanes[i + 1]))
             m.append(act_factory(self.activation_name, **self.activation_args))
             m.append(
-                ME.MinkowskiConvolutionTranspose(
+                sparse.ConvolutionTranspose(
                     in_channels=self.nPlanes[i + 1],
                     out_channels=self.nPlanes[i],
                     kernel_size=2,
@@ -126,7 +126,7 @@ class MobileNetV3(torch.nn.Module):
         Vanilla UResNet Encoder.
 
         INPUTS:
-            - x (SparseTensor): MinkowskiEngine SparseTensor
+            - x (SparseTensor): SPINE sparse tensor
 
         RETURNS:
             - result (dict): dictionary of encoder output with
@@ -160,7 +160,7 @@ class MobileNetV3(torch.nn.Module):
             eTensor = encoderTensors[-i - 2]
             x = layer(x)
             # print(x, eTensor)
-            x = ME.cat(eTensor, x)
+            x = sparse.cat(eTensor, x)
             x = self.decoding_block[i](x)
             decoderTensors.append(x)
         return decoderTensors
@@ -169,7 +169,7 @@ class MobileNetV3(torch.nn.Module):
         coordinates = input[:, 0 : self.D + 1].int()
         features = input[:, self.D + 1 :]
 
-        x = ME.SparseTensor(features, coordinates=coordinates)
+        x = sparse.SparseTensor(features, coordinates=coordinates)
         encoderOutput = self.encoder(x)
         encoderTensors = encoderOutput["encoderTensors"]
         finalTensor = encoderOutput["finalTensor"]
@@ -218,7 +218,7 @@ class MB3Encoder(torch.nn.Module):
         self.input_kernel = model_cfg.get("input_kernel", 3)
 
         # Initialize Input Layer
-        self.input_layer = ME.MinkowskiConvolution(
+        self.input_layer = sparse.Convolution(
             in_channels=self.num_input,
             out_channels=self.num_filters,
             kernel_size=self.input_kernel,
@@ -245,10 +245,10 @@ class MB3Encoder(torch.nn.Module):
             self.encoding_block.append(m)
             m = []
             if i < self.depth - 1:
-                m.append(ME.MinkowskiBatchNorm(F))
+                m.append(sparse.BatchNorm(F))
                 m.append(act_factory(self.activation_name, **self.activation_args))
                 m.append(
-                    ME.MinkowskiConvolution(
+                    sparse.Convolution(
                         in_channels=self.nPlanes[i],
                         out_channels=self.nPlanes[i + 1],
                         kernel_size=2,
@@ -266,7 +266,7 @@ class MB3Encoder(torch.nn.Module):
         Vanilla UResNet Encoder.
 
         INPUTS:
-            - x (SparseTensor): MinkowskiEngine SparseTensor
+            - x (SparseTensor): SPINE sparse tensor
 
         RETURNS:
             - result (dict): dictionary of encoder output with
@@ -289,7 +289,7 @@ class MB3Encoder(torch.nn.Module):
         coordinates = input[:, 0 : self.D + 1].int()
         features = input[:, self.D + 1 :]
 
-        x = ME.SparseTensor(features, coordinates=coordinates)
+        x = sparse.SparseTensor(features, coordinates=coordinates)
         encoderOutput = self.encoder(x)
         encoderTensors = encoderOutput["encoderTensors"]
         finalTensor = encoderOutput["finalTensor"]

--- a/src/spine/model/layer/cnn/nonlinearities.py
+++ b/src/spine/model/layer/cnn/nonlinearities.py
@@ -1,10 +1,9 @@
 """Custom non-linear activation functions."""
 
-import MinkowskiEngine as ME
 import torch
 
 
-class MinkowskiMish(torch.nn.Module):
+class Mish(torch.nn.Module):
     """Mish non-linearity layer.
 
     Reference: https://arxiv.org/pdf/1908.08681.pdf
@@ -19,18 +18,16 @@ class MinkowskiMish(torch.nn.Module):
 
         Parameters
         ----------
-        input_data : ME.SparseTensor
+        input_data : sparse.SparseTensor
             Sparse input tensor
 
         Return
         ------
-        ME.SparseTensor
+        sparse.SparseTensor
             Sparse output tensor
         """
         out = torch.nn.functional.softplus(input_data.F)
         out = torch.tanh(out)
         out = out * input_data.F
 
-        return ME.SparseTensor(
-            out, coords_key=input_data.coords_key, coords_manager=input_data.coords_man
-        )
+        return input_data.replace_features(out)

--- a/src/spine/model/layer/cnn/normalizations.py
+++ b/src/spine/model/layer/cnn/normalizations.py
@@ -1,10 +1,9 @@
 """Custom normalization layers."""
 
-import MinkowskiEngine as ME
 import torch
 
 
-class MinkowskiPixelNorm(torch.nn.Module):
+class PixelNorm(torch.nn.Module):
     """Pixel Normalization Layer for Sparse Tensors.
 
     PixelNorm layers were used in NVIDIA's ProGAN.
@@ -24,7 +23,7 @@ class MinkowskiPixelNorm(torch.nn.Module):
             Ensures non-divergent output features
         """
         # Initialize the parent class
-        super(MinkowskiPixelNorm, self).__init__()
+        super().__init__()
 
         # Store the parameters
         self.eps = eps
@@ -34,12 +33,12 @@ class MinkowskiPixelNorm(torch.nn.Module):
 
         Parameters
         ----------
-        input_data : ME.SparseTensor
+        input_data : sparse.SparseTensor
             Sparse input tensor
 
         Return
         ------
-        ME.SparseTensor
+        sparse.SparseTensor
             Sparse output tensor
         """
         features = input_data.F
@@ -47,11 +46,7 @@ class MinkowskiPixelNorm(torch.nn.Module):
         norm = torch.sum(torch.pow(features, 2), dim=1, keepdim=True)
         out = features / (norm + self.eps).sqrt()
 
-        return ME.SparseTensor(
-            out,
-            coordinate_manager=input_data.coordinate_manager,
-            coordinate_map_key=input_data.coordinate_map_key,
-        )
+        return input_data.replace_features(out)
 
     def __repr__(self):
         """Representation of the noamlization layer.
@@ -62,7 +57,7 @@ class MinkowskiPixelNorm(torch.nn.Module):
         return self.__class__.__name__ + suffix
 
 
-class MinkowskiAdaIN(torch.nn.Module):
+class AdaIN(torch.nn.Module):
     """Adaptive Instance Normalization Layer.
 
     Many parts of the code is borrowed from pytorch original
@@ -80,7 +75,7 @@ class MinkowskiAdaIN(torch.nn.Module):
             Ensures non-divergent output features
         """
         # Initialize the parent class
-        super(MinkowskiAdaIN, self).__init__()
+        super().__init__()
 
         # Store parameters
         self.in_channels = in_channels
@@ -131,18 +126,16 @@ class MinkowskiAdaIN(torch.nn.Module):
 
         Parameters
         ----------
-        input_data : ME.SparseTensor
+        input_data : sparse.SparseTensor
             Sparse input tensor
 
         Return
         ------
-        ME.SparseTensor
+        sparse.SparseTensor
             Sparse output tensor
         """
         f = x.F
         norm = (f - f.mean(dim=0)) / (f.var(dim=0) + self.eps).sqrt()
         out = self.weight * norm + self.bias
 
-        return ME.SparseTensor(
-            out, coords_key=input_data.coords_key, coords_manager=input_data.coords_man
-        )
+        return x.replace_features(out)

--- a/src/spine/model/layer/cnn/ppn.py
+++ b/src/spine/model/layer/cnn/ppn.py
@@ -1,7 +1,5 @@
 from collections import Counter
 
-import MinkowskiEngine as ME
-import MinkowskiFunctional as MF
 import numpy as np
 import torch
 import torch.nn as nn
@@ -21,6 +19,7 @@ from spine.constants import (
     VALUE_COL,
 )
 from spine.data import TensorBatch
+from spine.model import sparse
 from spine.utils.logger import logger
 from spine.utils.torch.scripts import cdist_fast
 from spine.utils.weighting import get_class_weights
@@ -185,10 +184,10 @@ class PPN(torch.nn.Module):
         self.ppn_masks = nn.ModuleList()
         for i in range(self.depth - 2, -1, -1):
             m = []
-            m.append(ME.MinkowskiBatchNorm(self.num_planes[i + 1]))
+            m.append(sparse.BatchNorm(self.num_planes[i + 1]))
             m.append(act_factory(self.act_cfg))
             m.append(
-                ME.MinkowskiConvolutionTranspose(
+                sparse.ConvolutionTranspose(
                     in_channels=self.num_planes[i + 1],
                     out_channels=self.num_planes[i],
                     kernel_size=2,
@@ -211,7 +210,7 @@ class PPN(torch.nn.Module):
                 )
             m = nn.Sequential(*m)
             self.decoding_block.append(m)
-            self.ppn_masks.append(ME.MinkowskiLinear(self.num_planes[i], 2))
+            self.ppn_masks.append(sparse.Linear(self.num_planes[i], 2))
 
         self.decoding_block = nn.Sequential(*self.decoding_block)
         self.decoding_conv = nn.Sequential(*self.decoding_conv)
@@ -226,21 +225,21 @@ class PPN(torch.nn.Module):
         )
 
         # Final linear layer for positional regression (dimension size)
-        self.ppn_pixel_pos = ME.MinkowskiLinear(num_output, self.dim)
+        self.ppn_pixel_pos = sparse.Linear(num_output, self.dim)
 
         # Final convolution layer for type classification
-        self.ppn_type = ME.MinkowskiLinear(num_output, self.num_classes)
+        self.ppn_type = sparse.Linear(num_output, self.num_classes)
 
         # Final convolution layer for endpoint prediction
         if self.classify_endpoints:
-            self.ppn_endpoint = ME.MinkowskiLinear(num_output, 2)
+            self.ppn_endpoint = sparse.Linear(num_output, 2)
 
         # Ghost point removal tools
         if self.ghost:
-            logger.debug("Ghost Masking is enabled for MinkPPN.")
+            logger.debug("Ghost masking is enabled for PPN.")
             self.masker = AttentionMask()
             self.merge_concat = MergeConcat()
-            self.ghost_mask = MinkGhostMask(self.dim)
+            self.ghost_mask = GhostMask(self.dim)
 
     def forward(self, final_tensor, decoder_tensors, ghost=None, seg_label=None):
         """Compute the PPN loss for a batch of data.
@@ -280,7 +279,7 @@ class PPN(torch.nn.Module):
                     )
 
                     labels = seg_label.tensor
-                    assert labels.shape[0] == decoder_tensors[-1].tensor.shape[0], (
+                    assert labels.shape[0] == decoder_tensors[-1].reference_size, (
                         "The label tensor length must match that "
                         "of the last UResNet layer"
                     )
@@ -289,29 +288,29 @@ class PPN(torch.nn.Module):
                     ghost_mask_tensor = labels[:, SHAPE_COL] < GHOST_SHP
                 else:
                     # If using predictions, convert the ghost scores to a mask
-                    ghost_coords = ghost.tensor.C
+                    ghost_coords = ghost.C
                     ghost_mask_tensor = 1.0 - torch.argmax(
-                        ghost.tensor.F, dim=1, keepdim=True
+                        ghost.aligned_features(), dim=1, keepdim=True
                     )
 
-                ghost_mask = ME.SparseTensor(
+                ghost_mask = sparse.SparseTensor(
                     ghost_mask_tensor, coordinates=ghost_coords
                 )
 
             # Downsample stride 1 ghost mask to all intermediate decoder layers
             for t in decoder_tensors[::-1]:
-                scaled_ghost_mask = self.ghost_mask(ghost_mask, t.tensor)
-                nonghost_tensor = self.masker(t.tensor, scaled_ghost_mask)
+                scaled_ghost_mask = self.ghost_mask(ghost_mask, t)
+                nonghost_tensor = self.masker(t, scaled_ghost_mask)
                 decoder_feature_maps.append(nonghost_tensor)
 
             decoder_feature_maps = decoder_feature_maps[::-1]
 
         else:
-            decoder_feature_maps = [t.tensor for t in decoder_tensors]
+            decoder_feature_maps = list(decoder_tensors)
 
         # Loop over the PPN decoding path
         ppn_masks, ppn_layers, ppn_coords = [], [], []
-        x = final_tensor.tensor
+        x = final_tensor
         for i, layer in enumerate(self.decoding_conv):
             # Pass the previous features through the decoding convolution
             x = layer(x)
@@ -321,12 +320,12 @@ class PPN(torch.nn.Module):
             if self.ghost:
                 x = self.merge_concat(decoder_tensor, x)
             else:
-                x = ME.cat(decoder_tensor, x)
+                x = sparse.cat(decoder_tensor, x)
 
             # Apply the decoding block, linear layer and sigmoid function
             x = self.decoding_block[i](x)
             scores = self.ppn_masks[i](x)
-            softmax = MF.softmax(scores, dim=1)
+            softmax = sparse.softmax(scores, dim=1)
             mask = softmax.F[:, 1:] > self.mask_score_threshold
 
             # Store the coordinates, raw score logits and score mask
@@ -349,7 +348,7 @@ class PPN(torch.nn.Module):
             x = x * s_expanded.detach()
 
         # Output set of coordinates (should match the last decoder tensor)
-        assert x.C.shape[0] == decoder_tensors[-1].tensor.shape[0], (
+        assert x.C.shape[0] == decoder_tensors[-1].shape[0], (
             "The output of the last PPN layer should be consistent "
             "with the length of the last UResNet decoder layer"
         )
@@ -366,20 +365,31 @@ class PPN(torch.nn.Module):
             ppn_endpoint = self.ppn_endpoint(x)
 
         # X, Y, Z, logits, and prob score
-        ppn_points = TensorBatch(
-            torch.cat([pixel_pos.F, ppn_type.F, ppn_layers[-1].tensor], dim=1),
-            final_counts,
+        point_features = x.replace_features(
+            torch.cat([pixel_pos.F, ppn_type.F, ppn_layers[-1].tensor], dim=1)
+        )
+        ppn_points_unique = point_features.to_tensor_batch(
+            include_coordinates=False,
+        )
+        ppn_points = point_features.to_tensor_batch(
+            include_coordinates=False, restore=True
         )
 
         result = {
             "ppn_points": ppn_points,
+            "ppn_points_unique": ppn_points_unique,
             "ppn_masks": ppn_masks,
             "ppn_layers": ppn_layers,
             "ppn_coords": ppn_coords,
             "ppn_output_coords": ppn_output_coords,
         }
         if self.classify_endpoints:
-            result["ppn_classify_endpoints"] = TensorBatch(ppn_endpoint.F, final_counts)
+            result["ppn_classify_endpoints_unique"] = ppn_endpoint.to_tensor_batch(
+                include_coordinates=False,
+            )
+            result["ppn_classify_endpoints"] = ppn_endpoint.to_tensor_batch(
+                include_coordinates=False, restore=True
+            )
 
         return result
 
@@ -595,6 +605,8 @@ class PPNLoss(torch.nn.modules.loss._Loss):
         ppn_coords,
         ppn_output_coords,
         ppn_classify_endpoints=None,
+        ppn_points_unique=None,
+        ppn_classify_endpoints_unique=None,
         clust_label=None,
         **kwargs,
     ):
@@ -616,6 +628,12 @@ class PPNLoss(torch.nn.modules.loss._Loss):
             Set of coordinates at the very last layer of the PPN
         ppn_classify_endpoins : TensorBatch, optional
             Set of logits associated with end point classification
+        ppn_points_unique : TensorBatch, optional
+            PPN predictions on unique sparse sites. When provided, these are
+            used for voxel-wise losses while ``ppn_points`` remains aligned
+            with the original input rows for downstream consumers.
+        ppn_classify_endpoints_unique : TensorBatch, optional
+            Endpoint logits on unique sparse sites.
         clust_label : TensorBatch, optional
             (N, 1 + D + N_c) Tensor of cluster labels
             - N_c is is the number of cluster labels
@@ -630,6 +648,12 @@ class PPNLoss(torch.nn.modules.loss._Loss):
         # Initialize the basics
         num_layers = len(ppn_layers)
         batch_size = ppn_label.batch_size
+        loss_points = ppn_points if ppn_points_unique is None else ppn_points_unique
+        loss_endpoints = (
+            ppn_classify_endpoints
+            if ppn_classify_endpoints_unique is None
+            else ppn_classify_endpoints_unique
+        )
 
         # If requested, narrow down the list of label points
         if self.point_classes is not None:
@@ -692,8 +716,8 @@ class PPNLoss(torch.nn.modules.loss._Loss):
         positives = torch.cat(positive_list, dim=0).long()
 
         # Downsample the final mask to each PPN layer, apply mask loss
-        downsample = ME.MinkowskiMaxPooling(2, 2, dimension=3)  # TODO
-        mask_tensor = ME.SparseTensor(
+        downsample = sparse.MaxPooling(2, 2, dimension=3)  # TODO
+        mask_tensor = sparse.SparseTensor(
             positives[:, None].float(), coordinates=coords_final.tensor[:, :VALUE_COL]
         )
 
@@ -750,9 +774,9 @@ class PPNLoss(torch.nn.modules.loss._Loss):
             closests = closests[pos_mask]
 
             anchors = coords_final.tensor[:, COORD_COLS] + 0.5
-            pixel_pos = ppn_points.tensor[:, PPN_ROFF_COLS] + anchors
-            pixel_scores = ppn_points.tensor[:, PPN_RPOS_COLS]
-            pixel_logits = ppn_points.tensor[:, PPN_RTYPE_COLS]
+            pixel_pos = loss_points.tensor[:, PPN_ROFF_COLS] + anchors
+            pixel_scores = loss_points.tensor[:, PPN_RPOS_COLS]
+            pixel_logits = loss_points.tensor[:, PPN_RTYPE_COLS]
 
             pixel_pos = pixel_pos[pos_mask]
             pixel_scores = pixel_scores[pos_mask]
@@ -792,9 +816,9 @@ class PPNLoss(torch.nn.modules.loss._Loss):
             # If the upstream models produced endpoint predictions, apply loss.
             # Narrow the problem down to predictions closest to track points
             track_index = torch.where(closest_type_labels == TRACK_SHP)[0]
-            if ppn_classify_endpoints and len(track_index):
+            if loss_endpoints is not None and len(track_index):
                 # Get the end point predictions
-                end_logits = ppn_classify_endpoints.tensor[pos_mask]
+                end_logits = loss_endpoints.tensor[pos_mask]
                 end_logits = end_logits[track_index]
 
                 # Compute the end point classification loss
@@ -858,7 +882,7 @@ class ExpandAs(nn.Module):
 
     Given a sparse tensor with one dimensional features, expand the
     feature map to a given shape and return a newly constructed
-    ME.SparseTensor. This is used to expand a score array and apply
+    sparse.SparseTensor. This is used to expand a score array and apply
     it to the entire feature tensor of the the input.
     """
 
@@ -893,11 +917,7 @@ class ExpandAs(nn.Module):
         else:
             features = features.expand(*shape)
 
-        return ME.SparseTensor(
-            features=features,
-            coordinate_map_key=x.coordinate_map_key,
-            coordinate_manager=x.coordinate_manager,
-        )
+        return x.replace_features(features)
 
 
 class AttentionMask(torch.nn.Module):
@@ -917,7 +937,7 @@ class AttentionMask(torch.nn.Module):
         super().__init__()
 
         # Pruning layer
-        self.prune = ME.MinkowskiPruning()
+        self.prune = sparse.Pruning()
 
         # Store parameters
         self.score_threshold = score_threshold
@@ -927,29 +947,31 @@ class AttentionMask(torch.nn.Module):
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
-        mask : ME.SparseTensor
+        mask : sparse.SparseTensor
             Mask to apply
         """
         assert x.tensor_stride == mask.tensor_stride
 
         device = x.F.device
         # Create a mask sparse tensor in x-coordinates
-        x0 = ME.SparseTensor(
+        x0 = sparse.SparseTensor(
             coordinates=x.C,
             features=torch.zeros(x.F.shape[0], mask.F.shape[1]).to(device),
             coordinate_manager=x.coordinate_manager,
             tensor_stride=x.tensor_stride,
+            source=x,
         )
 
         mask_in_xcoords = x0 + mask
 
-        x_expanded = ME.SparseTensor(
+        x_expanded = sparse.SparseTensor(
             coordinates=mask_in_xcoords.C,
             features=torch.zeros(mask_in_xcoords.F.shape[0], x.F.shape[1]).to(device),
             coordinate_manager=x.coordinate_manager,
             tensor_stride=x.tensor_stride,
+            source=x,
         )
 
         x_expanded = x_expanded + x
@@ -967,25 +989,26 @@ class MergeConcat(torch.nn.Module):
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
-        other : ME.SparseTensor
+        other : sparse.SparseTensor
             Other sparse tensor to merge
 
         Returns
         -------
-        ME.SparseTensor
+        sparse.SparseTensor
             Concatenated sparse tensor
         """
         assert x.tensor_stride == other.tensor_stride
         device = x.F.device
 
         # Create a placeholder tensor with x.C coordinates
-        x0 = ME.SparseTensor(
+        x0 = sparse.SparseTensor(
             coordinates=x.C,
             features=torch.zeros(x.F.shape[0], other.F.shape[1]).to(device),
             coordinate_manager=x.coordinate_manager,
             tensor_stride=x.tensor_stride,
+            source=x,
         )
 
         # Set placeholder values with other.F features by performing
@@ -993,21 +1016,22 @@ class MergeConcat(torch.nn.Module):
         x1 = x0 + other
 
         # Same procedure, but with other
-        x_expanded = ME.SparseTensor(
+        x_expanded = sparse.SparseTensor(
             coordinates=x1.C,
             features=torch.zeros(x1.F.shape[0], x.F.shape[1]).to(device),
             coordinate_manager=x.coordinate_manager,
             tensor_stride=x.tensor_stride,
+            source=x,
         )
 
         x2 = x_expanded + x
 
         # Now x and other share the same coordinates and shape
-        concated = ME.cat(x1, x2)
+        concated = sparse.cat(x1, x2)
         return concated
 
 
-class MinkGhostMask(torch.nn.Module):
+class GhostMask(torch.nn.Module):
     """Ghost mask downsampler.
 
     Downsamples the ghost mask and prunes a tensor with current
@@ -1020,7 +1044,7 @@ class MinkGhostMask(torch.nn.Module):
         super().__init__()
 
         # Initialize the downsampler
-        self.downsample = ME.MinkowskiMaxPooling(2, 2, dimension=3)
+        self.downsample = sparse.MaxPooling(2, 2, dimension=3)
 
         # Set the layer in evaluation mode (no gradients)
         self.eval()
@@ -1030,16 +1054,16 @@ class MinkGhostMask(torch.nn.Module):
 
         Parameters
         ----------
-        ghost_mask : ME.SparseTensor
+        ghost_mask : sparse.SparseTensor
             Current resolution ghost mask
-        premask_tensor : ME.SparseTensor
+        premask_tensor : sparse.SparseTensor
             Current resolution feature map to be pruned
 
         Returns
         -------
-        downsampled_mask : ME.SparseTensor)
+        downsampled_mask : sparse.SparseTensor)
             2x2 downsampled ghost mask
-        downsampled_tensor : ME.SparseTensor
+        downsampled_tensor : sparse.SparseTensor
             2x2 downsampled feature map
         """
         # assert ghost_mask.shape[0] == premask_tensor.shape[0]

--- a/src/spine/model/layer/cnn/senet.py
+++ b/src/spine/model/layer/cnn/senet.py
@@ -1,8 +1,8 @@
-import MinkowskiEngine as ME
-import MinkowskiFunctional as MF
 import numpy as np
 import torch
 import torch.nn as nn
+
+from spine.model import sparse
 
 from .act_norm import act_factory
 from .blocks import *
@@ -34,7 +34,7 @@ class SENet(torch.nn.Module):
         activation_args = self.activation_args
 
         # Initialize Input Layer
-        self.input_layer = ME.MinkowskiConvolution(
+        self.input_layer = sparse.Convolution(
             self.num_input,
             self.num_filters,
             kernel_size=self.input_kernel,
@@ -64,10 +64,10 @@ class SENet(torch.nn.Module):
             self.encoding_block.append(m)
             m = []
             if i < self.depth - 1:
-                m.append(ME.MinkowskiBatchNorm(F))
+                m.append(sparse.BatchNorm(F))
                 m.append(act_factory(activation, **activation_args))
                 m.append(
-                    ME.MinkowskiConvolution(
+                    sparse.Convolution(
                         in_channels=self.nPlanes[i],
                         out_channels=self.nPlanes[i + 1],
                         kernel_size=2,
@@ -85,10 +85,10 @@ class SENet(torch.nn.Module):
         self.decoding_conv = []
         for i in range(self.depth - 2, -1, -1):
             m = []
-            m.append(ME.MinkowskiBatchNorm(self.nPlanes[i + 1]))
+            m.append(sparse.BatchNorm(self.nPlanes[i + 1]))
             m.append(act_factory(activation, **activation_args))
             m.append(
-                ME.MinkowskiConvolutionTranspose(
+                sparse.ConvolutionTranspose(
                     in_channels=self.nPlanes[i + 1],
                     out_channels=self.nPlanes[i],
                     kernel_size=2,
@@ -124,7 +124,7 @@ class SENet(torch.nn.Module):
         UResNeXt Encoder.
 
         INPUTS:
-            - x (SparseTensor): MinkowskiEngine SparseTensor
+            - x (SparseTensor): SPINE sparse tensor
 
         RETURNS:
             - result (dict): dictionary of encoder output with
@@ -158,7 +158,7 @@ class SENet(torch.nn.Module):
         for i, layer in enumerate(self.decoding_conv):
             eTensor = encoderTensors[-i - 2]
             x = layer(x)
-            x = ME.cat((eTensor, x))
+            x = sparse.cat((eTensor, x))
             x = self.decoding_block[i](x)
             decoderTensors.append(x)
         return decoderTensors
@@ -167,7 +167,7 @@ class SENet(torch.nn.Module):
         coords = input[:, 0 : self.D + 1].int()
         features = input[:, self.D + 1 :]
 
-        x = ME.SparseTensor(features, coordinates=coords)
+        x = sparse.SparseTensor(features, coordinates=coords)
         encoderOutput = self.encoder(x)
         encoderTensors = encoderOutput["encoderTensors"]
         finalTensor = encoderOutput["finalTensor"]

--- a/src/spine/model/layer/cnn/sparse_generator.py
+++ b/src/spine/model/layer/cnn/sparse_generator.py
@@ -1,7 +1,8 @@
-import MinkowskiEngine as ME
 import torch
 import torch.nn as nn
 from scipy.special import logit
+
+from spine.model import sparse
 
 from .act_norm import act_factory, norm_factory
 from .blocks import ConvolutionBlock, ResNetBlock
@@ -36,7 +37,7 @@ class SparseGenerator(torch.nn.Module):
         self.linear = nn.Sequential(
             norm_factory(self.norm, self.latent_size, **self.norm_args),
             act_factory(self.activation_name, **self.activation_args),
-            ME.MinkowskiConvolutionTranspose(
+            sparse.ConvolutionTranspose(
                 in_channels=self.latent_size,
                 out_channels=self.nPlanes[-1],
                 kernel_size=final_tensor_shape,
@@ -55,7 +56,7 @@ class SparseGenerator(torch.nn.Module):
             m.append(norm_factory(self.norm, self.nPlanes[i + 1], **self.norm_args))
             m.append(act_factory(self.activation_name, **self.activation_args))
             m.append(
-                ME.MinkowskiConvolutionTranspose(
+                sparse.ConvolutionTranspose(
                     in_channels=self.nPlanes[i + 1],
                     out_channels=self.nPlanes[i],
                     kernel_size=2,
@@ -84,14 +85,14 @@ class SparseGenerator(torch.nn.Module):
             m = nn.Sequential(*m)
             self.decoding_block.append(m)
             self.layer_cls.append(
-                ME.MinkowskiLinear(self.nPlanes[i], 1, bias=self.allow_bias)
+                sparse.Linear(self.nPlanes[i], 1, bias=self.allow_bias)
             )
         self.decoding_block = nn.Sequential(*self.decoding_block)
         self.decoding_conv = nn.Sequential(*self.decoding_conv)
         self.layer_cls = nn.Sequential(*self.layer_cls)
 
         # pruning
-        self.pruning = ME.MinkowskiPruning()
+        self.pruning = sparse.Pruning()
 
     def get_batch_indices(self, out):
         return out.coords_man.get_row_indices_per_batch(out.coords_key)
@@ -172,7 +173,7 @@ class SparseGeneratorSimple(torch.nn.Module):
         self.linear = nn.Sequential(
             norm_factory(self.norm, self.latent_size, **self.norm_args),
             act_factory(self.activation_name, **self.activation_args),
-            ME.MinkowskiConvolutionTranspose(
+            sparse.ConvolutionTranspose(
                 in_channels=self.latent_size,
                 out_channels=self.nPlanes[-1],
                 kernel_size=final_tensor_shape,
@@ -191,7 +192,7 @@ class SparseGeneratorSimple(torch.nn.Module):
             m.append(norm_factory(self.norm, self.nPlanes[i + 1], **self.norm_args))
             m.append(act_factory(self.activation_name, **self.activation_args))
             m.append(
-                ME.MinkowskiConvolutionTranspose(
+                sparse.ConvolutionTranspose(
                     in_channels=self.nPlanes[i + 1],
                     out_channels=self.nPlanes[i],
                     kernel_size=2,
@@ -220,14 +221,14 @@ class SparseGeneratorSimple(torch.nn.Module):
             m = nn.Sequential(*m)
             self.decoding_block.append(m)
             self.layer_cls.append(
-                ME.MinkowskiLinear(self.nPlanes[i], 1, bias=self.allow_bias)
+                sparse.Linear(self.nPlanes[i], 1, bias=self.allow_bias)
             )
         self.decoding_block = nn.Sequential(*self.decoding_block)
         self.decoding_conv = nn.Sequential(*self.decoding_conv)
         self.layer_cls = nn.Sequential(*self.layer_cls)
 
         # pruning
-        self.pruning = ME.MinkowskiPruning()
+        self.pruning = sparse.Pruning()
 
     def get_batch_indices(self, out):
         return out.coords_man.get_row_indices_per_batch(out.coords_key)

--- a/src/spine/model/layer/cnn/uresnet_layers.py
+++ b/src/spine/model/layer/cnn/uresnet_layers.py
@@ -8,8 +8,9 @@ Contains the following components:
 
 from typing import List
 
-import MinkowskiEngine as ME
 import torch
+
+from spine.model import sparse
 
 from .act_norm import act_factory, norm_factory
 from .blocks import ASPP, CascadeDilationBlock, ResNetBlock
@@ -39,7 +40,7 @@ class UResNetEncoder(torch.nn.Module):
         setup_cnn_configuration(self, **cfg)
 
         # Initialize the input layer
-        self.input_layer = ME.MinkowskiConvolution(
+        self.input_layer = sparse.Convolution(
             in_channels=self.num_input,
             out_channels=self.num_filters,
             kernel_size=self.input_kernel,
@@ -71,7 +72,7 @@ class UResNetEncoder(torch.nn.Module):
                 m.append(norm_factory(self.norm_cfg, F))
                 m.append(act_factory(self.act_cfg))
                 m.append(
-                    ME.MinkowskiConvolution(
+                    sparse.Convolution(
                         in_channels=self.num_planes[i],
                         out_channels=self.num_planes[i + 1],
                         kernel_size=2,
@@ -90,15 +91,15 @@ class UResNetEncoder(torch.nn.Module):
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
 
         Returns
         -------
-        encoder_tensors : List[ME.SparseTensor]
+        encoder_tensors : List[sparse.SparseTensor]
             List of intermediate tensors (taken between encoding block and
             convolution) from the encoder half
-        final_tensor : ME.SparseTensor
+        final_tensor : sparse.SparseTensor
             Feature tensor at deepest layer
         """
         x = self.input_layer(x)
@@ -141,7 +142,7 @@ class UResNetDecoder(torch.nn.Module):
             m.append(norm_factory(self.norm_cfg, self.num_planes[i + 1]))
             m.append(act_factory(self.act_cfg))
             m.append(
-                ME.MinkowskiConvolutionTranspose(
+                sparse.ConvolutionTranspose(
                     in_channels=self.num_planes[i + 1],
                     out_channels=self.num_planes[i],
                     kernel_size=2,
@@ -174,14 +175,14 @@ class UResNetDecoder(torch.nn.Module):
 
         Parameters
         ----------
-        final : ME.SparseTensor
+        final : sparse.SparseTensor
             Output of the encoder
-        encoder_tensors : List[ME.SparseTensor]
+        encoder_tensors : List[sparse.SparseTensor]
             List of tensors from each depth of the encoder
 
         Returns
         -------
-        List[ME.SparseTensor]
+        List[sparse.SparseTensor]
             List of feature tensors in decoding path at each spatial resolution
         """
         decoder_tensors = []
@@ -189,7 +190,7 @@ class UResNetDecoder(torch.nn.Module):
         for i, layer in enumerate(self.decoding_conv):
             encoder_tensor = encoder_tensors[-i - 2]
             x = layer(x)
-            x = ME.cat(encoder_tensor, x)
+            x = sparse.cat(encoder_tensor, x)
             x = self.decoding_block[i](x)
             decoder_tensors.append(x)
 
@@ -220,28 +221,28 @@ class UResNet(torch.nn.Module):
         self.encoder = UResNetEncoder(cfg)
         self.decoder = UResNetDecoder(cfg)
 
-    def forward(self, input_data):
+    def forward(self, input_data, batch_size=None):
         """Pass a tensor through the UResNet backbone.
 
         Parameters
         ----------
-        x : ME.SparseTensor
+        x : sparse.SparseTensor
             Input sparse tensor
 
         Returns
         -------
-        encoder_tensors : List[ME.SparseTensor]
+        encoder_tensors : List[sparse.SparseTensor]
             List of intermediate tensors (taken between encoding block and
             convolution) from the encoder half
-        decoder_tensors : List[ME.SparseTensor]
+        decoder_tensors : List[sparse.SparseTensor]
             List of feature tensors in decoding path at each spatial resolution
-        final_tensor : ME.SparseTensor
+        final_tensor : sparse.SparseTensor
             Feature tensor at deepest layer
         """
         # Cast the input data to a sparse tensor
         coords = input_data[:, 0 : self.dim + 1].int()
         features = input_data[:, self.dim + 1 :]
-        x = ME.SparseTensor(features, coordinates=coords)
+        x = sparse.SparseTensor(features, coordinates=coords, batch_size=batch_size)
 
         # Pass it through the encoder
         encoder_output = self.encoder(x)

--- a/src/spine/model/layer/cnn/uresnext.py
+++ b/src/spine/model/layer/cnn/uresnext.py
@@ -1,8 +1,8 @@
-import MinkowskiEngine as ME
-import MinkowskiFunctional as MF
 import numpy as np
 import torch
 import torch.nn as nn
+
+from spine.model import sparse
 
 from .act_norm import act_factory
 from .blocks import *
@@ -36,7 +36,7 @@ class UResNeXt(torch.nn.Module):
         activation_args = self.activation_args
 
         # Initialize Input Layer
-        self.input_layer = ME.MinkowskiConvolution(
+        self.input_layer = sparse.Convolution(
             self.num_input,
             self.num_filters,
             kernel_size=self.input_kernel,
@@ -66,10 +66,10 @@ class UResNeXt(torch.nn.Module):
             self.encoding_block.append(m)
             m = []
             if i < self.depth - 1:
-                m.append(ME.MinkowskiBatchNorm(F))
+                m.append(sparse.BatchNorm(F))
                 m.append(act_factory(activation, **activation_args))
                 m.append(
-                    ME.MinkowskiConvolution(
+                    sparse.Convolution(
                         in_channels=self.nPlanes[i],
                         out_channels=self.nPlanes[i + 1],
                         kernel_size=2,
@@ -87,10 +87,10 @@ class UResNeXt(torch.nn.Module):
         self.decoding_conv = []
         for i in range(self.depth - 2, -1, -1):
             m = []
-            m.append(ME.MinkowskiBatchNorm(self.nPlanes[i + 1]))
+            m.append(sparse.BatchNorm(self.nPlanes[i + 1]))
             m.append(act_factory(activation, **activation_args))
             m.append(
-                ME.MinkowskiConvolutionTranspose(
+                sparse.ConvolutionTranspose(
                     in_channels=self.nPlanes[i + 1],
                     out_channels=self.nPlanes[i],
                     kernel_size=2,
@@ -126,7 +126,7 @@ class UResNeXt(torch.nn.Module):
         UResNeXt Encoder.
 
         INPUTS:
-            - x (SparseTensor): MinkowskiEngine SparseTensor
+            - x (SparseTensor): SPINE sparse tensor
 
         RETURNS:
             - result (dict): dictionary of encoder output with
@@ -160,7 +160,7 @@ class UResNeXt(torch.nn.Module):
         for i, layer in enumerate(self.decoding_conv):
             eTensor = encoderTensors[-i - 2]
             x = layer(x)
-            x = ME.cat((eTensor, x))
+            x = sparse.cat((eTensor, x))
             x = self.decoding_block[i](x)
             decoderTensors.append(x)
         return decoderTensors
@@ -169,7 +169,7 @@ class UResNeXt(torch.nn.Module):
         coords = input[:, 0 : self.D + 1].int()
         features = input[:, self.D + 1 :]
 
-        x = ME.SparseTensor(features, coordinates=coords)
+        x = sparse.SparseTensor(features, coordinates=coords)
         encoderOutput = self.encoder(x)
         encoderTensors = encoderOutput["encoderTensors"]
         finalTensor = encoderOutput["finalTensor"]

--- a/src/spine/model/layer/cnn/vertex_ppn.py
+++ b/src/spine/model/layer/cnn/vertex_ppn.py
@@ -1,9 +1,8 @@
-import MinkowskiEngine as ME
-import MinkowskiFunctional as MF
 import numpy as np
 import torch
 import torch.nn as nn
 
+from spine.model import sparse
 from spine.model.layer.cnn.blocks import ResNetBlock
 from spine.model.layer.cnn.configuration import setup_cnn_configuration
 from spine.model.layer.factories import loss_fn_factory
@@ -34,10 +33,10 @@ class VertexPPN(nn.Module):
         self.vertex_pred = nn.ModuleList()
         for i in range(self.depth - 2, -1, -1):
             m = []
-            m.append(ME.MinkowskiBatchNorm(self.nPlanes[i + 1]))
+            m.append(sparse.BatchNorm(self.nPlanes[i + 1]))
             m.append(act_factory(self.activation_name, **self.activation_args))
             m.append(
-                ME.MinkowskiConvolutionTranspose(
+                sparse.ConvolutionTranspose(
                     in_channels=self.nPlanes[i + 1],
                     out_channels=self.nPlanes[i],
                     kernel_size=2,
@@ -60,11 +59,11 @@ class VertexPPN(nn.Module):
                 )
             m = nn.Sequential(*m)
             self.decoding_block.append(m)
-            self.vertex_pred.append(ME.MinkowskiLinear(self.nPlanes[i], 1))
+            self.vertex_pred.append(sparse.Linear(self.nPlanes[i], 1))
         self.decoding_block = nn.Sequential(*self.decoding_block)
         self.decoding_conv = nn.Sequential(*self.decoding_conv)
 
-        self.sigmoid = ME.MinkowskiSigmoid()
+        self.sigmoid = sparse.Sigmoid()
         self.expand_as = ExpandAs()
 
         self.final_block = ResNetBlock(
@@ -75,10 +74,10 @@ class VertexPPN(nn.Module):
             activation_args=self.activation_args,
         )
 
-        self.vertex_regression = ME.MinkowskiConvolution(
+        self.vertex_regression = sparse.Convolution(
             self.nPlanes[0], self.D, kernel_size=3, stride=1, dimension=self.D
         )
-        self.vertexness_score = ME.MinkowskiConvolution(
+        self.vertexness_score = sparse.Convolution(
             self.nPlanes[0], 2, kernel_size=3, stride=1, dimension=self.D
         )
 
@@ -107,7 +106,7 @@ class VertexPPN(nn.Module):
 
             decTensor = decoder_feature_maps[i]
             x = layer(x)
-            x = ME.cat(decTensor, x)
+            x = sparse.cat(decTensor, x)
             x = self.decoding_block[i](x)
             scores = self.vertex_pred[i](x)
             tmp.append(scores.F)

--- a/src/spine/model/manager.py
+++ b/src/spine/model/manager.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import numpy as np
 
-from spine.data import EdgeIndexBatch, IndexBatch, TensorBatch
+from spine.data import EdgeIndexBatch, IndexBatch, TensorBatch, TensorBatchConvertible
 from spine.utils.conditional import TORCH_AVAILABLE, torch
 from spine.utils.logger import logger
 from spine.utils.stopwatch import StopwatchManager
@@ -593,6 +593,9 @@ class ModelManager:
         """
         # Loop over the key, value pairs in the result dictionary
         for key, value in result.items():
+            if isinstance(value, TensorBatchConvertible):
+                value = value.to_tensor_batch()
+
             # Cast to numpy or python scalars
             if np.isscalar(value):
                 # Scalar
@@ -609,10 +612,17 @@ class ModelManager:
             elif (
                 isinstance(value, list)
                 and len(value)
-                and isinstance(value[0], TensorBatch)
+                and isinstance(value[0], (TensorBatch, TensorBatchConvertible))
             ):
                 # List of tensor batches
-                result[key] = [v.to_numpy() for v in value]
+                result[key] = [
+                    (
+                        v.to_tensor_batch().to_numpy()
+                        if isinstance(v, TensorBatchConvertible)
+                        else v.to_numpy()
+                    )
+                    for v in value
+                ]
 
             else:
                 dtype = type(value)

--- a/src/spine/model/singlep.py
+++ b/src/spine/model/singlep.py
@@ -144,7 +144,7 @@ class DUQParticleClassifier(ImageClassifier):
     https://arxiv.org/pdf/2003.02037.pdf
     Joost van Amersfoort, Lewis Smith, Yee Whye Teh, Yarin Gal.
 
-    Pytorch Implementation for SparseConvNets with MinkowskiEngine backend.
+    PyTorch implementation for sparse convolutional networks.
     """
 
     MODULES = ["network_base", "particle_image_classifier", "mink_encoder"]

--- a/src/spine/model/sparse/__init__.py
+++ b/src/spine/model/sparse/__init__.py
@@ -1,0 +1,114 @@
+"""Backend-neutral sparse tensors and model operations.
+
+The package is the public sparse API for SPINE models. It exposes semantic
+operation names, an empty-safe :class:`SparseTensor`, and feature-wise
+functions while keeping concrete sparse-convolution engines behind an adapter.
+"""
+
+from .functional import softmax
+from .modules import (
+    CELU,
+    ELU,
+    SELU,
+    AvgPooling,
+    BatchNorm,
+    Broadcast,
+    BroadcastMultiplication,
+    ChannelwiseConvolution,
+    Convolution,
+    ConvolutionTranspose,
+    Dropout,
+    GlobalAvgPooling,
+    GlobalMaxPooling,
+    GlobalPooling,
+    GlobalSumPooling,
+    InstanceNorm,
+    LeakyReLU,
+    Linear,
+    MaxPooling,
+    Network,
+    PoolingTranspose,
+    PReLU,
+    Pruning,
+    ReLU,
+    Sigmoid,
+    Softplus,
+    SumPooling,
+    Tanh,
+)
+from .tensor import SparseTensor
+
+
+def cat(*inputs):
+    """Concatenate sparse feature matrices on a shared coordinate map.
+
+    Parameters
+    ----------
+    *inputs : SparseTensor or sequence of SparseTensor
+        Sparse tensors with identical coordinates. A single list or tuple is
+        accepted for compatibility with the native backend API.
+
+    Returns
+    -------
+    SparseTensor
+        Sparse tensor whose feature dimension is the sum of the input feature
+        dimensions. Input provenance is inherited from the first tensor.
+
+    Raises
+    ------
+    ValueError
+        If no input tensors are provided.
+
+    Notes
+    -----
+    If every input is empty, concatenation is performed without entering the
+    backend and preserves the empty tensor's batch and stride metadata.
+    """
+    from . import backend
+
+    if len(inputs) == 1 and isinstance(inputs[0], (list, tuple)):
+        inputs = tuple(inputs[0])
+    if not inputs:
+        raise ValueError("Sparse concatenation requires at least one tensor.")
+    if not all(isinstance(value, SparseTensor) for value in inputs):
+        return backend.concatenate(*inputs)
+    if not any(len(value) for value in inputs):
+        channels = sum(value.F.shape[1] for value in inputs)
+        return SparseTensor.empty_like(inputs[0], channels)
+    output = backend.concatenate(*(value.backend_tensor for value in inputs))
+    return inputs[0]._wrap(output)
+
+
+__all__ = [
+    "SparseTensor",
+    "Network",
+    "Convolution",
+    "ConvolutionTranspose",
+    "ChannelwiseConvolution",
+    "Linear",
+    "BatchNorm",
+    "InstanceNorm",
+    "Dropout",
+    "ReLU",
+    "PReLU",
+    "SELU",
+    "CELU",
+    "LeakyReLU",
+    "ELU",
+    "Tanh",
+    "Sigmoid",
+    "Softplus",
+    "MaxPooling",
+    "AvgPooling",
+    "SumPooling",
+    "PoolingTranspose",
+    "GlobalPooling",
+    "GlobalAvgPooling",
+    "GlobalSumPooling",
+    "GlobalMaxPooling",
+    "Pruning",
+    "Broadcast",
+    "BroadcastMultiplication",
+    "cat",
+    "softmax",
+]

--- a/src/spine/model/sparse/backend.py
+++ b/src/spine/model/sparse/backend.py
@@ -1,0 +1,133 @@
+"""Select and access the sparse-convolution backend.
+
+This module defines the small semantic contract that concrete sparse backends
+must implement. Model code should use :mod:`spine.model.sparse` instead of
+calling this registry or importing a backend directly.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from typing import Any
+
+_BACKEND_NAME = os.getenv("SPINE_SPARSE_BACKEND", "minkowski")
+_ADAPTER: Any = None
+
+
+def name() -> str:
+    """Return the configured sparse backend name.
+
+    Returns
+    -------
+    str
+        Backend name selected by ``SPINE_SPARSE_BACKEND``. The default is
+        ``"minkowski"``.
+    """
+    return _BACKEND_NAME
+
+
+def adapter() -> Any:
+    """Load and cache the configured backend adapter.
+
+    Returns
+    -------
+    module
+        Module implementing the sparse backend contract.
+
+    Raises
+    ------
+    ValueError
+        If no adapter exists for the configured backend name.
+    """
+    global _ADAPTER  # pylint: disable=global-statement
+    if _ADAPTER is None:
+        try:
+            _ADAPTER = importlib.import_module(
+                f"{__package__}.backends.{_BACKEND_NAME}"
+            )
+        except ModuleNotFoundError as exc:
+            if exc.name == f"{__package__}.backends.{_BACKEND_NAME}":
+                raise ValueError(
+                    f"Unsupported sparse backend: {_BACKEND_NAME}"
+                ) from exc
+            raise
+    return _ADAPTER
+
+
+def module(operation: str) -> type:
+    """Resolve a semantic sparse operation to a backend module class.
+
+    Parameters
+    ----------
+    operation : str
+        Backend-neutral operation name, such as ``"Convolution"``.
+
+    Returns
+    -------
+    type
+        Backend implementation of the requested operation.
+    """
+    return adapter().module(operation)
+
+
+def create_tensor(**kwargs: Any) -> Any:
+    """Create a native sparse tensor.
+
+    Parameters
+    ----------
+    **kwargs : Any
+        Arguments forwarded to the selected backend tensor constructor.
+
+    Returns
+    -------
+    Any
+        Native sparse tensor owned by the backend.
+    """
+    return adapter().create_tensor(**kwargs)
+
+
+def concatenate(*tensors: Any) -> Any:
+    """Concatenate native sparse tensors on a shared coordinate map.
+
+    Parameters
+    ----------
+    *tensors : Any
+        Native sparse tensors with compatible coordinates.
+
+    Returns
+    -------
+    Any
+        Native sparse tensor containing the concatenated features.
+    """
+    return adapter().concatenate(*tensors)
+
+
+def coordinates(tensor: Any) -> Any:
+    """Return the coordinate matrix of a native sparse tensor."""
+    return adapter().coordinates(tensor)
+
+
+def features(tensor: Any) -> Any:
+    """Return the feature matrix of a native sparse tensor."""
+    return adapter().features(tensor)
+
+
+def tensor_stride(tensor: Any) -> tuple[int, ...]:
+    """Return the spatial stride of a native sparse tensor."""
+    return adapter().tensor_stride(tensor)
+
+
+def coordinate_map_key(tensor: Any) -> Any:
+    """Return the coordinate-map key of a native sparse tensor."""
+    return adapter().coordinate_map_key(tensor)
+
+
+def coordinate_manager(tensor: Any) -> Any:
+    """Return the coordinate manager of a native sparse tensor."""
+    return adapter().coordinate_manager(tensor)
+
+
+def features_at_coordinates(tensor: Any, queries: Any) -> Any:
+    """Query native sparse features at continuous coordinates."""
+    return adapter().features_at_coordinates(tensor, queries)

--- a/src/spine/model/sparse/backend.py
+++ b/src/spine/model/sparse/backend.py
@@ -128,6 +128,16 @@ def coordinate_manager(tensor: Any) -> Any:
     return adapter().coordinate_manager(tensor)
 
 
+def unique_index(tensor: Any) -> Any:
+    """Return input-row indices retained by backend quantization."""
+    return adapter().unique_index(tensor)
+
+
+def inverse_mapping(tensor: Any) -> Any:
+    """Map original input rows to backend sparse sites."""
+    return adapter().inverse_mapping(tensor)
+
+
 def features_at_coordinates(tensor: Any, queries: Any) -> Any:
     """Query native sparse features at continuous coordinates."""
     return adapter().features_at_coordinates(tensor, queries)

--- a/src/spine/model/sparse/backends/__init__.py
+++ b/src/spine/model/sparse/backends/__init__.py
@@ -1,0 +1,5 @@
+"""Concrete implementations of the SPINE sparse backend contract.
+
+Backend modules are private implementation details. Models should import the
+semantic operations exposed by :mod:`spine.model.sparse`.
+"""

--- a/src/spine/model/sparse/backends/minkowski.py
+++ b/src/spine/model/sparse/backends/minkowski.py
@@ -48,6 +48,12 @@ _MODULES = {
     "BroadcastMultiplication": engine.MinkowskiBroadcastMultiplication,
 }
 
+_DUPLICATE_REDUCTIONS = {
+    "sum": engine.SparseTensorQuantizationMode.UNWEIGHTED_SUM,
+    "mean": engine.SparseTensorQuantizationMode.UNWEIGHTED_AVERAGE,
+    "first": engine.SparseTensorQuantizationMode.RANDOM_SUBSAMPLE,
+}
+
 
 def module(operation: str) -> type:
     """Resolve a semantic SPINE operation to its native module class.
@@ -75,8 +81,35 @@ def module(operation: str) -> type:
         ) from exc
 
 
-def create_tensor(**kwargs: Any) -> Any:
-    """Create a native MinkowskiEngine sparse tensor."""
+def create_tensor(duplicate_reduction: str | None = None, **kwargs: Any) -> Any:
+    """Create a native MinkowskiEngine sparse tensor.
+
+    Parameters
+    ----------
+    duplicate_reduction : {"sum", "mean", "first"}, optional
+        Backend quantization mode used when explicit coordinates contain
+        duplicates. Coordinate-map reuse does not require quantization.
+    **kwargs : Any
+        Arguments forwarded to ``MinkowskiEngine.SparseTensor``.
+
+    Returns
+    -------
+    MinkowskiEngine.SparseTensor
+        Native sparse tensor.
+
+    Raises
+    ------
+    ValueError
+        If the duplicate reduction is not supported.
+    """
+    if duplicate_reduction is not None:
+        try:
+            kwargs["quantization_mode"] = _DUPLICATE_REDUCTIONS[duplicate_reduction]
+        except KeyError as exc:
+            raise ValueError(
+                f"Unknown duplicate reduction `{duplicate_reduction}`. "
+                "Choose from 'mean', 'sum' or 'first'."
+            ) from exc
     return engine.SparseTensor(**kwargs)
 
 
@@ -108,6 +141,16 @@ def coordinate_map_key(tensor: Any) -> Any:
 def coordinate_manager(tensor: Any) -> Any:
     """Return a native tensor's coordinate manager."""
     return tensor.coordinate_manager
+
+
+def unique_index(tensor: Any) -> Any:
+    """Return indices retained during native coordinate quantization."""
+    return tensor.unique_index
+
+
+def inverse_mapping(tensor: Any) -> Any:
+    """Map native constructor input rows to quantized sparse sites."""
+    return tensor.inverse_mapping
 
 
 def features_at_coordinates(tensor: Any, queries: Any) -> Any:

--- a/src/spine/model/sparse/backends/minkowski.py
+++ b/src/spine/model/sparse/backends/minkowski.py
@@ -1,0 +1,115 @@
+"""Implement the SPINE sparse backend contract with MinkowskiEngine.
+
+This is the only module in :mod:`spine.model` that imports MinkowskiEngine.
+Keeping native names and tensor access here prevents backend details from
+leaking into model definitions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    import MinkowskiEngine as engine
+except ModuleNotFoundError as exc:
+    raise ImportError(
+        "MinkowskiEngine is required for the `minkowski` sparse backend."
+    ) from exc
+
+
+_MODULES = {
+    "Network": engine.MinkowskiNetwork,
+    "Convolution": engine.MinkowskiConvolution,
+    "ConvolutionTranspose": engine.MinkowskiConvolutionTranspose,
+    "ChannelwiseConvolution": engine.MinkowskiChannelwiseConvolution,
+    "Linear": engine.MinkowskiLinear,
+    "BatchNorm": engine.MinkowskiBatchNorm,
+    "InstanceNorm": engine.MinkowskiInstanceNorm,
+    "Dropout": engine.MinkowskiDropout,
+    "ReLU": engine.MinkowskiReLU,
+    "PReLU": engine.MinkowskiPReLU,
+    "SELU": engine.MinkowskiSELU,
+    "CELU": engine.MinkowskiCELU,
+    "LeakyReLU": engine.MinkowskiLeakyReLU,
+    "ELU": engine.MinkowskiELU,
+    "Tanh": engine.MinkowskiTanh,
+    "Sigmoid": engine.MinkowskiSigmoid,
+    "Softplus": engine.MinkowskiSoftplus,
+    "MaxPooling": engine.MinkowskiMaxPooling,
+    "AvgPooling": engine.MinkowskiAvgPooling,
+    "SumPooling": engine.MinkowskiSumPooling,
+    "PoolingTranspose": engine.MinkowskiPoolingTranspose,
+    "GlobalPooling": engine.MinkowskiGlobalPooling,
+    "GlobalAvgPooling": engine.MinkowskiGlobalAvgPooling,
+    "GlobalSumPooling": engine.MinkowskiGlobalSumPooling,
+    "GlobalMaxPooling": engine.MinkowskiGlobalMaxPooling,
+    "Pruning": engine.MinkowskiPruning,
+    "Broadcast": engine.MinkowskiBroadcast,
+    "BroadcastMultiplication": engine.MinkowskiBroadcastMultiplication,
+}
+
+
+def module(operation: str) -> type:
+    """Resolve a semantic SPINE operation to its native module class.
+
+    Parameters
+    ----------
+    operation : str
+        Backend-neutral operation name.
+
+    Returns
+    -------
+    type
+        MinkowskiEngine implementation of the operation.
+
+    Raises
+    ------
+    ValueError
+        If the operation is not implemented by this adapter.
+    """
+    try:
+        return _MODULES[operation]
+    except KeyError as exc:
+        raise ValueError(
+            f"The Minkowski backend does not implement `{operation}`."
+        ) from exc
+
+
+def create_tensor(**kwargs: Any) -> Any:
+    """Create a native MinkowskiEngine sparse tensor."""
+    return engine.SparseTensor(**kwargs)
+
+
+def concatenate(*tensors: Any) -> Any:
+    """Concatenate native tensors with a common coordinate map."""
+    return engine.cat(*tensors)
+
+
+def coordinates(tensor: Any) -> Any:
+    """Return a native tensor's batched coordinate matrix."""
+    return tensor.C
+
+
+def features(tensor: Any) -> Any:
+    """Return a native tensor's feature matrix."""
+    return tensor.F
+
+
+def tensor_stride(tensor: Any) -> tuple[int, ...]:
+    """Return a native tensor's spatial stride as a tuple."""
+    return tuple(int(value) for value in tensor.tensor_stride)
+
+
+def coordinate_map_key(tensor: Any) -> Any:
+    """Return a native tensor's coordinate-map key."""
+    return tensor.coordinate_map_key
+
+
+def coordinate_manager(tensor: Any) -> Any:
+    """Return a native tensor's coordinate manager."""
+    return tensor.coordinate_manager
+
+
+def features_at_coordinates(tensor: Any, queries: Any) -> Any:
+    """Query native tensor features at continuous coordinates."""
+    return tensor.features_at_coordinates(queries)

--- a/src/spine/model/sparse/functional.py
+++ b/src/spine/model/sparse/functional.py
@@ -1,0 +1,23 @@
+"""Backend-neutral functions that operate on sparse feature matrices."""
+
+import torch
+
+from .tensor import SparseTensor
+
+
+def softmax(input: SparseTensor, dim: int = 1) -> SparseTensor:
+    """Apply softmax to sparse features without changing coordinates.
+
+    Parameters
+    ----------
+    input : SparseTensor
+        Sparse tensor containing the features to normalize.
+    dim : int, default 1
+        Feature dimension along which to apply softmax.
+
+    Returns
+    -------
+    SparseTensor
+        Tensor on the same coordinate map with normalized features.
+    """
+    return input.replace_features(torch.softmax(input.F, dim=dim))

--- a/src/spine/model/sparse/modules.py
+++ b/src/spine/model/sparse/modules.py
@@ -1,0 +1,309 @@
+"""Backend-selected, empty-safe sparse neural-network modules.
+
+Each public class subclasses the corresponding native backend module so that
+constructor signatures, parameters, and state-dictionary keys remain
+compatible. The :class:`SparseTensor` wrapper is removed before a native
+operation and restored afterward. Empty inputs bypass the backend entirely.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from . import backend
+from .tensor import SparseTensor
+
+_NativeConvolution = backend.module("Convolution")
+_NativeConvolutionTranspose = backend.module("ConvolutionTranspose")
+_NativeChannelwiseConvolution = backend.module("ChannelwiseConvolution")
+_NativeLinear = backend.module("Linear")
+_NativeBatchNorm = backend.module("BatchNorm")
+_NativeInstanceNorm = backend.module("InstanceNorm")
+_NativeDropout = backend.module("Dropout")
+_NativeReLU = backend.module("ReLU")
+_NativePReLU = backend.module("PReLU")
+_NativeSELU = backend.module("SELU")
+_NativeCELU = backend.module("CELU")
+_NativeLeakyReLU = backend.module("LeakyReLU")
+_NativeELU = backend.module("ELU")
+_NativeTanh = backend.module("Tanh")
+_NativeSigmoid = backend.module("Sigmoid")
+_NativeSoftplus = backend.module("Softplus")
+_NativeMaxPooling = backend.module("MaxPooling")
+_NativeAvgPooling = backend.module("AvgPooling")
+_NativeSumPooling = backend.module("SumPooling")
+_NativePoolingTranspose = backend.module("PoolingTranspose")
+_NativeGlobalPooling = backend.module("GlobalPooling")
+_NativeGlobalAvgPooling = backend.module("GlobalAvgPooling")
+_NativeGlobalSumPooling = backend.module("GlobalSumPooling")
+_NativeGlobalMaxPooling = backend.module("GlobalMaxPooling")
+_NativePruning = backend.module("Pruning")
+_NativeBroadcast = backend.module("Broadcast")
+_NativeBroadcastMultiplication = backend.module("BroadcastMultiplication")
+
+
+def _stride_values(value: Any, dimension: int) -> tuple[int, ...]:
+    """Normalize a scalar or vector stride to one value per dimension."""
+    if isinstance(value, int):
+        return (value,) * dimension
+    if isinstance(value, torch.Tensor):
+        value = value.detach().cpu().tolist()
+    return tuple(int(v) for v in value)
+
+
+def _scaled_stride(
+    tensor: SparseTensor, layer: Any, transpose: bool = False
+) -> tuple[int, ...]:
+    """Compute the output stride of an empty convolution or pooling layer."""
+    stride = getattr(layer, "stride", None)
+    if stride is None and hasattr(layer, "kernel_generator"):
+        stride = layer.kernel_generator.kernel_stride
+    factor = _stride_values(1 if stride is None else stride, tensor.dimension)
+    if transpose:
+        return tuple(max(1, a // b) for a, b in zip(tensor.tensor_stride, factor))
+    return tuple(a * b for a, b in zip(tensor.tensor_stride, factor))
+
+
+class _EmptySafe:
+    """Mixin that unwraps SPINE tensors and wraps backend results.
+
+    Native inputs continue through the underlying backend unchanged. Empty
+    SPINE tensors instead produce metadata-preserving empty outputs, avoiding
+    backend kernels that require at least one active site.
+    """
+
+    out_channels: int | None = None
+    _changes_stride = False
+    _transpose_stride = False
+
+    def _empty_channels(self, input: SparseTensor) -> int:
+        """Infer the output feature count for an empty input."""
+        channels = getattr(self, "out_channels", None)
+        if channels is None:
+            channels = getattr(self, "out_features", None)
+        if channels is None and hasattr(self, "linear"):
+            channels = getattr(self.linear, "out_features", None)
+        return input.F.shape[1] if channels is None else int(channels)
+
+    def forward(self, input: Any, *args: Any, **kwargs: Any) -> Any:
+        """Apply the native module or construct an empty result."""
+        if not isinstance(input, SparseTensor):
+            return super().forward(input, *args, **kwargs)
+        if not len(input):
+            stride = input.tensor_stride
+            if self._changes_stride:
+                stride = _scaled_stride(input, self, self._transpose_stride)
+            return SparseTensor.empty_like(input, self._empty_channels(input), stride)
+        output = super().forward(input.backend_tensor, *args, **kwargs)
+        return input._wrap(output)
+
+
+class Convolution(_EmptySafe, _NativeConvolution):
+    """Apply an empty-safe sparse convolution."""
+
+    _changes_stride = True
+
+
+class ConvolutionTranspose(_EmptySafe, _NativeConvolutionTranspose):
+    """Apply an empty-safe transposed sparse convolution."""
+
+    _changes_stride = True
+    _transpose_stride = True
+
+
+class ChannelwiseConvolution(_EmptySafe, _NativeChannelwiseConvolution):
+    """Apply an empty-safe channel-wise sparse convolution."""
+
+
+class Linear(_EmptySafe, _NativeLinear):
+    """Apply an empty-safe linear transformation to sparse features."""
+
+
+class BatchNorm(_EmptySafe, _NativeBatchNorm):
+    """Apply empty-safe batch normalization to sparse features."""
+
+
+class InstanceNorm(_EmptySafe, _NativeInstanceNorm):
+    """Apply empty-safe instance normalization to sparse features."""
+
+
+class Dropout(_EmptySafe, _NativeDropout):
+    """Apply dropout to sparse features, including empty tensors."""
+
+
+class ReLU(_EmptySafe, _NativeReLU):
+    """Apply a rectified linear unit to sparse features."""
+
+
+class PReLU(_EmptySafe, _NativePReLU):
+    """Apply a parametric rectified linear unit to sparse features."""
+
+
+class SELU(_EmptySafe, _NativeSELU):
+    """Apply a scaled exponential linear unit to sparse features."""
+
+
+class CELU(_EmptySafe, _NativeCELU):
+    """Apply a continuously differentiable ELU to sparse features."""
+
+
+class LeakyReLU(_EmptySafe, _NativeLeakyReLU):
+    """Apply a leaky rectified linear unit to sparse features."""
+
+
+class ELU(_EmptySafe, _NativeELU):
+    """Apply an exponential linear unit to sparse features."""
+
+
+class Tanh(_EmptySafe, _NativeTanh):
+    """Apply the hyperbolic tangent function to sparse features."""
+
+
+class Sigmoid(_EmptySafe, _NativeSigmoid):
+    """Apply the logistic sigmoid function to sparse features."""
+
+
+class Softplus(_EmptySafe, _NativeSoftplus):
+    """Apply the softplus function to sparse features."""
+
+
+class MaxPooling(_EmptySafe, _NativeMaxPooling):
+    """Apply empty-safe max pooling and update the tensor stride."""
+
+    _changes_stride = True
+
+
+class AvgPooling(_EmptySafe, _NativeAvgPooling):
+    """Apply empty-safe average pooling and update the tensor stride."""
+
+    _changes_stride = True
+
+
+class SumPooling(_EmptySafe, _NativeSumPooling):
+    """Apply empty-safe sum pooling and update the tensor stride."""
+
+    _changes_stride = True
+
+
+class PoolingTranspose(_EmptySafe, _NativePoolingTranspose):
+    """Apply empty-safe transposed pooling and reduce the tensor stride."""
+
+    _changes_stride = True
+    _transpose_stride = True
+
+
+class _GlobalPooling(_EmptySafe):
+    """Mixin that defines global pooling for entirely empty batches.
+
+    A global pool normally emits one row per batch entry. For an entirely
+    empty input, this mixin returns one zero feature vector per entry so that
+    downstream dense layers retain a well-defined batch dimension.
+    """
+
+    def forward(self, input: Any, *args: Any, **kwargs: Any) -> Any:
+        """Apply global pooling, synthesizing batch rows when necessary."""
+        if isinstance(input, SparseTensor) and not len(input) and input.batch_size:
+            coordinates = input.C.new_zeros((input.batch_size, input.dimension + 1))
+            coordinates[:, 0] = torch.arange(
+                input.batch_size, device=input.C.device, dtype=input.C.dtype
+            )
+            features = input.F.new_zeros((input.batch_size, input.F.shape[1]))
+            return SparseTensor(
+                features,
+                coordinates,
+                tensor_stride=input.tensor_stride,
+                batch_size=input.batch_size,
+            )
+        return super().forward(input, *args, **kwargs)
+
+
+class GlobalPooling(_GlobalPooling, _NativeGlobalPooling):
+    """Apply the backend's general global pooling operation."""
+
+
+class GlobalAvgPooling(_GlobalPooling, _NativeGlobalAvgPooling):
+    """Average sparse features independently for each batch entry."""
+
+
+class GlobalSumPooling(_GlobalPooling, _NativeGlobalSumPooling):
+    """Sum sparse features independently for each batch entry."""
+
+
+class GlobalMaxPooling(_GlobalPooling, _NativeGlobalMaxPooling):
+    """Take the feature-wise maximum for each batch entry."""
+
+
+class Pruning(_NativePruning):
+    """Remove sparse sites selected by a Boolean mask."""
+
+    def forward(self, input: Any, mask: torch.Tensor) -> Any:
+        """Prune active sites while preserving SPINE tensor metadata."""
+        if not isinstance(input, SparseTensor):
+            return super().forward(input, mask)
+        if not len(input):
+            return SparseTensor.empty_like(input)
+        return input._wrap(super().forward(input.backend_tensor, mask))
+
+
+class Broadcast(_NativeBroadcast):
+    """Broadcast per-batch global features to every active sparse site."""
+
+    def forward(self, input: Any, input_glob: Any) -> Any:
+        """Broadcast global features onto a sparse tensor."""
+        if not isinstance(input, SparseTensor):
+            return super().forward(input, input_glob)
+        if not len(input):
+            return SparseTensor.empty_like(input, input_glob.F.shape[1])
+        return input._wrap(
+            super().forward(input.backend_tensor, input_glob.backend_tensor)
+        )
+
+
+class BroadcastMultiplication(_NativeBroadcastMultiplication):
+    """Multiply active features by per-batch global features."""
+
+    def forward(self, input: Any, input_glob: Any) -> Any:
+        """Broadcast and multiply global features onto a sparse tensor."""
+        if not isinstance(input, SparseTensor):
+            return super().forward(input, input_glob)
+        if not len(input):
+            return SparseTensor.empty_like(input)
+        return input._wrap(
+            super().forward(input.backend_tensor, input_glob.backend_tensor)
+        )
+
+
+Network = backend.module("Network")
+
+__all__ = [
+    "Network",
+    "Convolution",
+    "ConvolutionTranspose",
+    "ChannelwiseConvolution",
+    "Linear",
+    "BatchNorm",
+    "InstanceNorm",
+    "Dropout",
+    "ReLU",
+    "PReLU",
+    "SELU",
+    "CELU",
+    "LeakyReLU",
+    "ELU",
+    "Tanh",
+    "Sigmoid",
+    "Softplus",
+    "MaxPooling",
+    "AvgPooling",
+    "SumPooling",
+    "PoolingTranspose",
+    "GlobalPooling",
+    "GlobalAvgPooling",
+    "GlobalSumPooling",
+    "GlobalMaxPooling",
+    "Pruning",
+    "Broadcast",
+    "BroadcastMultiplication",
+]

--- a/src/spine/model/sparse/tensor.py
+++ b/src/spine/model/sparse/tensor.py
@@ -1,0 +1,659 @@
+"""Backend-neutral sparse tensor exposed to SPINE models."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import torch
+
+from spine.data.batch import TensorBatch
+
+from . import backend
+
+__all__ = ["SparseTensor"]
+
+
+def _normalize_stride(
+    stride: int | Sequence[int] | torch.Tensor, dimension: int
+) -> tuple[int, ...]:
+    """Normalize a tensor stride to one value per spatial dimension.
+
+    Parameters
+    ----------
+    stride : int, sequence of int or torch.Tensor
+        Scalar stride or one stride value per spatial dimension.
+    dimension : int
+        Number of spatial dimensions.
+
+    Returns
+    -------
+    tuple of int
+        Normalized stride with ``dimension`` entries.
+    """
+    if isinstance(stride, torch.Tensor):
+        stride = stride.detach().cpu().tolist()
+    if isinstance(stride, int):
+        return (stride,) * dimension
+    return tuple(int(value) for value in stride)
+
+
+def _coalesce(
+    coordinates: torch.Tensor,
+    features: torch.Tensor,
+    reduction: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Coalesce duplicate coordinates and retain row provenance.
+
+    Parameters
+    ----------
+    coordinates : torch.Tensor
+        ``(N, D + 1)`` integer coordinate matrix. The first column contains
+        batch indices.
+    features : torch.Tensor
+        ``(N, C)`` feature matrix aligned with ``coordinates``.
+    reduction : {"sum", "mean", "first"}
+        Rule used to combine features at identical coordinates.
+
+    Returns
+    -------
+    unique_coordinates : torch.Tensor
+        Coordinate matrix containing one row per active sparse site.
+    unique_features : torch.Tensor
+        Reduced feature matrix aligned with ``unique_coordinates``.
+    unique_index : torch.Tensor
+        Original row index of the first occurrence of each unique coordinate.
+    inverse_index : torch.Tensor
+        Unique-coordinate index associated with every original row.
+
+    Raises
+    ------
+    ValueError
+        If ``reduction`` is not a supported reduction rule.
+    """
+    unique, inverse = torch.unique(coordinates, dim=0, return_inverse=True)
+    if len(unique) == len(coordinates):
+        index = torch.arange(len(coordinates), device=coordinates.device)
+        return coordinates, features, index, index
+
+    if reduction not in {"mean", "sum", "first"}:
+        raise ValueError(
+            f"Unknown duplicate reduction `{reduction}`. "
+            "Choose from 'mean', 'sum' or 'first'."
+        )
+
+    num_unique = len(unique)
+    if reduction in {"mean", "sum"}:
+        reduced = features.new_zeros((num_unique, features.shape[1]))
+        reduced.index_add_(0, inverse, features)
+        if reduction == "mean":
+            counts = features.new_zeros(num_unique)
+            counts.index_add_(0, inverse, features.new_ones(len(features)))
+            reduced = reduced / counts[:, None]
+    else:
+        row_ids = torch.arange(
+            len(coordinates), device=coordinates.device, dtype=torch.long
+        )
+        first = torch.full(
+            (num_unique,),
+            len(coordinates),
+            device=coordinates.device,
+            dtype=torch.long,
+        )
+        first.scatter_reduce_(0, inverse, row_ids, reduce="amin", include_self=True)
+        reduced = features[first]
+
+    row_ids = torch.arange(
+        len(coordinates), device=coordinates.device, dtype=torch.long
+    )
+    first = torch.full(
+        (num_unique,),
+        len(coordinates),
+        device=coordinates.device,
+        dtype=torch.long,
+    )
+    first.scatter_reduce_(0, inverse, row_ids, reduce="amin", include_self=True)
+    return unique, reduced, first, inverse
+
+
+class SparseTensor:
+    """Sparse model-runtime tensor.
+
+    The public object owns batching and input-row provenance while the selected
+    backend owns the active coordinate map. Duplicate input coordinates are
+    coalesced for sparse convolution and can be restored at row-aligned output
+    boundaries with :meth:`aligned_features`.
+
+    Parameters
+    ----------
+    features : torch.Tensor, optional
+        ``(N, C)`` feature matrix. A one-dimensional input is promoted to
+        ``(N, 1)``.
+    coordinates : torch.Tensor, optional
+        ``(N, D + 1)`` coordinate matrix with the batch index in column zero.
+        Either this argument or both ``coordinate_map_key`` and
+        ``coordinate_manager`` must be provided.
+    tensor_stride : int, sequence of int or torch.Tensor, default 1
+        Spatial stride represented by the input coordinates.
+    coordinate_map_key : Any, optional
+        Existing backend coordinate-map key used when replacing features.
+    coordinate_manager : Any, optional
+        Existing backend coordinate manager paired with
+        ``coordinate_map_key``.
+    feats : torch.Tensor, optional
+        Compatibility alias for ``features``.
+    coords : torch.Tensor, optional
+        Compatibility alias for ``coordinates``.
+    coords_key : Any, optional
+        Compatibility alias for ``coordinate_map_key``.
+    coords_manager : Any, optional
+        Compatibility alias for ``coordinate_manager``.
+    batch_size : int, optional
+        Number of batch entries. This must be supplied to preserve trailing
+        empty entries that cannot be inferred from coordinates.
+    duplicate_reduction : {"sum", "mean", "first"}, default "sum"
+        Reduction applied to features with identical coordinates before the
+        backend tensor is constructed.
+    source : SparseTensor, optional
+        Tensor whose input-row provenance should be propagated.
+    **kwargs : Any
+        Additional arguments forwarded to the backend tensor constructor.
+
+    Notes
+    -----
+    Sparse backends require one feature vector per active coordinate. SPINE
+    therefore coalesces duplicate coordinates but retains their original row
+    mapping. Calling :meth:`aligned_features` or setting ``restore=True`` in
+    :meth:`to_tensor_batch` repeats processed voxel features in the original
+    input order. It does not recover distinctions discarded by the duplicate
+    reduction.
+
+    Examples
+    --------
+    Duplicate feature rows are summed internally but remain recoverable as
+    logical output rows:
+
+    >>> coordinates = torch.tensor([[0, 1, 2], [0, 1, 2]], dtype=torch.int32)
+    >>> features = torch.tensor([[2.0], [3.0]])
+    >>> tensor = SparseTensor(features, coordinates)
+    >>> tensor.F
+    tensor([[5.]])
+    >>> tensor.aligned_features()
+    tensor([[5.],
+            [5.]])
+    """
+
+    def __init__(
+        self,
+        features: torch.Tensor | None = None,
+        coordinates: torch.Tensor | None = None,
+        tensor_stride: int | Sequence[int] | torch.Tensor = 1,
+        coordinate_map_key: Any = None,
+        coordinate_manager: Any = None,
+        *,
+        feats: torch.Tensor | None = None,
+        coords: torch.Tensor | None = None,
+        coords_key: Any = None,
+        coords_manager: Any = None,
+        batch_size: int | None = None,
+        duplicate_reduction: str = "sum",
+        source: "SparseTensor | None" = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the sparse tensor and its input-row provenance."""
+        if features is None:
+            features = feats
+        if coordinates is None:
+            coordinates = coords
+        if coordinate_map_key is None:
+            coordinate_map_key = coords_key
+        if coordinate_manager is None:
+            coordinate_manager = coords_manager
+        if features is None:
+            raise ValueError("SparseTensor requires `features`.")
+        if features.ndim == 1:
+            features = features[:, None]
+
+        self._backend_tensor = None
+        self._batch_size = batch_size
+        self._reference_coordinates = None
+        self._reference_counts = None
+        self._unique_index = None
+        self._inverse_index = None
+
+        if coordinates is not None:
+            if coordinates.ndim != 2 or features.ndim != 2:
+                raise ValueError("Sparse coordinates and features must be matrices.")
+            if len(coordinates) != len(features):
+                raise ValueError(
+                    "Sparse coordinates and features must have equal length."
+                )
+
+            dimension = coordinates.shape[1] - 1
+            self._tensor_stride = _normalize_stride(tensor_stride, dimension)
+            self._reference_coordinates = coordinates
+            if batch_size is None:
+                batch_size = (
+                    int(coordinates[:, 0].max().item()) + 1 if len(coordinates) else 0
+                )
+            self._batch_size = batch_size
+            self._reference_counts = self._counts_from_coordinates(
+                coordinates, batch_size
+            )
+
+            unique_coords, unique_feats, unique_index, inverse_index = _coalesce(
+                coordinates, features, duplicate_reduction
+            )
+            self._unique_index = unique_index
+            self._inverse_index = inverse_index
+            self._coordinates = unique_coords
+            self._features = unique_feats
+        else:
+            if coordinate_map_key is None or coordinate_manager is None:
+                raise ValueError(
+                    "Provide coordinates or both a coordinate map key and manager."
+                )
+            self._features = features
+            self._coordinates = None
+            dimension = len(coordinate_map_key.get_tensor_stride())
+            self._tensor_stride = _normalize_stride(
+                coordinate_map_key.get_tensor_stride(), dimension
+            )
+
+        if source is not None:
+            self._batch_size = source.batch_size
+            self._reference_coordinates = source._reference_coordinates
+            self._reference_counts = source._reference_counts
+            self._unique_index = source._unique_index
+            self._inverse_index = source._inverse_index
+
+        if len(self._features):
+            if coordinates is not None:
+                self._backend_tensor = backend.create_tensor(
+                    features=self._features,
+                    coordinates=self._coordinates,
+                    tensor_stride=self._tensor_stride,
+                    coordinate_manager=coordinate_manager,
+                    **kwargs,
+                )
+            else:
+                self._backend_tensor = backend.create_tensor(
+                    features=self._features,
+                    coordinate_map_key=coordinate_map_key,
+                    coordinate_manager=coordinate_manager,
+                    **kwargs,
+                )
+
+    @classmethod
+    def from_backend(
+        cls, backend_tensor: Any, source: "SparseTensor | None" = None
+    ) -> "SparseTensor":
+        """Wrap a backend result and propagate SPINE metadata.
+
+        Parameters
+        ----------
+        backend_tensor : Any
+            Native sparse tensor returned by a backend operation.
+        source : SparseTensor, optional
+            Input tensor from which batch and row-provenance metadata should
+            be inherited.
+
+        Returns
+        -------
+        SparseTensor
+            Backend-neutral wrapper around ``backend_tensor``.
+        """
+        obj = cls.__new__(cls)
+        obj._backend_tensor = backend_tensor
+        obj._features = backend.features(backend_tensor)
+        obj._coordinates = backend.coordinates(backend_tensor)
+        obj._tensor_stride = backend.tensor_stride(backend_tensor)
+        obj._batch_size = source.batch_size if source is not None else None
+        obj._reference_coordinates = (
+            source._reference_coordinates if source is not None else None
+        )
+        obj._reference_counts = source._reference_counts if source is not None else None
+        obj._unique_index = source._unique_index if source is not None else None
+        obj._inverse_index = source._inverse_index if source is not None else None
+        return obj
+
+    @classmethod
+    def empty_like(
+        cls,
+        source: "SparseTensor",
+        channels: int | None = None,
+        tensor_stride: int | Sequence[int] | torch.Tensor | None = None,
+    ) -> "SparseTensor":
+        """Create an empty result without entering the sparse backend.
+
+        Parameters
+        ----------
+        source : SparseTensor
+            Tensor supplying device, dtype, coordinates, and provenance.
+        channels : int, optional
+            Output feature count. By default, preserve the source count.
+        tensor_stride : int, sequence of int or torch.Tensor, optional
+            Output spatial stride. By default, preserve the source stride.
+
+        Returns
+        -------
+        SparseTensor
+            Empty tensor carrying the requested output metadata.
+        """
+        obj = cls.__new__(cls)
+        num_channels = source.F.shape[1] if channels is None else channels
+        obj._backend_tensor = None
+        obj._features = source.F.new_empty((0, num_channels))
+        obj._coordinates = source.C.new_empty((0, source.C.shape[1]))
+        obj._tensor_stride = _normalize_stride(
+            source.tensor_stride if tensor_stride is None else tensor_stride,
+            source.dimension,
+        )
+        obj._batch_size = source.batch_size
+        obj._reference_coordinates = source._reference_coordinates
+        obj._reference_counts = source._reference_counts
+        obj._unique_index = source._unique_index
+        obj._inverse_index = source._inverse_index
+        return obj
+
+    @staticmethod
+    def _counts_from_coordinates(
+        coordinates: torch.Tensor, batch_size: int
+    ) -> torch.Tensor:
+        """Count active coordinate rows in each batch entry."""
+        if not len(coordinates):
+            return torch.zeros(batch_size, dtype=torch.long, device=coordinates.device)
+        return torch.bincount(coordinates[:, 0].long(), minlength=batch_size).to(
+            coordinates.device
+        )
+
+    @property
+    def F(self) -> torch.Tensor:
+        """Return the ``(N, C)`` sparse feature matrix."""
+        return self._features
+
+    @property
+    def C(self) -> torch.Tensor:
+        """Return the ``(N, D + 1)`` batched coordinate matrix."""
+        if self._coordinates is None and self._backend_tensor is not None:
+            self._coordinates = backend.coordinates(self._backend_tensor)
+        return self._coordinates
+
+    features = F
+    coordinates = C
+    feats = F
+    coords = C
+
+    @property
+    def dtype(self) -> torch.dtype:
+        """Return the feature data type."""
+        return self.F.dtype
+
+    @property
+    def device(self) -> torch.device:
+        """Return the device holding the feature matrix."""
+        return self.F.device
+
+    @property
+    def shape(self) -> torch.Size:
+        """Return the shape of the feature matrix."""
+        return self.F.shape
+
+    @property
+    def dimension(self) -> int:
+        """Return the number of spatial coordinate dimensions."""
+        return self.C.shape[1] - 1
+
+    @property
+    def tensor_stride(self) -> tuple[int, ...]:
+        """Return the stride represented by each spatial coordinate axis."""
+        return self._tensor_stride
+
+    @property
+    def batch_size(self) -> int:
+        """Return the number of batch entries, including trailing empty ones."""
+        if self._batch_size is not None:
+            return self._batch_size
+        return int(self.C[:, 0].max().item()) + 1 if len(self) else 0
+
+    @property
+    def counts(self) -> torch.Tensor:
+        """Return the number of active sparse sites in each batch entry."""
+        return self._counts_from_coordinates(self.C, self.batch_size)
+
+    @property
+    def decomposed_coordinates(self) -> list[torch.Tensor]:
+        """Spatial coordinates separated by batch, including empty entries."""
+        return [self.coordinates_at(batch_id) for batch_id in range(self.batch_size)]
+
+    @property
+    def decomposed_features(self) -> list[torch.Tensor]:
+        """Features separated by batch, including empty entries."""
+        return [self.features_at(batch_id) for batch_id in range(self.batch_size)]
+
+    @property
+    def decomposed_coordinates_and_features(
+        self,
+    ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+        """Return per-entry coordinates and features as parallel lists."""
+        return self.decomposed_coordinates, self.decomposed_features
+
+    @property
+    def coordinate_map_key(self) -> Any:
+        """Return the backend coordinate-map key, or ``None`` when empty."""
+        if self._backend_tensor is None:
+            return None
+        return backend.coordinate_map_key(self._backend_tensor)
+
+    @property
+    def coordinate_manager(self) -> Any:
+        """Return the backend coordinate manager, or ``None`` when empty."""
+        if self._backend_tensor is None:
+            return None
+        return backend.coordinate_manager(self._backend_tensor)
+
+    coords_key = coordinate_map_key
+    coords_man = coordinate_manager
+
+    @property
+    def backend_tensor(self) -> Any:
+        """Return the native tensor consumed by backend-selected modules.
+
+        Returns
+        -------
+        Any
+            Native backend tensor, or ``None`` when there are no active sites.
+
+        Notes
+        -----
+        Model code should not depend on this property. It exists for operation
+        wrappers and backend integration.
+        """
+        return self._backend_tensor
+
+    @property
+    def unique_index(self) -> torch.Tensor | None:
+        """Return first input-row indices for the coalesced coordinates."""
+        return self._unique_index
+
+    @property
+    def inverse_mapping(self) -> torch.Tensor | None:
+        """Map each original input row to its coalesced coordinate."""
+        return self._inverse_index
+
+    @property
+    def reference_size(self) -> int:
+        """Number of logical rows represented by the input reference."""
+        if self._reference_coordinates is None:
+            return len(self)
+        return len(self._reference_coordinates)
+
+    def __len__(self) -> int:
+        """Return the number of active, unique sparse sites."""
+        return len(self.F)
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate backend-specific read access during the migration period."""
+        if name.startswith("_") or self._backend_tensor is None:
+            raise AttributeError(name)
+        return getattr(self._backend_tensor, name)
+
+    def features_at(self, batch_id: int) -> torch.Tensor:
+        """Return active features belonging to one batch entry.
+
+        Parameters
+        ----------
+        batch_id : int
+            Batch entry to select.
+
+        Returns
+        -------
+        torch.Tensor
+            ``(N_i, C)`` feature matrix for the selected entry.
+        """
+        return self.F[self.C[:, 0].long() == batch_id]
+
+    def coordinates_at(self, batch_id: int) -> torch.Tensor:
+        """Return spatial coordinates belonging to one batch entry.
+
+        Parameters
+        ----------
+        batch_id : int
+            Batch entry to select.
+
+        Returns
+        -------
+        torch.Tensor
+            ``(N_i, D)`` spatial coordinates without the batch column.
+        """
+        mask = self.C[:, 0].long() == batch_id
+        return self.C[mask, 1:]
+
+    def _wrap(self, backend_tensor: Any) -> "SparseTensor":
+        """Wrap a backend result and inherit this tensor's provenance."""
+        return SparseTensor.from_backend(backend_tensor, self)
+
+    def replace_features(self, features: torch.Tensor) -> "SparseTensor":
+        """Return a tensor on the same coordinate map with new features.
+
+        Parameters
+        ----------
+        features : torch.Tensor
+            ``(N, C_out)`` feature matrix aligned with the active coordinates.
+
+        Returns
+        -------
+        SparseTensor
+            Tensor sharing coordinates and provenance with this tensor.
+        """
+        if not len(self):
+            result = SparseTensor.empty_like(self, features.shape[1])
+            result._features = features
+            return result
+        backend_tensor = backend.create_tensor(
+            features=features,
+            coordinate_map_key=self.coordinate_map_key,
+            coordinate_manager=self.coordinate_manager,
+        )
+        return self._wrap(backend_tensor)
+
+    def aligned_features(self) -> torch.Tensor:
+        """Restore features to the original input rows.
+
+        Returns
+        -------
+        torch.Tensor
+            Feature matrix in the original input order and with the original
+            row multiplicity. Duplicate rows receive the same processed sparse
+            feature vector.
+        """
+        reference = self._reference_coordinates
+        if reference is None:
+            return self.F
+        if not len(self):
+            return self.F.new_zeros((len(reference), self.F.shape[1]))
+        queries = reference.to(device=self.C.device, dtype=self.F.dtype)
+        return backend.features_at_coordinates(self.backend_tensor, queries)
+
+    def to_tensor_batch(
+        self, *, include_coordinates: bool = True, restore: bool = False
+    ) -> TensorBatch:
+        """Convert sparse model data to a portable tensor batch.
+
+        Parameters
+        ----------
+        include_coordinates : bool, default True
+            Prefix each output feature row with its batched coordinates.
+        restore : bool, default False
+            Restore original input ordering and duplicate multiplicity.
+
+        Returns
+        -------
+        TensorBatch
+            Dense batched representation suitable for output handling and
+            unwrapping.
+        """
+        if restore and self._reference_coordinates is not None:
+            features = self.aligned_features()
+            coordinates = self._reference_coordinates
+            counts = self._reference_counts
+        else:
+            features = self.F
+            coordinates = self.C
+            counts = self.counts
+
+        if not include_coordinates:
+            return TensorBatch(features, counts)
+
+        data = torch.cat([coordinates.to(features.dtype), features], dim=1)
+        return TensorBatch(
+            data,
+            counts,
+            has_batch_col=True,
+            coord_cols=tuple(range(1, coordinates.shape[1])),
+        )
+
+    def detach(self) -> "SparseTensor":
+        """Return a tensor whose features are detached from autograd.
+
+        Returns
+        -------
+        SparseTensor
+            Tensor sharing coordinates and provenance with detached features.
+        """
+        return self.replace_features(self.F.detach())
+
+    def float(self) -> "SparseTensor":
+        """Cast sparse features to single precision.
+
+        Returns
+        -------
+        SparseTensor
+            Tensor sharing coordinates and provenance with ``float32``
+            features.
+        """
+        return self.replace_features(self.F.float())
+
+    def __add__(self, other: Any) -> "SparseTensor":
+        """Add another sparse tensor or a value to the feature matrix."""
+        if isinstance(other, SparseTensor):
+            if not len(self) and not len(other):
+                return SparseTensor.empty_like(self)
+            return self._wrap(self.backend_tensor + other.backend_tensor)
+        return self.replace_features(self.F + other)
+
+    def __mul__(self, other: Any) -> "SparseTensor":
+        """Multiply by another sparse tensor or a feature-wise value."""
+        if isinstance(other, SparseTensor):
+            if not len(self) and not len(other):
+                return SparseTensor.empty_like(self)
+            return self._wrap(self.backend_tensor * other.backend_tensor)
+        return self.replace_features(self.F * other)
+
+    def __truediv__(self, other: Any) -> "SparseTensor":
+        """Divide by another sparse tensor or a feature-wise value."""
+        if isinstance(other, SparseTensor):
+            if not len(self) and not len(other):
+                return SparseTensor.empty_like(self)
+            return self._wrap(self.backend_tensor / other.backend_tensor)
+        return self.replace_features(self.F / other)

--- a/src/spine/model/sparse/tensor.py
+++ b/src/spine/model/sparse/tensor.py
@@ -38,84 +38,6 @@ def _normalize_stride(
     return tuple(int(value) for value in stride)
 
 
-def _coalesce(
-    coordinates: torch.Tensor,
-    features: torch.Tensor,
-    reduction: str,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Coalesce duplicate coordinates and retain row provenance.
-
-    Parameters
-    ----------
-    coordinates : torch.Tensor
-        ``(N, D + 1)`` integer coordinate matrix. The first column contains
-        batch indices.
-    features : torch.Tensor
-        ``(N, C)`` feature matrix aligned with ``coordinates``.
-    reduction : {"sum", "mean", "first"}
-        Rule used to combine features at identical coordinates.
-
-    Returns
-    -------
-    unique_coordinates : torch.Tensor
-        Coordinate matrix containing one row per active sparse site.
-    unique_features : torch.Tensor
-        Reduced feature matrix aligned with ``unique_coordinates``.
-    unique_index : torch.Tensor
-        Original row index of the first occurrence of each unique coordinate.
-    inverse_index : torch.Tensor
-        Unique-coordinate index associated with every original row.
-
-    Raises
-    ------
-    ValueError
-        If ``reduction`` is not a supported reduction rule.
-    """
-    unique, inverse = torch.unique(coordinates, dim=0, return_inverse=True)
-    if len(unique) == len(coordinates):
-        index = torch.arange(len(coordinates), device=coordinates.device)
-        return coordinates, features, index, index
-
-    if reduction not in {"mean", "sum", "first"}:
-        raise ValueError(
-            f"Unknown duplicate reduction `{reduction}`. "
-            "Choose from 'mean', 'sum' or 'first'."
-        )
-
-    num_unique = len(unique)
-    if reduction in {"mean", "sum"}:
-        reduced = features.new_zeros((num_unique, features.shape[1]))
-        reduced.index_add_(0, inverse, features)
-        if reduction == "mean":
-            counts = features.new_zeros(num_unique)
-            counts.index_add_(0, inverse, features.new_ones(len(features)))
-            reduced = reduced / counts[:, None]
-    else:
-        row_ids = torch.arange(
-            len(coordinates), device=coordinates.device, dtype=torch.long
-        )
-        first = torch.full(
-            (num_unique,),
-            len(coordinates),
-            device=coordinates.device,
-            dtype=torch.long,
-        )
-        first.scatter_reduce_(0, inverse, row_ids, reduce="amin", include_self=True)
-        reduced = features[first]
-
-    row_ids = torch.arange(
-        len(coordinates), device=coordinates.device, dtype=torch.long
-    )
-    first = torch.full(
-        (num_unique,),
-        len(coordinates),
-        device=coordinates.device,
-        dtype=torch.long,
-    )
-    first.scatter_reduce_(0, inverse, row_ids, reduce="amin", include_self=True)
-    return unique, reduced, first, inverse
-
-
 class SparseTensor:
     """Sparse model-runtime tensor.
 
@@ -152,8 +74,7 @@ class SparseTensor:
         Number of batch entries. This must be supplied to preserve trailing
         empty entries that cannot be inferred from coordinates.
     duplicate_reduction : {"sum", "mean", "first"}, default "sum"
-        Reduction applied to features with identical coordinates before the
-        backend tensor is constructed.
+        Reduction the backend applies to features with identical coordinates.
     source : SparseTensor, optional
         Tensor whose input-row provenance should be propagated.
     **kwargs : Any
@@ -161,12 +82,13 @@ class SparseTensor:
 
     Notes
     -----
-    Sparse backends require one feature vector per active coordinate. SPINE
-    therefore coalesces duplicate coordinates but retains their original row
-    mapping. Calling :meth:`aligned_features` or setting ``restore=True`` in
+    Sparse backends require one feature vector per active coordinate. The
+    selected backend therefore coalesces duplicate coordinates while SPINE
+    retains original-row provenance only when quantization reduces the input
+    length. Calling :meth:`aligned_features` or setting ``restore=True`` in
     :meth:`to_tensor_batch` repeats processed voxel features in the original
     input order. It does not recover distinctions discarded by the duplicate
-    reduction.
+    reduction. Unique inputs stay on the backend's native fast path.
 
     Examples
     --------
@@ -228,26 +150,21 @@ class SparseTensor:
                 raise ValueError(
                     "Sparse coordinates and features must have equal length."
                 )
+            if duplicate_reduction not in {"mean", "sum", "first"}:
+                raise ValueError(
+                    f"Unknown duplicate reduction `{duplicate_reduction}`. "
+                    "Choose from 'mean', 'sum' or 'first'."
+                )
 
             dimension = coordinates.shape[1] - 1
             self._tensor_stride = _normalize_stride(tensor_stride, dimension)
-            self._reference_coordinates = coordinates
             if batch_size is None:
                 batch_size = (
                     int(coordinates[:, 0].max().item()) + 1 if len(coordinates) else 0
                 )
             self._batch_size = batch_size
-            self._reference_counts = self._counts_from_coordinates(
-                coordinates, batch_size
-            )
-
-            unique_coords, unique_feats, unique_index, inverse_index = _coalesce(
-                coordinates, features, duplicate_reduction
-            )
-            self._unique_index = unique_index
-            self._inverse_index = inverse_index
-            self._coordinates = unique_coords
-            self._features = unique_feats
+            self._coordinates = coordinates
+            self._features = features
         else:
             if coordinate_map_key is None or coordinate_manager is None:
                 raise ValueError(
@@ -260,13 +177,6 @@ class SparseTensor:
                 coordinate_map_key.get_tensor_stride(), dimension
             )
 
-        if source is not None:
-            self._batch_size = source.batch_size
-            self._reference_coordinates = source._reference_coordinates
-            self._reference_counts = source._reference_counts
-            self._unique_index = source._unique_index
-            self._inverse_index = source._inverse_index
-
         if len(self._features):
             if coordinates is not None:
                 self._backend_tensor = backend.create_tensor(
@@ -274,8 +184,18 @@ class SparseTensor:
                     coordinates=self._coordinates,
                     tensor_stride=self._tensor_stride,
                     coordinate_manager=coordinate_manager,
+                    duplicate_reduction=duplicate_reduction,
                     **kwargs,
                 )
+                self._features = backend.features(self._backend_tensor)
+                self._coordinates = backend.coordinates(self._backend_tensor)
+                self._unique_index = backend.unique_index(self._backend_tensor)
+                self._inverse_index = backend.inverse_mapping(self._backend_tensor)
+                if len(self._features) != len(features):
+                    self._reference_coordinates = coordinates
+                    self._reference_counts = self._counts_from_coordinates(
+                        coordinates, self._batch_size
+                    )
             else:
                 self._backend_tensor = backend.create_tensor(
                     features=self._features,
@@ -283,6 +203,17 @@ class SparseTensor:
                     coordinate_manager=coordinate_manager,
                     **kwargs,
                 )
+        elif coordinates is not None:
+            identity = torch.arange(0, device=features.device)
+            self._unique_index = identity
+            self._inverse_index = identity
+
+        if source is not None:
+            self._batch_size = source.batch_size
+            self._reference_coordinates = source._reference_coordinates
+            self._reference_counts = source._reference_counts
+            self._unique_index = source._unique_index
+            self._inverse_index = source._inverse_index
 
     @classmethod
     def from_backend(

--- a/src/spine/model/transformer.py
+++ b/src/spine/model/transformer.py
@@ -1,13 +1,13 @@
 from collections import defaultdict
 from pprint import pprint
 
-import MinkowskiEngine as ME
 import numpy as np
 import torch
 import torch.nn as nn
 from scipy.optimize import linear_sum_assignment
 
 from spine.constants import *
+from spine.model import sparse
 from spine.model.experimental.cluster.criterion import *
 from spine.model.experimental.cluster.transformer_spice import TransformerSPICE
 
@@ -84,9 +84,6 @@ class Mask3dLoss(nn.Module):
     ------
     To be completed.
 
-    See Also
-    --------
-    MinkGraphSPICE
     """
 
     def __init__(self, cfg, name="mask3d"):

--- a/src/spine/model/uresnet.py
+++ b/src/spine/model/uresnet.py
@@ -2,13 +2,13 @@
 
 from collections import defaultdict
 
-import MinkowskiEngine as ME
 import numpy as np
 import torch
 import torch.nn as nn
 
 from spine.constants import BATCH_COL, COORD_COLS, GHOST_SHP, VALUE_COL
 from spine.data import TensorBatch
+from spine.model import sparse
 from spine.utils.logger import logger
 from spine.utils.torch.scripts import cdist_fast
 
@@ -65,14 +65,12 @@ class UResNetSegmentation(nn.Module):
             act_factory(self.backbone.act_cfg),
         ]
         self.output = nn.Sequential(*self.output)
-        self.linear_segmentation = ME.MinkowskiLinear(
-            self.num_filters, self.num_classes
-        )
+        self.linear_segmentation = sparse.Linear(self.num_filters, self.num_classes)
 
         # If needed, activate the ghost classification layer
         if self.ghost:
             logger.debug("Ghost Masking is enabled for UResNet Segmentation")
-            self.linear_ghost = ME.MinkowskiLinear(self.num_filters, 2)
+            self.linear_ghost = sparse.Linear(self.num_filters, 2)
 
     def process_model_config(self, num_classes, ghost=False, **backbone):
         """Initialize the underlying UResNet model.
@@ -116,7 +114,7 @@ class UResNetSegmentation(nn.Module):
         input_tensor = data.tensor[:, :num_cols]
 
         # Pass the data through the UResNet backbone
-        result_backbone = self.backbone(input_tensor)
+        result_backbone = self.backbone(input_tensor, batch_size=data.batch_size)
 
         # Pass the output features through the output layer
         feats = result_backbone["decoder_tensors"][-1]
@@ -124,20 +122,11 @@ class UResNetSegmentation(nn.Module):
         seg = self.linear_segmentation(feats)
 
         # Store the output as tensor batches
-        segmentation = TensorBatch(seg.F, data.counts)
+        segmentation = TensorBatch(seg.aligned_features(), data.counts)
 
-        batch_size = data.batch_size
-        final_tensor = TensorBatch(
-            result_backbone["final_tensor"], batch_size=batch_size, is_sparse=True
-        )
-        encoder_tensors = [
-            TensorBatch(t, batch_size=batch_size, is_sparse=True)
-            for t in result_backbone["encoder_tensors"]
-        ]
-        decoder_tensors = [
-            TensorBatch(t, batch_size=batch_size, is_sparse=True)
-            for t in result_backbone["decoder_tensors"]
-        ]
+        final_tensor = result_backbone["final_tensor"]
+        encoder_tensors = result_backbone["encoder_tensors"]
+        decoder_tensors = result_backbone["decoder_tensors"]
 
         result = {
             "segmentation": segmentation,
@@ -150,8 +139,8 @@ class UResNetSegmentation(nn.Module):
         if self.ghost:
             ghost = self.linear_ghost(feats)
 
-            result["ghost"] = TensorBatch(ghost.F, data.counts)
-            result["ghost_tensor"] = TensorBatch(ghost, data.counts, is_sparse=True)
+            result["ghost"] = TensorBatch(ghost.aligned_features(), data.counts)
+            result["ghost_tensor"] = ghost
 
         return result
 

--- a/src/spine/model/vertex.py
+++ b/src/spine/model/vertex.py
@@ -1,14 +1,13 @@
 import time
 from collections import defaultdict
 
-import MinkowskiEngine as ME
-import MinkowskiFunctional as MF
 import numpy as np
 import torch
 import torch.nn as nn
 from torch_geometric.data import Batch, Data
 
 from spine.constants import BATCH_COL, INTER_COL, NU_COL, VTX_COLS
+from spine.model import sparse
 from spine.model.experimental.layer.pointnet import PointNetEncoder
 from spine.model.layer.cnn.vertex_ppn import VertexPPN, VertexPPNLoss
 from spine.model.uresnet import SegmentationLoss, UResNetSegmentation
@@ -29,7 +28,7 @@ class VertexPPNChain(nn.Module):
         self.vertex_ppn = VertexPPN(cfg)
         self.num_classes = self.backbone.num_classes
         self.num_filters = self.backbone.F
-        self.segmentation = ME.MinkowskiLinear(self.num_filters, self.num_classes)
+        self.segmentation = sparse.Linear(self.num_filters, self.num_classes)
 
     def forward(self, input):
 

--- a/src/spine/utils/__init__.py
+++ b/src/spine/utils/__init__.py
@@ -4,7 +4,7 @@ This module contains reusable utility functions organized into several categorie
 
 Core utilities:
 
-- ``conditional`` for optional imports such as ROOT, LArCV, MinkowskiEngine, and PyTorch.
+- ``conditional`` for optional imports such as ROOT, LArCV, and PyTorch.
 - ``factory`` and ``logger`` for application infrastructure.
 - ``globals`` for deprecated shared-constant compatibility.
 

--- a/src/spine/utils/conditional.py
+++ b/src/spine/utils/conditional.py
@@ -10,56 +10,16 @@ import importlib
 import importlib.util
 import os
 import sys
-from typing import TYPE_CHECKING, Any, Protocol, TypeGuard
+from typing import TYPE_CHECKING, Any
 
 __all__ = [
     "ROOT",
     "larcv",
     "torch",
-    "ME",
-    "MF",
     "ROOT_AVAILABLE",
     "LARCV_AVAILABLE",
     "TORCH_AVAILABLE",
-    "ME_AVAILABLE",
-    "SparseTensorLike",
 ]
-
-
-class SparseTensorLike(Protocol):
-    """Structural type for MinkowskiEngine sparse tensors.
-
-    MinkowskiEngine is an optional runtime dependency exposed through a lazy
-    proxy, so ``ME.SparseTensor`` cannot be used directly in type expressions.
-    This protocol captures the sparse tensor surface used by SPINE without
-    making static analysis depend on MinkowskiEngine stubs.
-    """
-
-    dtype: Any
-    device: Any
-    F: Any
-    C: Any
-    coordinate_map_key: Any
-    coordinate_manager: Any
-
-    def __len__(self) -> int: ...
-
-    def __getitem__(self, index: Any) -> Any: ...
-
-    def features_at(self, batch_id: int) -> Any: ...
-
-    def coordinates_at(self, batch_id: int) -> Any: ...
-
-
-def is_sparse_tensor_like(obj: object) -> TypeGuard[SparseTensorLike]:
-    """Check whether an object exposes the sparse tensor API SPINE uses."""
-    return (
-        hasattr(obj, "dtype")
-        and hasattr(obj, "F")
-        and hasattr(obj, "C")
-        and hasattr(obj, "coordinate_map_key")
-        and hasattr(obj, "coordinate_manager")
-    )
 
 
 class _MissingType:
@@ -159,22 +119,9 @@ class _MissingTorch(_LazyModule):
         return _MissingNamespace(self._error)
 
 
-class _MissingME(_LazyModule):
-    """MinkowskiEngine proxy with a SparseTensor placeholder when unavailable."""
-
-    SparseTensor = _MissingType
-
-    def __getattr__(self, name: str) -> Any:
-        if name and name[0].isupper():
-            return _MissingType
-        return _MissingNamespace(self._error)
-
-
 def _module_available(module_name: str) -> bool:
     if os.getenv("SPINE_DOC_BUILD") and module_name in {
         "torch",
-        "MinkowskiEngine",
-        "MinkowskiFunctional",
         "larcv",
         "ROOT",
     }:
@@ -216,11 +163,7 @@ def _module_available(module_name: str) -> bool:
 ROOT_AVAILABLE = _module_available("ROOT")
 LARCV_AVAILABLE = _module_available("larcv")
 TORCH_AVAILABLE = _module_available("torch")
-ME_AVAILABLE = _module_available("MinkowskiEngine")
-
 if TYPE_CHECKING:
-    import MinkowskiEngine as ME
-    import MinkowskiFunctional as MF
     import ROOT
     import torch
     from larcv import larcv
@@ -234,22 +177,3 @@ else:
         torch = _LazyModule("torch", "torch", "PyTorch is required.")
     else:
         torch = _MissingTorch("torch", "torch", "PyTorch is required.")
-
-    if ME_AVAILABLE:
-        ME = _LazyModule(
-            "MinkowskiEngine", "MinkowskiEngine", "MinkowskiEngine is required."
-        )
-        MF = _LazyModule(
-            "MinkowskiFunctional",
-            "MinkowskiFunctional",
-            "MinkowskiFunctional is required.",
-        )
-    else:
-        ME = _MissingME(
-            "MinkowskiEngine", "MinkowskiEngine", "MinkowskiEngine is required."
-        )
-        MF = _LazyModule(
-            "MinkowskiFunctional",
-            "MinkowskiFunctional",
-            "MinkowskiFunctional is required.",
-        )

--- a/test/test_bin/test_cli.py
+++ b/test/test_bin/test_cli.py
@@ -396,6 +396,11 @@ def test_get_version_show_info_and_dependency_checks(monkeypatch, capsys):
         return original_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", fake_missing_dep_import)
+    monkeypatch.setattr(
+        cli_module,
+        "package_version",
+        lambda name: (_ for _ in ()).throw(cli_module.PackageNotFoundError(name)),
+    )
     deps = cli_module.check_dependencies()
     assert deps["torch"] is None
     assert deps["minkowski"] is None
@@ -423,6 +428,11 @@ def test_get_version_and_dependency_checks_success(monkeypatch):
         return original_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", fake_dep_import)
+    monkeypatch.setattr(
+        cli_module,
+        "package_version",
+        lambda name: {"MinkowskiEngine": "0.5.4"}[name],
+    )
 
     assert cli_module.get_version() == __version__
     deps = cli_module.check_dependencies()

--- a/test/test_bin/test_output_compare.py
+++ b/test/test_bin/test_output_compare.py
@@ -1,0 +1,233 @@
+"""Tests for the SPINE HDF5 output comparison utility."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+
+def load_output_compare_module():
+    """Import ``bin/output/output_compare.py`` as a test module."""
+    script_path = (
+        Path(__file__).resolve().parents[2] / "bin" / "output" / "output_compare.py"
+    )
+    spec = importlib.util.spec_from_file_location("output_compare", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_output_file(
+    path: Path,
+    values: list[np.ndarray],
+    *,
+    labels: list[np.ndarray] | None = None,
+) -> None:
+    """Create a minimal multi-event SPINE-style HDF5 output."""
+    ref_dtype = h5py.special_dtype(ref=h5py.RegionReference)
+    event_dtype = [("values", ref_dtype)]
+    if labels is not None:
+        event_dtype.append(("labels", ref_dtype))
+
+    with h5py.File(path, "w") as out_file:
+        events = out_file.create_dataset(
+            "events", (len(values),), dtype=np.dtype(event_dtype)
+        )
+        flat_values = np.concatenate(values)
+        value_ds = out_file.create_dataset("values", data=flat_values, maxshape=(None,))
+        value_ds.attrs["scalar"] = False
+
+        labels_ds = None
+        if labels is not None:
+            flat_labels = np.concatenate(labels)
+            labels_ds = out_file.create_dataset(
+                "labels", data=flat_labels, maxshape=(None,)
+            )
+            labels_ds.attrs["scalar"] = False
+
+        value_offset = 0
+        label_offset = 0
+        for idx, event_values in enumerate(values):
+            event = np.zeros(1, dtype=np.dtype(event_dtype))
+            value_end = value_offset + len(event_values)
+            event["values"][0] = value_ds.regionref[value_offset:value_end]
+            value_offset = value_end
+            if labels is not None and labels_ds is not None:
+                label_end = label_offset + len(labels[idx])
+                event["labels"][0] = labels_ds.regionref[label_offset:label_end]
+                label_offset = label_end
+            events[idx] = event[0]
+
+
+def test_compare_files_exact_match(tmp_path):
+    """Identical semantic content should pass exact comparison."""
+    module = load_output_compare_module()
+    reference = tmp_path / "reference.h5"
+    candidate = tmp_path / "candidate.h5"
+    values = [
+        np.asarray([1.0, np.nan], dtype=np.float32),
+        np.asarray([], dtype=np.float32),
+    ]
+    make_output_file(reference, values)
+    make_output_file(candidate, values)
+
+    result = module.compare_files(reference, candidate, exact=True)
+
+    assert result.agrees
+    assert result.num_events == 2
+    assert result.num_products == 2
+    assert result.num_values == 2
+
+
+def test_compare_files_float_tolerance_and_exact(tmp_path):
+    """Tolerant comparison should accept noise that exact mode rejects."""
+    module = load_output_compare_module()
+    reference = tmp_path / "reference.h5"
+    candidate = tmp_path / "candidate.h5"
+    make_output_file(reference, [np.asarray([1.0, 0.0], dtype=np.float32)])
+    make_output_file(candidate, [np.asarray([1.0 + 5.0e-5, 5.0e-7], dtype=np.float32)])
+
+    tolerant = module.compare_files(reference, candidate, rtol=1.0e-4, atol=1.0e-6)
+    exact = module.compare_files(reference, candidate, exact=True)
+
+    assert tolerant.agrees
+    assert not exact.agrees
+    assert exact.num_mismatches == 1
+    assert "event[0].values[0]" in exact.differences[0]
+
+
+def test_compare_files_exact_non_float_and_schema(tmp_path):
+    """Non-floating data and event-product schemas must agree exactly."""
+    module = load_output_compare_module()
+    reference = tmp_path / "reference.h5"
+    candidate = tmp_path / "candidate.h5"
+    make_output_file(
+        reference,
+        [np.asarray([1.0], dtype=np.float32)],
+        labels=[np.asarray([1, 2], dtype=np.int64)],
+    )
+    make_output_file(
+        candidate,
+        [np.asarray([1.0], dtype=np.float32)],
+        labels=[np.asarray([1, 3], dtype=np.int64)],
+    )
+
+    result = module.compare_files(reference, candidate)
+
+    assert not result.agrees
+    assert result.num_mismatches == 1
+    assert "event[0].labels[1]" in result.differences[0]
+
+
+def test_compare_files_shape_and_event_count(tmp_path):
+    """Shape and event-count differences should produce clear failures."""
+    module = load_output_compare_module()
+    reference = tmp_path / "reference.h5"
+    shape_candidate = tmp_path / "shape.h5"
+    count_candidate = tmp_path / "count.h5"
+    make_output_file(reference, [np.asarray([1.0, 2.0], dtype=np.float32)])
+    make_output_file(shape_candidate, [np.asarray([1.0], dtype=np.float32)])
+    make_output_file(
+        count_candidate,
+        [
+            np.asarray([1.0, 2.0], dtype=np.float32),
+            np.asarray([3.0], dtype=np.float32),
+        ],
+    )
+
+    shape_result = module.compare_files(reference, shape_candidate)
+    count_result = module.compare_files(reference, count_candidate)
+
+    assert "shape differs" in shape_result.differences[0]
+    assert "count differs" in count_result.differences[0]
+
+
+def test_compare_files_key_selection(tmp_path):
+    """Key inclusion and exclusion should limit compared products."""
+    module = load_output_compare_module()
+    reference = tmp_path / "reference.h5"
+    candidate = tmp_path / "candidate.h5"
+    make_output_file(
+        reference,
+        [np.asarray([1.0], dtype=np.float32)],
+        labels=[np.asarray([1], dtype=np.int64)],
+    )
+    make_output_file(
+        candidate,
+        [np.asarray([2.0], dtype=np.float32)],
+        labels=[np.asarray([1], dtype=np.int64)],
+    )
+
+    included = module.compare_files(reference, candidate, keys=["labels"])
+    skipped = module.compare_files(reference, candidate, skip_keys=["values"])
+    missing = module.compare_files(reference, candidate, keys=["unknown"])
+
+    assert included.agrees
+    assert skipped.agrees
+    assert not missing.agrees
+    assert "missing products" in missing.differences[0]
+
+
+def test_compare_values_structured_and_object_fields():
+    """Structured variable-length object fields should compare recursively."""
+    module = load_output_compare_module()
+    dtype = np.dtype(
+        [("id", np.int64), ("scores", h5py.vlen_dtype(np.dtype("float32")))]
+    )
+    reference = np.empty(1, dtype=dtype)
+    candidate = np.empty(1, dtype=dtype)
+    reference["id"] = 4
+    candidate["id"] = 4
+    reference["scores"][0] = np.asarray([0.1, 0.2], dtype=np.float32)
+    candidate["scores"][0] = np.asarray([0.1, 0.3], dtype=np.float32)
+    result = module.ComparisonResult()
+
+    module.compare_values(
+        reference,
+        candidate,
+        "event[0].objects",
+        result,
+        rtol=0.0,
+        atol=0.0,
+        exact=True,
+    )
+
+    assert not result.agrees
+    assert "objects.scores[0][1]" in result.differences[0]
+
+
+def test_compare_files_rejects_invalid_options(tmp_path):
+    """Negative tolerances and report bounds should be rejected."""
+    module = load_output_compare_module()
+    path = tmp_path / "output.h5"
+    make_output_file(path, [np.asarray([1.0], dtype=np.float32)])
+
+    for kwargs in ({"rtol": -1.0}, {"atol": -1.0}, {"max_differences": -1}):
+        try:
+            module.compare_files(path, path, **kwargs)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"Expected ValueError for {kwargs}")
+
+
+def test_format_result():
+    """The text report should expose status, mode, and bounded differences."""
+    module = load_output_compare_module()
+    result = module.ComparisonResult(max_differences=1)
+    result.add_difference("event[0].x", "first")
+    result.add_difference("event[0].y", "second")
+
+    report = module.format_result(
+        result, "reference.h5", "candidate.h5", rtol=1.0e-4, atol=1.0e-6, exact=False
+    )
+
+    assert report.startswith("FAIL:")
+    assert "rtol=0.0001, atol=1e-06" in report
+    assert "1 additional mismatches not shown" in report

--- a/test/test_data/test_batch/test_base.py
+++ b/test/test_data/test_batch/test_base.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from spine.data.batch.base import BatchBase
-from spine.utils.conditional import ME, ME_AVAILABLE, TORCH_AVAILABLE, torch
+from spine.utils.conditional import TORCH_AVAILABLE, torch
 
 
 # Create a concrete implementation for testing the abstract BatchBase class
@@ -26,7 +26,9 @@ class ConcreteBatch(BatchBase):
         else:
             init_data = data
 
-        super().__init__(init_data, is_sparse=is_sparse, is_list=is_list)
+        if is_sparse:
+            raise TypeError("BatchBase no longer stores sparse model tensors.")
+        super().__init__(init_data, is_list=is_list)
         self.data = data
         self.counts = counts
         self.edges = edges
@@ -104,17 +106,6 @@ class TestBatchBaseInitialization:
         )
 
         assert batch_float.dtype == np.float64
-
-    def test_sparse_flag_requires_sparse_interface(self):
-        """Sparse initialization should reject non-sparse data."""
-        with pytest.raises(TypeError, match="Sparse batch data"):
-            ConcreteBatch(
-                data=np.array([1, 2, 3]),
-                counts=np.array([3]),
-                edges=np.array([0, 3]),
-                batch_size=1,
-                is_sparse=True,
-            )
 
 
 class TestBatchBaseLength:
@@ -720,25 +711,3 @@ class TestBatchBaseWithTorch:
 
         arange = batch._arange(5)
         assert torch.equal(arange, torch.arange(5))
-
-
-@pytest.mark.skipif(not ME_AVAILABLE, reason="ME not available")
-class TestBatchBaseWithME:
-    """Test BatchBase with MinkowskiEngine sparse tensors."""
-
-    def test_me_initialization(self):
-        """Test BatchBase detects ME sparse tensors correctly."""
-        coords = torch.tensor([[0, 0, 0], [1, 1, 1], [2, 2, 2]])
-        features = torch.tensor([[1], [2], [3]])
-        data = ME.SparseTensor(features=features, coordinates=coords)
-        batch = ConcreteBatch(
-            data=data,
-            counts=torch.tensor([3]),
-            edges=torch.tensor([0, 3]),
-            batch_size=1,
-            is_sparse=True,
-        )
-
-        assert batch.is_numpy is False
-        assert batch.is_sparse is True
-        assert batch.device == data.device

--- a/test/test_data/test_batch/test_tensor.py
+++ b/test/test_data/test_batch/test_tensor.py
@@ -6,26 +6,7 @@ import numpy as np
 import pytest
 
 from spine.data.batch.tensor import TensorBatch
-from spine.utils.conditional import ME, ME_AVAILABLE, TORCH_AVAILABLE, torch
-
-
-class SparseLike:
-    """Minimal sparse tensor-like object for validation branches."""
-
-    dtype = np.dtype(np.float32)
-    coordinate_map_key = object()
-    coordinate_manager = object()
-
-    def __init__(self):
-        self.F = Mock(device=None)
-        self.C = (
-            torch.tensor([[0, 0], [0, 1]])
-            if TORCH_AVAILABLE
-            else np.array([[0, 0], [0, 1]])
-        )
-
-    def __len__(self):
-        return 2
+from spine.utils.conditional import TORCH_AVAILABLE, torch
 
 
 class TestTensorBatchInitialization:
@@ -117,33 +98,6 @@ class TestTensorBatchInitialization:
 
         assert batch.batch_size == 0
         assert len(batch) == 0
-
-    def test_sparse_like_data_requires_sparse_flag(self):
-        """Sparse-like data should not silently initialize as dense."""
-        with pytest.raises(TypeError, match="is_sparse=True"):
-            TensorBatch(SparseLike(), batch_size=1, has_batch_col=True)
-
-    def test_internal_tensor_accessors_validate_storage(self):
-        """Internal accessors should reject the wrong tensor representation."""
-        dense = TensorBatch(np.ones((2, 2)), counts=[2])
-        with pytest.raises(TypeError, match="not sparse"):
-            dense._sparse_data
-
-        if not TORCH_AVAILABLE:
-            pytest.skip("torch not available")
-
-        sparse = TensorBatch(SparseLike(), counts=[2], is_sparse=True)
-        with pytest.raises(TypeError, match="is sparse"):
-            sparse._array_data
-
-    def test_sparse_like_counts_from_batch_column(self):
-        """Sparse-like data should infer counts from its coordinate batch column."""
-        if not TORCH_AVAILABLE:
-            pytest.skip("torch not available")
-
-        batch = TensorBatch(SparseLike(), batch_size=1, is_sparse=True)
-
-        assert torch.equal(batch.counts, torch.tensor([2]))
 
 
 class TestTensorBatchIndexing:
@@ -741,90 +695,3 @@ class TestTensorBatchWithTorch:
 
         with pytest.raises(ValueError, match="numpy arrays"):
             batch.to_px(meta)
-
-
-@pytest.mark.skipif(not ME_AVAILABLE, reason="ME not available")
-class TestTensorBatchWithME:
-    """Test TensorBatch with MinkowskiEngine tensors."""
-
-    def test_me_initialization(self):
-        """Test TensorBatch with ME tensors."""
-        data = ME.SparseTensor(
-            features=torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=torch.float32),
-            coordinates=torch.tensor(
-                [[0, 0, 0], [0, 1, 0], [1, 0, 0]], dtype=torch.int32
-            ),
-        )
-        counts = [3]
-
-        batch = TensorBatch(data, counts=counts, is_sparse=True)
-
-        assert batch.is_numpy is False
-        assert isinstance(batch.data, ME.SparseTensor)
-        assert batch.batch_size == 1
-        assert batch.device == torch.device("cpu")
-
-    def test_to_numpy_from_me(self):
-        """Test to_numpy converts ME SparseTensor to numpy."""
-        data = ME.SparseTensor(
-            features=torch.tensor([[1, 2], [3, 4]], dtype=torch.float32),
-            coordinates=torch.tensor([[0, 0, 0], [0, 1, 0]], dtype=torch.int32),
-        )
-        counts = [2]
-
-        batch = TensorBatch(data, counts=counts, is_sparse=True)
-        result = batch.to_numpy()
-
-        assert result.is_numpy is True
-        assert isinstance(result.data, np.ndarray)
-        # The data should be concatenation of coordinates and features
-        expected = np.array([[0, 0, 0, 1, 2], [0, 1, 0, 3, 4]])
-        np.testing.assert_array_equal(result.data, expected)
-
-    def test_getitem_with_me(self):
-        """Test indexing with ME SparseTensor."""
-        data = ME.SparseTensor(
-            features=torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=torch.float32),
-            coordinates=torch.tensor(
-                [[0, 0, 0], [0, 1, 0], [1, 0, 0]], dtype=torch.int32
-            ),
-        )
-        counts = [2, 1]
-
-        batch = TensorBatch(data, counts=counts, is_sparse=True)
-
-        batch_0 = batch[0]
-        batch_1 = batch[1]
-
-        # batch_0 should contain the first two entries
-        expected_0 = np.array([[0, 0, 0, 1, 2], [0, 1, 0, 3, 4]])
-        np.testing.assert_array_equal(batch_0.C.numpy(), expected_0[:, :3])
-        np.testing.assert_array_equal(batch_0.F.numpy(), expected_0[:, 3:])
-
-        # batch_1 should contain the last entry
-        expected_1 = np.array([[1, 0, 0, 5, 6]])
-        np.testing.assert_array_equal(batch_1.C.numpy(), expected_1[:, :3])
-        np.testing.assert_array_equal(batch_1.F.numpy(), expected_1[:, 3:])
-
-    def test_split_with_me(self):
-        """Test split method with ME SparseTensor."""
-        data = ME.SparseTensor(
-            features=torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=torch.float32),
-            coordinates=torch.tensor(
-                [[0, 0, 0], [0, 1, 0], [1, 0, 0]], dtype=torch.int32
-            ),
-        )
-        counts = [1, 2]
-
-        batch = TensorBatch(data, counts=counts, is_sparse=True)
-        split_data = batch.split()
-
-        assert len(split_data) == 2
-
-        expected_0 = np.array([[0, 0, 0, 1, 2]])
-        np.testing.assert_array_equal(split_data[0].C.numpy(), expected_0[:, :3])
-        np.testing.assert_array_equal(split_data[0].F.numpy(), expected_0[:, 3:])
-
-        expected_1 = np.array([[0, 1, 0, 3, 4], [1, 0, 0, 5, 6]])
-        np.testing.assert_array_equal(split_data[1].C.numpy(), expected_1[:, :3])
-        np.testing.assert_array_equal(split_data[1].F.numpy(), expected_1[:, 3:])

--- a/test/test_io/test_unwrap.py
+++ b/test/test_io/test_unwrap.py
@@ -141,6 +141,35 @@ def test_unwrap_tensor_batch_list():
     np.testing.assert_array_equal(result["tensors"][0][1], np.array([[5, 6]]))
 
 
+def test_unwrap_tensor_batch_convertible_values():
+    """Portable model outputs unwrap directly and inside feature-map lists."""
+
+    class Convertible:
+        def __init__(self, values):
+            self.values = np.asarray(values)
+
+        def to_tensor_batch(self):
+            return TensorBatch(self.values, counts=[1, 1])
+
+    direct = Convertible([[1, 2], [3, 4]])
+    levels = [
+        Convertible([[5, 6], [7, 8]]),
+        Convertible([[9, 10], [11, 12]]),
+    ]
+
+    result = Unwrapper()(
+        {
+            "index": [0, 1],
+            "direct": direct,
+            "levels": levels,
+        }
+    )
+
+    np.testing.assert_array_equal(result["direct"][0], np.array([[1, 2]]))
+    np.testing.assert_array_equal(result["levels"][1][0], np.array([[7, 8]]))
+    np.testing.assert_array_equal(result["levels"][1][1], np.array([[11, 12]]))
+
+
 def test_unwrap_tensor_batch_multi_volume(monkeypatch):
     class MockTPC:
         num_modules = 2

--- a/test/test_model/test_sparse/__init__.py
+++ b/test/test_model/test_sparse/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the backend-neutral sparse model runtime."""

--- a/test/test_model/test_sparse/conftest.py
+++ b/test/test_model/test_sparse/conftest.py
@@ -1,0 +1,28 @@
+"""Shared fixtures for sparse model tests."""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("MinkowskiEngine")
+
+from spine.model.uresnet import UResNetSegmentation  # noqa: E402
+
+
+@pytest.fixture
+def uresnet_config():
+    """Return a minimal UResNet configuration for sparse contract tests."""
+    return {
+        "num_classes": 3,
+        "reps": 1,
+        "depth": 2,
+        "filters": 2,
+        "num_input": 1,
+        "activation": "relu",
+        "norm_layer": "none",
+    }
+
+
+@pytest.fixture
+def uresnet(uresnet_config):
+    """Build a small UResNet segmentation model."""
+    return UResNetSegmentation(uresnet_config)

--- a/test/test_model/test_sparse/test_backend.py
+++ b/test/test_model/test_sparse/test_backend.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import torch
 
 from spine.model import sparse
 from spine.model.sparse import backend
@@ -70,6 +71,16 @@ def test_minkowski_adapter_rejects_an_unknown_operation():
     """The selected adapter reports unsupported semantic operations."""
     with pytest.raises(ValueError, match="does not implement"):
         backend.adapter().module("UnknownOperation")
+
+
+def test_minkowski_adapter_rejects_an_unknown_reduction():
+    """The backend validates semantic duplicate-reduction names."""
+    with pytest.raises(ValueError, match="Unknown duplicate reduction"):
+        backend.adapter().create_tensor(
+            features=torch.tensor([[1.0]]),
+            coordinates=torch.tensor([[0, 0]], dtype=torch.int32),
+            duplicate_reduction="maximum",
+        )
 
 
 def test_minkowski_adapter_reports_a_missing_engine(monkeypatch):

--- a/test/test_model/test_sparse/test_backend.py
+++ b/test/test_model/test_sparse/test_backend.py
@@ -1,0 +1,94 @@
+"""Tests for sparse backend selection and isolation."""
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from spine.model import sparse
+from spine.model.sparse import backend
+
+
+def test_sparse_api_does_not_expose_backend_names():
+    """Models consume semantic operations, not native backend class names."""
+    assert not any(name.startswith("Minkowski") for name in dir(sparse))
+
+
+def test_backend_import_is_isolated_to_adapter():
+    """The selected engine may only be imported by its backend adapter."""
+    repository = Path(__file__).resolve().parents[3]
+    model_root = repository / "src" / "spine" / "model"
+    adapter = model_root / "sparse" / "backends" / "minkowski.py"
+
+    for path in model_root.rglob("*.py"):
+        if path == adapter:
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = {alias.name for alias in node.names}
+            elif isinstance(node, ast.ImportFrom):
+                names = {node.module or ""}
+            else:
+                continue
+            assert "MinkowskiEngine" not in names, path
+
+
+def test_default_backend_implements_public_operations():
+    """The default adapter resolves the semantic operation contract."""
+    assert backend.name() == "minkowski"
+    assert backend.adapter().__name__.endswith(".backends.minkowski")
+    assert backend.module("Convolution") is not None
+
+
+def test_backend_rejects_an_unknown_adapter(monkeypatch):
+    """An unsupported configured backend produces a useful public error."""
+    monkeypatch.setattr(backend, "_BACKEND_NAME", "does_not_exist")
+    monkeypatch.setattr(backend, "_ADAPTER", None)
+
+    with pytest.raises(ValueError, match="Unsupported sparse backend"):
+        backend.adapter()
+
+
+def test_backend_preserves_nested_import_errors(monkeypatch):
+    """A backend's missing dependency is not misreported as a bad backend."""
+
+    def fail_import(_):
+        raise ModuleNotFoundError("missing dependency", name="dependency")
+
+    monkeypatch.setattr(backend, "_BACKEND_NAME", "broken")
+    monkeypatch.setattr(backend, "_ADAPTER", None)
+    monkeypatch.setattr(backend.importlib, "import_module", fail_import)
+
+    with pytest.raises(ModuleNotFoundError, match="missing dependency"):
+        backend.adapter()
+
+
+def test_minkowski_adapter_rejects_an_unknown_operation():
+    """The selected adapter reports unsupported semantic operations."""
+    with pytest.raises(ValueError, match="does not implement"):
+        backend.adapter().module("UnknownOperation")
+
+
+def test_minkowski_adapter_reports_a_missing_engine(monkeypatch):
+    """Importing the adapter without MinkowskiEngine gives a clear error."""
+    adapter_path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "spine"
+        / "model"
+        / "sparse"
+        / "backends"
+        / "minkowski.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "_missing_minkowski",
+        adapter_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "MinkowskiEngine", None)
+
+    with pytest.raises(ImportError, match="MinkowskiEngine is required"):
+        spec.loader.exec_module(module)

--- a/test/test_model/test_sparse/test_functional.py
+++ b/test/test_model/test_sparse/test_functional.py
@@ -1,0 +1,19 @@
+"""Tests for sparse feature-wise functions."""
+
+import torch
+
+from spine.model import sparse
+
+
+def test_softmax_preserves_coordinates_and_normalizes_features():
+    """Sparse softmax changes features without changing active sites."""
+    tensor = sparse.SparseTensor(
+        torch.tensor([[1.0, 2.0], [3.0, 1.0]]),
+        torch.tensor([[0, 0, 0], [1, 1, 0]], dtype=torch.int32),
+        batch_size=2,
+    )
+
+    output = sparse.softmax(tensor, dim=1)
+
+    assert torch.equal(output.C, tensor.C)
+    assert torch.allclose(output.F.sum(dim=1), torch.ones(2))

--- a/test/test_model/test_sparse/test_init.py
+++ b/test/test_model/test_sparse/test_init.py
@@ -1,0 +1,63 @@
+"""Tests for the public sparse package facade."""
+
+import pytest
+import torch
+
+from spine.model import sparse
+
+
+def test_cat_concatenates_features_and_preserves_provenance():
+    """Sparse concatenation operates on a shared coordinate map."""
+    first = sparse.SparseTensor(
+        torch.tensor([[1.0], [2.0]]),
+        torch.tensor([[0, 0, 0], [1, 1, 0]], dtype=torch.int32),
+        batch_size=2,
+    )
+    second = first.replace_features(torch.tensor([[3.0, 4.0], [5.0, 6.0]]))
+
+    output = sparse.cat([first, second])
+
+    assert torch.equal(output.C, first.C)
+    assert torch.equal(
+        output.F,
+        torch.tensor([[1.0, 3.0, 4.0], [2.0, 5.0, 6.0]]),
+    )
+    assert output.batch_size == 2
+
+
+def test_cat_handles_empty_tensors_without_entering_backend():
+    """Empty concatenation preserves metadata and sums channel counts."""
+    first = sparse.SparseTensor(
+        torch.empty((0, 2)),
+        torch.empty((0, 4), dtype=torch.int32),
+        batch_size=3,
+    )
+    second = sparse.SparseTensor(
+        torch.empty((0, 4)),
+        torch.empty((0, 4), dtype=torch.int32),
+        batch_size=3,
+    )
+
+    output = sparse.cat(first, second)
+
+    assert output.shape == (0, 6)
+    assert output.counts.tolist() == [0, 0, 0]
+
+
+def test_cat_forwards_native_tensors_to_backend():
+    """Native backend inputs remain supported at the adapter boundary."""
+    first = sparse.SparseTensor(
+        torch.tensor([[1.0]]),
+        torch.tensor([[0, 0, 0]], dtype=torch.int32),
+    )
+    second = first.replace_features(torch.tensor([[2.0]]))
+
+    output = sparse.cat(first.backend_tensor, second.backend_tensor)
+
+    assert torch.equal(output.F, torch.tensor([[1.0, 2.0]]))
+
+
+def test_cat_requires_an_input():
+    """Sparse concatenation rejects an empty argument list."""
+    with pytest.raises(ValueError, match="at least one tensor"):
+        sparse.cat()

--- a/test/test_model/test_sparse/test_integration.py
+++ b/test/test_model/test_sparse/test_integration.py
@@ -1,0 +1,104 @@
+"""Integration tests for sparse model outputs and consumers."""
+
+import torch
+
+from spine.data import TensorBatch
+from spine.io.unwrap import Unwrapper
+from spine.model import sparse
+from spine.model.manager import ModelManager
+from spine.model.uresnet_ppn import UResNetPPN
+
+
+def test_sparse_output_is_unwrapped_and_cast_to_numpy():
+    """Unwrapping consumers accept sparse tensors and feature-map lists."""
+    tensor = sparse.SparseTensor(
+        torch.tensor([[1.0], [2.0]]),
+        torch.tensor([[0, 1, 2, 3], [2, 4, 5, 6]], dtype=torch.int32),
+        batch_size=3,
+    )
+
+    unwrapper = Unwrapper()
+    unwrapper.batch_size = 3
+    entries = unwrapper._unwrap("feature_map", tensor)
+    assert [len(entry) for entry in entries] == [1, 0, 1]
+
+    levels = unwrapper._unwrap("decoder_tensors", [tensor, tensor])
+    assert len(levels) == 3
+    assert [len(level) for level in levels] == [2, 2, 2]
+
+    result = {"decoder_tensors": [tensor]}
+    ModelManager.cast_to_numpy(object.__new__(ModelManager), result)
+    assert result["decoder_tensors"][0].is_numpy
+    assert result["decoder_tensors"][0].counts.tolist() == [1, 0, 1]
+
+
+def test_uresnet_accepts_an_empty_batch(uresnet):
+    """A complete encoder-decoder remains defined with no active sites."""
+    data = TensorBatch(torch.empty((0, 5)), counts=torch.tensor([0, 0]))
+
+    result = uresnet(data)
+
+    assert result["segmentation"].shape == (0, 3)
+    assert result["segmentation"].counts.tolist() == [0, 0]
+    assert result["final_tensor"].batch_size == 2
+    assert result["decoder_tensors"][-1].shape == (0, 2)
+
+
+def test_uresnet_restores_duplicate_input_rows(uresnet):
+    """Point-aligned predictions retain the input multiplicity."""
+    data = TensorBatch(
+        torch.tensor(
+            [
+                [0.0, 1.0, 1.0, 1.0, 2.0],
+                [0.0, 1.0, 1.0, 1.0, 4.0],
+                [1.0, 3.0, 3.0, 3.0, 5.0],
+            ]
+        ),
+        counts=torch.tensor([2, 1]),
+    )
+
+    result = uresnet(data)
+
+    segmentation = result["segmentation"]
+    assert segmentation.shape == (3, 3)
+    assert segmentation.counts.tolist() == [2, 1]
+    assert torch.equal(segmentation.tensor[0], segmentation.tensor[1])
+
+
+def test_uresnet_ppn_accepts_an_empty_batch(uresnet_config):
+    """The downstream PPN path consumes empty sparse feature maps."""
+    data = TensorBatch(torch.empty((0, 5)), counts=torch.tensor([0, 0]))
+    model = UResNetPPN(uresnet_config, {})
+
+    result = model(data)
+
+    assert result["segmentation"].shape == (0, 3)
+    assert result["ppn_points"].counts.tolist() == [0, 0]
+    assert result["ppn_points"].shape[0] == 0
+
+
+def test_uresnet_ppn_separates_unique_and_restored_predictions(uresnet_config):
+    """PPN retains unique predictions for loss and restored rows for users."""
+    data = TensorBatch(
+        torch.tensor(
+            [
+                [0.0, 1.0, 1.0, 1.0, 2.0],
+                [0.0, 1.0, 1.0, 1.0, 4.0],
+                [1.0, 3.0, 3.0, 3.0, 5.0],
+            ]
+        ),
+        counts=torch.tensor([2, 1]),
+    )
+    model = UResNetPPN(uresnet_config, {})
+
+    result = model(data)
+
+    assert result["ppn_points"].counts.tolist() == [2, 1]
+    assert result["ppn_points"].shape[0] == 3
+    assert result["ppn_points_unique"].counts.tolist() == [1, 1]
+    assert result["ppn_points_unique"].shape[0] == 2
+    assert result["ppn_coords"][-1].shape[0] == 2
+    assert torch.equal(
+        result["ppn_points"].tensor[0],
+        result["ppn_points"].tensor[1],
+    )

--- a/test/test_model/test_sparse/test_modules.py
+++ b/test/test_model/test_sparse/test_modules.py
@@ -1,0 +1,193 @@
+"""Tests for backend-selected, empty-safe sparse modules."""
+
+import pytest
+import torch
+
+from spine.model import sparse
+from spine.model.sparse.modules import _scaled_stride, _stride_values
+
+
+def test_empty_convolution_and_transpose_are_safe():
+    """Empty tensors bypass backend convolution while preserving metadata."""
+    tensor = sparse.SparseTensor(
+        torch.empty((0, 2)),
+        torch.empty((0, 4), dtype=torch.int32),
+        batch_size=3,
+    )
+    conv = sparse.Convolution(2, 4, kernel_size=2, stride=2, dimension=3)
+    deconv = sparse.ConvolutionTranspose(
+        4,
+        3,
+        kernel_size=2,
+        stride=2,
+        dimension=3,
+    )
+
+    encoded = conv(tensor)
+    decoded = deconv(encoded)
+
+    assert encoded.shape == (0, 4)
+    assert encoded.tensor_stride == (2, 2, 2)
+    assert decoded.shape == (0, 3)
+    assert decoded.tensor_stride == (1, 1, 1)
+    assert decoded.counts.tolist() == [0, 0, 0]
+
+    pooled = sparse.GlobalAvgPooling()(decoded)
+    assert pooled.shape == (3, 3)
+    assert pooled.counts.tolist() == [1, 1, 1]
+    assert torch.count_nonzero(pooled.F) == 0
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        sparse.Linear(2, 3),
+        sparse.BatchNorm(2),
+        sparse.Dropout(),
+        sparse.ReLU(),
+        sparse.Sigmoid(),
+        sparse.Softplus(),
+    ],
+)
+def test_pointwise_modules_accept_empty_tensors(module):
+    """Point-wise operations preserve an empty sparse domain."""
+    tensor = sparse.SparseTensor(
+        torch.empty((0, 2)),
+        torch.empty((0, 4), dtype=torch.int32),
+        batch_size=2,
+    )
+
+    output = module(tensor)
+
+    expected_channels = 3 if isinstance(module, sparse.Linear) else 2
+    assert output.shape == (0, expected_channels)
+    assert output.counts.tolist() == [0, 0]
+
+
+def test_nonempty_modules_return_spine_sparse_tensors():
+    """Native module results are wrapped back into the public tensor type."""
+    tensor = sparse.SparseTensor(
+        torch.tensor([[1.0, -2.0], [3.0, 4.0]]),
+        torch.tensor([[0, 0, 0], [1, 1, 0]], dtype=torch.int32),
+        batch_size=2,
+    )
+
+    output = sparse.ReLU()(sparse.Linear(2, 3)(tensor))
+
+    assert isinstance(output, sparse.SparseTensor)
+    assert output.shape == (2, 3)
+    assert torch.equal(output.C, tensor.C)
+
+
+def test_stride_helpers_accept_all_backend_representations():
+    """Empty fallbacks normalize scalar, tensor, and generated strides."""
+    tensor = sparse.SparseTensor(
+        torch.empty((0, 1)),
+        torch.empty((0, 3), dtype=torch.int32),
+        tensor_stride=torch.tensor([4, 4]),
+    )
+
+    class KernelGenerator:
+        kernel_stride = torch.tensor([2, 4])
+
+    class GeneratedStride:
+        kernel_generator = KernelGenerator()
+
+    class UnitStride:
+        pass
+
+    assert _stride_values(3, 2) == (3, 3)
+    assert _stride_values(torch.tensor([2, 3]), 2) == (2, 3)
+    assert _scaled_stride(tensor, GeneratedStride()) == (8, 16)
+    assert _scaled_stride(tensor, UnitStride(), transpose=True) == (4, 4)
+
+
+def test_modules_continue_to_accept_native_tensors():
+    """Native tensors pass directly through inherited backend forwards."""
+    tensor = sparse.SparseTensor(
+        torch.tensor([[-1.0], [2.0]]),
+        torch.tensor([[0, 0, 0], [1, 1, 0]], dtype=torch.int32),
+        batch_size=2,
+    )
+
+    output = sparse.ReLU()(tensor.backend_tensor)
+
+    assert not isinstance(output, sparse.SparseTensor)
+    assert torch.equal(output.F, torch.tensor([[0.0], [2.0]]))
+
+
+def test_global_pooling_handles_nonempty_native_and_zero_batch_inputs():
+    """Global pooling covers wrapped, native, and truly empty batch domains."""
+    tensor = sparse.SparseTensor(
+        torch.tensor([[1.0], [3.0], [2.0], [4.0]]),
+        torch.tensor(
+            [[0, 0, 0], [0, 1, 0], [1, 1, 0], [1, 2, 0]],
+            dtype=torch.int32,
+        ),
+        batch_size=2,
+    )
+    pool = sparse.GlobalAvgPooling()
+
+    wrapped = pool(tensor)
+    native = pool(tensor.backend_tensor)
+    empty = sparse.SparseTensor(
+        torch.empty((0, 1)),
+        torch.empty((0, 3), dtype=torch.int32),
+        batch_size=0,
+    )
+
+    assert isinstance(wrapped, sparse.SparseTensor)
+    assert native.F.shape == (2, 1)
+    assert pool(empty).shape == (0, 1)
+
+
+def test_pruning_handles_wrapped_empty_and_native_inputs():
+    """Pruning preserves wrappers and bypasses the backend for empties."""
+    tensor = sparse.SparseTensor(
+        torch.tensor([[1.0], [2.0]]),
+        torch.tensor([[0, 0, 0], [0, 1, 0]], dtype=torch.int32),
+    )
+    empty = sparse.SparseTensor.empty_like(tensor)
+    pruning = sparse.Pruning()
+
+    wrapped = pruning(tensor, torch.tensor([True, False]))
+    native = pruning(tensor.backend_tensor, torch.tensor([False, True]))
+
+    assert isinstance(wrapped, sparse.SparseTensor)
+    assert wrapped.F.tolist() == [[1.0]]
+    assert native.F.tolist() == [[2.0]]
+    assert pruning(empty, torch.empty(0, dtype=torch.bool)).shape == (0, 1)
+
+
+def test_broadcast_operations_handle_wrapped_empty_and_native_inputs():
+    """Broadcast wrappers cover normal, empty, and native backend domains."""
+    tensor = sparse.SparseTensor(
+        torch.tensor([[2.0], [4.0], [3.0], [5.0]]),
+        torch.tensor(
+            [[0, 0, 0], [0, 1, 0], [1, 1, 0], [1, 2, 0]],
+            dtype=torch.int32,
+        ),
+        batch_size=2,
+    )
+    global_tensor = sparse.GlobalAvgPooling()(tensor)
+    empty = sparse.SparseTensor(
+        torch.empty((0, 1)),
+        torch.empty((0, 3), dtype=torch.int32),
+        batch_size=2,
+    )
+    broadcast = sparse.Broadcast()
+    multiply = sparse.BroadcastMultiplication()
+    native_input = tensor.backend_tensor
+    native_global = global_tensor.backend_tensor
+
+    wrapped_broadcast = broadcast(tensor, global_tensor)
+    native_broadcast = broadcast(native_input, native_global)
+    wrapped_product = multiply(tensor, global_tensor)
+    native_product = multiply(native_input, native_global)
+
+    assert isinstance(wrapped_broadcast, sparse.SparseTensor)
+    assert native_broadcast.F.shape == (4, 1)
+    assert isinstance(wrapped_product, sparse.SparseTensor)
+    assert native_product.F.tolist() == [[6.0], [12.0], [12.0], [20.0]]
+    assert broadcast(empty, global_tensor).shape == (0, 1)
+    assert multiply(empty, global_tensor).shape == (0, 1)

--- a/test/test_model/test_sparse/test_tensor.py
+++ b/test/test_model/test_sparse/test_tensor.py
@@ -16,6 +16,7 @@ def test_duplicate_coordinates_restore_original_rows():
     tensor = sparse.SparseTensor(features, coordinates, batch_size=3)
 
     assert len(tensor) == 2
+    assert tensor.reference_size == 3
     assert tensor.counts.tolist() == [1, 1, 0]
     expected = torch.tensor([[4.0], [4.0], [5.0]])
     assert torch.equal(tensor.aligned_features(), expected)
@@ -73,6 +74,24 @@ def test_sparse_export_is_portable_tensor_batch():
         exported.tensor,
         torch.tensor([[0.0, 1.0, 2.0, 3.0, 1.0], [2.0, 4.0, 5.0, 6.0, 2.0]]),
     )
+
+
+def test_unique_coordinates_preserve_native_order_without_provenance():
+    """Unique inputs remain ordered and avoid duplicate-restoration metadata."""
+    coordinates = torch.tensor(
+        [[1, 4, 2], [0, 9, 1], [1, 0, 7], [0, 3, 5]],
+        dtype=torch.int32,
+    )
+    features = torch.tensor([[10.0], [20.0], [30.0], [40.0]])
+
+    tensor = sparse.SparseTensor(features, coordinates, batch_size=2)
+
+    assert torch.equal(tensor.C, coordinates)
+    assert torch.equal(tensor.F, features)
+    assert tensor._reference_coordinates is None
+    assert tensor.aligned_features().data_ptr() == tensor.F.data_ptr()
+    assert tensor.unique_index.tolist() == [0, 1, 2, 3]
+    assert tensor.inverse_mapping.tolist() == [0, 1, 2, 3]
 
 
 def test_tensor_feature_operations_preserve_coordinates():
@@ -147,6 +166,14 @@ def test_coordinate_map_construction_and_source_propagation():
     )
     assert torch.equal(explicit.C, source.C)
 
+    empty = sparse.SparseTensor(
+        torch.empty((0, 1)),
+        coordinate_map_key=source.coordinate_map_key,
+        coordinate_manager=source.coordinate_manager,
+    )
+    assert empty.shape == (0, 1)
+    assert empty.backend_tensor is None
+
 
 def test_backend_wrapping_without_a_source_infers_metadata():
     """A bare native result lazily exposes backend metadata and delegation."""
@@ -182,8 +209,11 @@ def test_backend_wrapping_without_a_source_infers_metadata():
 def test_empty_feature_replacement_and_alignment():
     """Empty tensors replace features and restore referenced rows safely."""
     source = sparse.SparseTensor(
-        torch.tensor([[1.0], [2.0]]),
-        torch.tensor([[0, 0, 0], [1, 1, 0]], dtype=torch.int32),
+        torch.tensor([[1.0], [2.0], [3.0]]),
+        torch.tensor(
+            [[0, 0, 0], [0, 0, 0], [1, 1, 0]],
+            dtype=torch.int32,
+        ),
         batch_size=2,
     )
     empty = sparse.SparseTensor.empty_like(source, tensor_stride=2)
@@ -191,13 +221,13 @@ def test_empty_feature_replacement_and_alignment():
 
     assert replaced.shape == (0, 3)
     assert replaced.tensor_stride == (2, 2)
-    assert replaced.aligned_features().shape == (2, 3)
+    assert replaced.aligned_features().shape == (3, 3)
     assert replaced.coordinate_map_key is None
     assert replaced.coordinate_manager is None
 
     restored = replaced.to_tensor_batch(restore=True)
-    assert restored.counts.tolist() == [1, 1]
-    assert restored.shape == (2, 6)
+    assert restored.counts.tolist() == [2, 1]
+    assert restored.shape == (3, 6)
 
 
 def test_tensor_arithmetic_covers_tensor_and_scalar_operands():

--- a/test/test_model/test_sparse/test_tensor.py
+++ b/test/test_model/test_sparse/test_tensor.py
@@ -1,0 +1,219 @@
+"""Tests for the backend-neutral sparse tensor."""
+
+import pytest
+import torch
+
+from spine.model import sparse
+
+
+def test_duplicate_coordinates_restore_original_rows():
+    """Sparse processing coalesces sites but retains row provenance."""
+    coordinates = torch.tensor(
+        [[0, 0, 0, 0], [0, 0, 0, 0], [1, 2, 0, 0]], dtype=torch.int32
+    )
+    features = torch.tensor([[1.0], [3.0], [5.0]], requires_grad=True)
+
+    tensor = sparse.SparseTensor(features, coordinates, batch_size=3)
+
+    assert len(tensor) == 2
+    assert tensor.counts.tolist() == [1, 1, 0]
+    expected = torch.tensor([[4.0], [4.0], [5.0]])
+    assert torch.equal(tensor.aligned_features(), expected)
+
+    restored = tensor.to_tensor_batch(include_coordinates=False, restore=True)
+    assert restored.counts.tolist() == [2, 1, 0]
+    assert torch.equal(restored.tensor, torch.tensor([[4.0], [4.0], [5.0]]))
+
+    restored.tensor.sum().backward()
+    assert torch.equal(features.grad, torch.tensor([[2.0], [2.0], [1.0]]))
+
+
+@pytest.mark.parametrize(
+    ("reduction", "expected"),
+    [("sum", 4.0), ("mean", 2.0), ("first", 1.0)],
+)
+def test_duplicate_reduction_policies(reduction, expected):
+    """Every supported duplicate policy produces one deterministic site."""
+    tensor = sparse.SparseTensor(
+        torch.tensor([[1.0], [3.0]]),
+        torch.tensor([[0, 2, 3], [0, 2, 3]], dtype=torch.int32),
+        duplicate_reduction=reduction,
+    )
+
+    assert tensor.shape == (1, 1)
+    assert tensor.F.item() == expected
+    assert tensor.unique_index.tolist() == [0]
+    assert tensor.inverse_mapping.tolist() == [0, 0]
+
+
+def test_invalid_duplicate_reduction_is_rejected():
+    """Unknown duplicate reductions fail before backend construction."""
+    with pytest.raises(ValueError, match="Unknown duplicate reduction"):
+        sparse.SparseTensor(
+            torch.tensor([[1.0], [2.0]]),
+            torch.tensor([[0, 0], [0, 0]], dtype=torch.int32),
+            duplicate_reduction="maximum",
+        )
+
+
+def test_sparse_export_is_portable_tensor_batch():
+    """Feature maps export unique coordinates and features."""
+    tensor = sparse.SparseTensor(
+        torch.tensor([[1.0], [2.0]]),
+        torch.tensor([[0, 1, 2, 3], [2, 4, 5, 6]], dtype=torch.int32),
+        batch_size=3,
+    )
+
+    exported = tensor.to_tensor_batch()
+
+    assert exported.counts.tolist() == [1, 0, 1]
+    assert exported.has_batch_col
+    assert exported.coord_cols == (1, 2, 3)
+    assert torch.equal(
+        exported.tensor,
+        torch.tensor([[0.0, 1.0, 2.0, 3.0, 1.0], [2.0, 4.0, 5.0, 6.0, 2.0]]),
+    )
+
+
+def test_tensor_feature_operations_preserve_coordinates():
+    """Feature replacement, arithmetic, casting, and detach retain metadata."""
+    tensor = sparse.SparseTensor(
+        torch.tensor([[2.0], [4.0]], dtype=torch.float64, requires_grad=True),
+        torch.tensor([[0, 0, 0], [1, 1, 0]], dtype=torch.int32),
+        batch_size=2,
+    )
+
+    replaced = tensor.replace_features(torch.tensor([[3.0], [5.0]]))
+    added = tensor + tensor
+    multiplied = tensor * 2
+    divided = tensor / 2
+
+    assert torch.equal(replaced.C, tensor.C)
+    expected_double = torch.tensor([[4.0], [8.0]], dtype=torch.float64)
+    expected_half = torch.tensor([[1.0], [2.0]], dtype=torch.float64)
+    assert torch.equal(added.F, expected_double)
+    assert torch.equal(multiplied.F, expected_double)
+    assert torch.equal(divided.F, expected_half)
+    assert tensor.float().dtype == torch.float32
+    assert not tensor.detach().F.requires_grad
+
+
+def test_constructor_aliases_and_validation():
+    """Aliases work and malformed inputs fail before the backend."""
+    tensor = sparse.SparseTensor(
+        feats=torch.tensor([1.0, 2.0]),
+        coords=torch.tensor([[0, 0], [1, 1]], dtype=torch.int32),
+        tensor_stride=torch.tensor([2]),
+        batch_size=2,
+    )
+
+    assert tensor.shape == (2, 1)
+    assert tensor.tensor_stride == (2,)
+
+    with pytest.raises(ValueError, match="requires `features`"):
+        sparse.SparseTensor(coords=torch.empty((0, 2), dtype=torch.int32))
+    with pytest.raises(ValueError, match="must be matrices"):
+        sparse.SparseTensor(torch.ones((1, 1, 1)), torch.zeros((1, 2)))
+    with pytest.raises(ValueError, match="equal length"):
+        sparse.SparseTensor(torch.ones((2, 1)), torch.zeros((1, 2)))
+    with pytest.raises(ValueError, match="coordinate map key"):
+        sparse.SparseTensor(torch.ones((1, 1)))
+
+
+def test_coordinate_map_construction_and_source_propagation():
+    """Coordinate maps support aliases, lazy coordinates, and sources."""
+    source = sparse.SparseTensor(
+        torch.tensor([[1.0], [2.0]]),
+        torch.tensor([[0, 0, 0], [1, 1, 0]], dtype=torch.int32),
+        batch_size=3,
+    )
+    tensor = sparse.SparseTensor(
+        feats=torch.tensor([[3.0], [4.0]]),
+        coords_key=source.coordinate_map_key,
+        coords_manager=source.coordinate_manager,
+        source=source,
+    )
+
+    assert torch.equal(tensor.C, source.C)
+    assert tensor.batch_size == 3
+    assert tensor.reference_size == 2
+    assert tensor.coords_key == source.coordinate_map_key
+    assert tensor.coords_man == source.coordinate_manager
+
+    explicit = sparse.SparseTensor(
+        torch.tensor([[5.0], [6.0]]),
+        coordinate_map_key=source.coordinate_map_key,
+        coordinate_manager=source.coordinate_manager,
+    )
+    assert torch.equal(explicit.C, source.C)
+
+
+def test_backend_wrapping_without_a_source_infers_metadata():
+    """A bare native result lazily exposes backend metadata and delegation."""
+    source = sparse.SparseTensor(
+        torch.tensor([[1.0], [2.0]]),
+        torch.tensor([[0, 0, 0], [2, 1, 0]], dtype=torch.int32),
+    )
+    tensor = sparse.SparseTensor.from_backend(source.backend_tensor)
+
+    assert tensor.batch_size == 3
+    assert tensor.reference_size == 2
+    assert tensor.device == source.device
+    assert tensor.coordinate_map_key is not None
+    assert tensor.coordinate_manager is not None
+    assert tensor.tensor_stride == (1, 1)
+    assert tensor.D == 2
+    assert torch.equal(tensor.aligned_features(), tensor.F)
+    assert tensor.features_at(0).tolist() == [[1.0]]
+    assert tensor.coordinates_at(2).tolist() == [[1, 0]]
+    assert [len(value) for value in tensor.decomposed_features] == [1, 0, 1]
+    assert [len(value) for value in tensor.decomposed_coordinates] == [1, 0, 1]
+    coords, features = tensor.decomposed_coordinates_and_features
+    assert len(coords) == len(features) == 3
+    native_manager = tensor.backend_tensor.coordinate_manager
+    assert tensor.coordinate_manager == native_manager
+
+    with pytest.raises(AttributeError):
+        _ = tensor._missing
+    with pytest.raises(AttributeError):
+        _ = sparse.SparseTensor.empty_like(tensor).missing
+
+
+def test_empty_feature_replacement_and_alignment():
+    """Empty tensors replace features and restore referenced rows safely."""
+    source = sparse.SparseTensor(
+        torch.tensor([[1.0], [2.0]]),
+        torch.tensor([[0, 0, 0], [1, 1, 0]], dtype=torch.int32),
+        batch_size=2,
+    )
+    empty = sparse.SparseTensor.empty_like(source, tensor_stride=2)
+    replaced = empty.replace_features(torch.empty((0, 3)))
+
+    assert replaced.shape == (0, 3)
+    assert replaced.tensor_stride == (2, 2)
+    assert replaced.aligned_features().shape == (2, 3)
+    assert replaced.coordinate_map_key is None
+    assert replaced.coordinate_manager is None
+
+    restored = replaced.to_tensor_batch(restore=True)
+    assert restored.counts.tolist() == [1, 1]
+    assert restored.shape == (2, 6)
+
+
+def test_tensor_arithmetic_covers_tensor_and_scalar_operands():
+    """All arithmetic operations preserve sparse wrapper semantics."""
+    tensor = sparse.SparseTensor(
+        torch.tensor([[2.0], [4.0]]),
+        torch.tensor([[0, 0, 0], [1, 1, 0]], dtype=torch.int32),
+        batch_size=2,
+    )
+    other = tensor.replace_features(torch.tensor([[1.0], [2.0]]))
+
+    assert (tensor + 1).F.tolist() == [[3.0], [5.0]]
+    assert (tensor * other).F.tolist() == [[2.0], [8.0]]
+    assert (tensor / other).F.tolist() == [[2.0], [2.0]]
+
+    empty = sparse.SparseTensor.empty_like(tensor)
+    assert (empty + empty).shape == (0, 1)
+    assert (empty * empty).shape == (0, 1)
+    assert (empty / empty).shape == (0, 1)


### PR DESCRIPTION
## Summary

Introduces `spine.model.sparse`, a backend-neutral sparse tensor and operation API. MinkowskiEngine remains the default implementation but is isolated behind a backend adapter.

## Key changes

- Adds empty-safe sparse convolutions, transpose convolutions, pooling, and model paths.
- Coalesces duplicate coordinates using `sum` by default.
- Restores duplicate row multiplicity for public outputs.
- Uses unique-site PPN predictions for loss calculations.
- Integrates sparse outputs with `TensorBatch`, model output conversion, and the unwrapper.
- Replaces backend-specific model operations with semantic names such as `sparse.Convolution`.
- Adds a test directory mirroring the sparse package structure.

## Validation

- 274 affected tests passed.
- `spine.model.sparse`: 100% statement and branch coverage.
- `spine.io.unwrap`: 100% statement coverage.
- Existing full-chain regression passed unchanged.
- Empty and duplicate-input full-chain sanity runs completed.
- Black, isort, flake8, and all commit hooks passed.

## Production validation notes

- Unique-coordinate inputs should remain unchanged.
- Duplicate features are now deterministically summed internally.
- Public point-aligned outputs retain the original duplicate rows.
- Entirely empty supervised batches run successfully, although aggregate loss and accuracy may be `NaN` because there are no supervised elements.