### PR TITLE
Faster, versioned HDF5 storage protocol

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,32 @@
+# Command-line Utilities
+
+This directory contains source-checkout entry points and focused maintenance
+utilities. Run commands from the repository root so imports and relative paths
+match the examples below.
+
+## Primary entry points
+
+- `run.py` runs the main SPINE training, inference, or analysis CLI:
+
+  ```bash
+  python3 bin/run.py --config config/infer/example.yaml
+  ```
+
+- `config.py` inspects resolved configuration files. Use `--help` to see the
+  available dump, diff, and validation operations:
+
+  ```bash
+  python3 bin/config.py --help
+  ```
+
+- `coverage.sh` runs the project test suite with coverage reporting.
+
+## Specialized utilities
+
+- [`calib/`](calib/README.md): calibration-map diagnostics
+- [`geo/`](geo/README.md): geometry conversion tools
+- [`larcv/`](larcv/README.md): LArCV ROOT inspection and maintenance
+- [`output/`](output/README.md): SPINE HDF5 validation, comparison, and reduction
+
+Every Python utility supports `--help`. The functions above the CLI wrappers
+are also importable for programmatic use and carry type annotations.

--- a/bin/calib/README.md
+++ b/bin/calib/README.md
@@ -2,5 +2,25 @@
 
 Small diagnostic and validation scripts for calibration inputs and corrections.
 
-These are intentionally separate from the top-level `bin/` entry points and
-general data-inspection utilities.
+## Inspect a space-charge field map
+
+`sce_field_check.py` samples points in an ICARUS or SBND detector geometry,
+applies a ROOT TH3 space-charge displacement map, and writes one PNG for each
+of the x, y, and z displacement components.
+
+```bash
+python3 bin/calib/sce_field_check.py \
+  --detector icarus \
+  --map-file /path/to/SCEoffsets_ICARUS_E500_voxelTH3.root \
+  --map-prefix TrueFwd_Displacement \
+  --output-dir sce/plots
+```
+
+By default the script samples 50,000 reproducible points across the detector
+TPC geometry. `--sample-volume` can instead select the map bounds or the
+intersection of map and detector bounds. `--bounds` controls how the field map
+handles points outside its domain. Plot density and output size can be adjusted
+with `--num-points`, `--point-size`, and `--dpi`.
+
+The script requires the optional ROOT and Matplotlib dependencies used by the
+field-map reader and plotting backend.

--- a/bin/calib/sce_field_check.py
+++ b/bin/calib/sce_field_check.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
@@ -146,7 +147,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def sample_points(
-    geo,
+    geo: Any,
     map_range: np.ndarray,
     num_points: int,
     mode: str,
@@ -179,7 +180,9 @@ def sample_points(
     return points
 
 
-def apply_field(calibrator: FieldCalibrator, geo, points: np.ndarray) -> np.ndarray:
+def apply_field(
+    calibrator: FieldCalibrator, geo: Any, points: np.ndarray
+) -> np.ndarray:
     """Apply a field calibrator to a mixed-TPC point cloud."""
     corrected = np.asarray(points, dtype=float).copy()
     tpc_ids = geo.get_closest_tpc(points)
@@ -192,7 +195,7 @@ def apply_field(calibrator: FieldCalibrator, geo, points: np.ndarray) -> np.ndar
     return corrected
 
 
-def sample_volumes(geo, map_range: np.ndarray, mode: str) -> list[np.ndarray]:
+def sample_volumes(geo: Any, map_range: np.ndarray, mode: str) -> list[np.ndarray]:
     """Build a list of box volumes to sample."""
     if mode == "map":
         return [np.asarray(map_range, dtype=float)]
@@ -222,7 +225,7 @@ def plot_component(
     map_file: Path,
     sample_volume: str,
     point_size: float,
-):
+) -> Any:
     """Draw one offset component in the three 2D coordinate projections."""
     import matplotlib.pyplot as plt
 

--- a/bin/config.py
+++ b/bin/config.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+"""Run the SPINE configuration inspection command from a source checkout."""
+
+from __future__ import annotations
+
 import os
 import sys
 
@@ -10,5 +14,11 @@ if src_path not in sys.path:
 # Import and run the config CLI
 from spine.bin.config import cli
 
+
+def main() -> int:
+    """Execute the configuration CLI and return its process status."""
+    return cli()
+
+
 if __name__ == "__main__":
-    sys.exit(cli())
+    sys.exit(main())

--- a/bin/geo/README.md
+++ b/bin/geo/README.md
@@ -1,3 +1,41 @@
 # Geometry Scripts
 
 Utilities for extracting or converting detector geometry descriptions.
+
+## Convert FLOW geometry
+
+`parse_flow_geometry.py` reads detector and optical geometry stored in a FLOW
+HDF5 file and emits a SPINE geometry YAML file.
+
+```bash
+python3 bin/geo/parse_flow_geometry.py \
+  --source FSD_CosmicRun3.flow.0000000.FLOW.hdf5 \
+  --tag cr3 \
+  --output fsd_cr3.yaml \
+  --opdet-thickness 1.0
+```
+
+`--tag` identifies the geometry revision and is used to derive the version.
+`--opdet-thickness` is required only when the stored optical-detector bounds
+have zero thickness. If `--output` is omitted, the script replaces the input
+`.hdf5` suffix with `_geometry.yaml`.
+
+## Convert a LArSoft geometry dump
+
+First produce a text dump using the appropriate LArSoft geometry configuration,
+then convert it:
+
+```bash
+lar -c dump_icarus_geometry.fcl
+python3 bin/geo/parse_larsoft_geometry.py \
+  --source icarus-geometry.txt \
+  --output icarus.yaml
+```
+
+`--cathode-thickness` and `--pixel-size` adjust active-volume dimensions when
+the text dump does not encode those effects directly. `--crt-mapping` accepts
+a YAML mapping from CRT module names to stable logical IDs. Without `--output`,
+the input `.txt` suffix is replaced with `_tpc.yaml`.
+
+Both converters print the generated YAML before writing it, making their output
+easy to inspect before installing it as detector geometry.

--- a/bin/geo/parse_flow_geometry.py
+++ b/bin/geo/parse_flow_geometry.py
@@ -1,22 +1,25 @@
 #!/usr/bin/env python3
-"""
-Parse LArND geometry HDF5 files and extract relevant detector information
-in YAML format to be used by SPINE.
+"""Convert a FLOW geometry HDF5 file to SPINE geometry YAML.
 
 Example usage:
-    python3 parse_larnd_geometry.py --source FSD_CosmicRun3.flow.0000000.FLOW.hdf5
-    --output larnd_geometry.yaml --opdet-thickness 1.0 --tag cr3
+    python3 bin/geo/parse_flow_geometry.py --source geometry.hdf5 \
+        --output geometry.yaml --opdet-thickness 1.0 --tag cr3
 """
+
+from __future__ import annotations
 
 import argparse
 import re
+from typing import Any
 
 import h5py
 import numpy as np
 import yaml
 
+GeometryData = dict[str, Any]
 
-def extract_version(tag, fallback=None):
+
+def extract_version(tag: str, fallback: Any = None) -> int | float | Any:
     """Extract a geometry version from a detector tag.
 
     Prefer explicit version tokens such as ``v3`` or ``_v3_``. Otherwise,
@@ -45,7 +48,7 @@ def extract_version(tag, fallback=None):
     raise ValueError("Could not extract version from tag")
 
 
-def extract_tpc_geometry(f):
+def extract_tpc_geometry(f: h5py.File) -> GeometryData:
     """
     Extract TPC geometry information from HDF5 file.
 
@@ -111,7 +114,11 @@ def extract_tpc_geometry(f):
     }
 
 
-def extract_optical_geometry(f, tpc_positions, opdet_thickness=None):
+def extract_optical_geometry(
+    f: h5py.File,
+    tpc_positions: list[list[float]],
+    opdet_thickness: float | None = None,
+) -> GeometryData | None:
     """
     Extract optical detector geometry information from HDF5 file.
 
@@ -242,7 +249,12 @@ def extract_optical_geometry(f, tpc_positions, opdet_thickness=None):
     }
 
 
-def main(source, tag, output=None, opdet_thickness=None):
+def main(
+    source: str,
+    tag: str,
+    output: str | None = None,
+    opdet_thickness: float | None = None,
+) -> None:
     """
     Main function for parsing LArND geometry HDF5 files.
 
@@ -376,7 +388,8 @@ def main(source, tag, output=None, opdet_thickness=None):
         print(f"\nYAML file written to: {output_path}")
 
 
-if __name__ == "__main__":
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
     parser = argparse.ArgumentParser(description="Parse LArND geometry HDF5 files")
 
     parser.add_argument(
@@ -409,11 +422,19 @@ if __name__ == "__main__":
         required=True,
     )
 
-    args = parser.parse_args()
+    return parser
 
+
+def cli() -> None:
+    """Run the command-line interface."""
+    args = build_parser().parse_args()
     main(
         source=args.source,
         tag=args.tag,
         output=args.output,
         opdet_thickness=args.opdet_thickness,
     )
+
+
+if __name__ == "__main__":
+    cli()

--- a/bin/geo/parse_larsoft_geometry.py
+++ b/bin/geo/parse_larsoft_geometry.py
@@ -10,16 +10,22 @@ First dump the geometry from LArSoft using:
 Then run this script on the dumped text file.
 """
 
+from __future__ import annotations
+
 import argparse
 import os
 import re
+from collections.abc import Sequence
+from typing import Any
 from warnings import warn
 
 import numpy as np
 import yaml
 
+GeometryData = dict[str, Any]
 
-def parse_vector(text):
+
+def parse_vector(text: str) -> list[float] | None:
     """Parse a vector from text like '(x,y,z)'.
 
     Parameters
@@ -38,7 +44,7 @@ def parse_vector(text):
     return None
 
 
-def extract_version(tag):
+def extract_version(tag: str) -> int:
     """Extract a geometry version from a detector tag.
 
     Prefer explicit version tokens such as ``v3`` or ``_v3_``. If no such
@@ -55,7 +61,12 @@ def extract_version(tag):
     raise ValueError("Could not extract version from tag")
 
 
-def parse_tpc_block(lines, start_idx, cathode_thickness=0.0, pixel_size=0.0):
+def parse_tpc_block(
+    lines: Sequence[str],
+    start_idx: int,
+    cathode_thickness: float = 0.0,
+    pixel_size: float = 0.0,
+) -> GeometryData:
     """Parse a single TPC block from the geometry file.
 
     Parameters
@@ -203,7 +214,7 @@ def parse_tpc_block(lines, start_idx, cathode_thickness=0.0, pixel_size=0.0):
     return tpc_info
 
 
-def parse_optical_block(lines, start_idx):
+def parse_optical_block(lines: Sequence[str], start_idx: int) -> GeometryData:
     """Parse a single optical block from the geometry file.
 
     Parameters
@@ -327,7 +338,7 @@ def parse_optical_block(lines, start_idx):
     return op_info
 
 
-def parse_crt_block(lines, start_idx):
+def parse_crt_block(lines: Sequence[str], start_idx: int) -> GeometryData:
     """Parse a single CRT block from the geometry file.
 
     Parameters
@@ -567,7 +578,9 @@ def parse_crt_block(lines, start_idx):
     }
 
 
-def group_tpcs_by_cathode(tpc_list):
+def group_tpcs_by_cathode(
+    tpc_list: Sequence[GeometryData],
+) -> list[list[GeometryData]]:
     """Group TPCs by shared cathode and drift direction.
 
     Parameters
@@ -614,7 +627,7 @@ def group_tpcs_by_cathode(tpc_list):
     return [tpc_groups[gid] for gid in sorted(tpc_groups.keys())]
 
 
-def combine_tpc_group(group_tpcs):
+def combine_tpc_group(group_tpcs: Sequence[GeometryData]) -> GeometryData:
     """Combine a group of TPCs into a single combined TPC.
 
     Parameters
@@ -666,7 +679,10 @@ def combine_tpc_group(group_tpcs):
     }
 
 
-def build_tpc_yaml(combined_tpcs, all_tpcs):
+def build_tpc_yaml(
+    combined_tpcs: Sequence[GeometryData],
+    all_tpcs: Sequence[GeometryData],
+) -> GeometryData:
     """Build YAML structure for TPC section.
 
     Parameters
@@ -736,7 +752,9 @@ def build_tpc_yaml(combined_tpcs, all_tpcs):
     return tpc_yaml
 
 
-def build_optical_yaml(op_info_list, tpc_yaml):
+def build_optical_yaml(
+    op_info_list: Sequence[GeometryData], tpc_yaml: GeometryData
+) -> GeometryData:
     """Build YAML structure for optical section.
 
     Parameters
@@ -803,7 +821,10 @@ def build_optical_yaml(op_info_list, tpc_yaml):
     return op_yaml
 
 
-def build_crt_yaml(crt_info_list, crt_mapping=None):
+def build_crt_yaml(
+    crt_info_list: Sequence[GeometryData],
+    crt_mapping: str | None = None,
+) -> GeometryData:
     """Build YAML structure for CRT section.
 
     Parameters
@@ -963,7 +984,13 @@ def build_crt_yaml(crt_info_list, crt_mapping=None):
     return crt_yaml
 
 
-def main(source, output=None, cathode_thickness=0.0, pixel_size=0.0, crt_mapping=None):
+def main(
+    source: str,
+    output: str | None = None,
+    cathode_thickness: float = 0.0,
+    pixel_size: float = 0.0,
+    crt_mapping: str | None = None,
+) -> None:
     """Main function for parsing LArSoft geometry files.
 
     Parameters
@@ -1082,7 +1109,8 @@ def main(source, output=None, cathode_thickness=0.0, pixel_size=0.0, crt_mapping
     print(f"\nYAML file written to: {output_path}")
 
 
-if __name__ == "__main__":
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
     parser = argparse.ArgumentParser(description="Parse dumped LArSoft geometry files")
 
     parser.add_argument(
@@ -1122,8 +1150,12 @@ if __name__ == "__main__":
         default=None,
     )
 
-    args = parser.parse_args()
+    return parser
 
+
+def cli() -> None:
+    """Run the command-line interface."""
+    args = build_parser().parse_args()
     main(
         source=args.source,
         output=args.output,
@@ -1131,3 +1163,7 @@ if __name__ == "__main__":
         pixel_size=args.pixel_size,
         crt_mapping=args.crt_mapping,
     )
+
+
+if __name__ == "__main__":
+    cli()

--- a/bin/larcv/README.md
+++ b/bin/larcv/README.md
@@ -1,3 +1,86 @@
 # LArCV Scripts
 
 Utilities for inspecting, validating, and editing LArCV ROOT files.
+
+All commands accept input paths either directly with `--source`/`-s` or from a
+text file containing one path per line with `--source-list`/`-S`. These options
+are mutually exclusive. ROOT and LArCV Python bindings must be available.
+
+## Validate files before merging
+
+`larcv_check_valid.py` verifies that every `*_tree` in each file has the same
+non-zero entry count and that all files expose the same trees. It writes bad
+input paths to a text file.
+
+```bash
+python3 bin/larcv/larcv_check_valid.py \
+  -S files.txt --output bad_files.txt
+```
+
+## Count events
+
+`larcv_count_entries.py` reports per-file and total event counts. By default it
+uses the first LArCV tree; `--tree-name` selects a short product name without
+the `_tree` suffix.
+
+```bash
+python3 bin/larcv/larcv_count_entries.py \
+  -s input_0.root input_1.root --tree-name sparse3d_pcluster
+```
+
+## Find duplicate files
+
+`larcv_find_duplicates.py` groups likely duplicates using the entry count and
+the first `(run, subrun, event)` triplet. All but the first file in each group
+are written to the requested output list.
+
+```bash
+python3 bin/larcv/larcv_find_duplicates.py \
+  -S files.txt --output duplicates.txt
+```
+
+This is a fast campaign-level heuristic; it does not compare every event or
+payload byte.
+
+## Select files from one run
+
+`larcv_find_run.py` writes files whose first event carries a requested run
+number.
+
+```bash
+python3 bin/larcv/larcv_find_run.py \
+  -S files.txt --run-number 10536 --output run_10536.txt
+```
+
+## Inject run numbers
+
+`larcv_inject_run_number.py` rewrites event IDs across all products. Choose one
+output policy (`--dest` or `--overwrite`) and one numbering policy:
+`--run-number`, `--run-list`, or `--offset`.
+
+```bash
+python3 bin/larcv/larcv_inject_run_number.py \
+  -S files.txt --dest updated --run-number 10536 --suffix run_fixed
+```
+
+A run number of `-1` assigns each input file its zero-based position in the
+input list. `--run-list` consumes one integer per input file, while `--offset`
+adds a constant to each existing run number. `--overwrite` replaces original
+files after LArCV has successfully finalized temporary outputs, so it should be
+used deliberately.
+
+## Measure product sizes per event
+
+`larcv_tree_sizes.py` writes one CSV per input file with the number of elements
+in each requested product for every event.
+
+```bash
+python3 bin/larcv/larcv_tree_sizes.py \
+  -S files.txt \
+  --tree-names sparse3d_pcluster particle_pcluster \
+  --suffix counts
+```
+
+CSV files are written in the current directory as
+`<input-stem>_<suffix>.csv`. Existing files are skipped unless `--replace` is
+provided.

--- a/bin/larcv/larcv_check_valid.py
+++ b/bin/larcv/larcv_check_valid.py
@@ -1,16 +1,23 @@
 #!/usr/bin/env python3
 """Mark all bad LArCV ROOT files before merging them with hadd."""
 
+from __future__ import annotations
+
 import argparse
+from collections.abc import Sequence
 
 import numpy as np
 from larcv import larcv  # pylint: disable=W0611
 from ROOT import TFile  # pylint: disable=E0611
 from tqdm import tqdm
-from utils import get_tree, list_tree_keys
+from utils import get_tree, list_tree_keys, resolve_sources
 
 
-def main(source, source_list, output):
+def main(
+    source: Sequence[str] | None,
+    source_list: str | None,
+    output: str,
+) -> None:
     """Checks the validity of a LArCV root file.
 
     This script loops over all TTrees in a given ROOT file and check that they
@@ -25,17 +32,14 @@ def main(source, source_list, output):
 
     Parameters
     ----------
-    source : List[str]
+    source : sequence of str, optional
         List of paths to the input files
-    source_list : str
+    source_list : str, optional
         Path to a text file containing a list of data file paths
     output : str
         Path to the output text file with the list of bad files
     """
-    # If using source list, read it in
-    if source_list is not None:
-        with open(source_list, "r", encoding="utf-8") as f:
-            source = f.read().splitlines()
+    source = resolve_sources(source, source_list)
 
     # Initialize the output text file
     out_file = open(output, "w", encoding="utf-8")
@@ -84,8 +88,8 @@ def main(source, source_list, output):
     out_file.close()
 
 
-if __name__ == "__main__":
-    # Parse the command-line arguments
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
     parser = argparse.ArgumentParser(description="Check dataset validity")
 
     group = parser.add_mutually_exclusive_group(required=True)
@@ -108,7 +112,14 @@ if __name__ == "__main__":
         required=True,
     )
 
-    args = parser.parse_args()
+    return parser
 
-    # Execute the main function
+
+def cli() -> None:
+    """Run the command-line interface."""
+    args = build_parser().parse_args()
     main(args.source, args.source_list, args.output)
+
+
+if __name__ == "__main__":
+    cli()

--- a/bin/larcv/larcv_count_entries.py
+++ b/bin/larcv/larcv_count_entries.py
@@ -1,31 +1,35 @@
 #!/usr/bin/env python3
 """Counts the number of events in a LArCV dataset."""
 
+from __future__ import annotations
+
 import argparse
+from collections.abc import Sequence
 
 from larcv import larcv  # pylint: disable=W0611
 from ROOT import TFile  # pylint: disable=E0611
 from tqdm import tqdm
-from utils import get_tree, get_tree_key
+from utils import get_tree, get_tree_key, resolve_sources
 
 
-def main(source, source_list, tree_name):
+def main(
+    source: Sequence[str] | None,
+    source_list: str | None,
+    tree_name: str | None,
+) -> None:
     """Checks the number of entries in a file/list of files.
 
     Parameters
     ----------
-    source : Union[str, List[str]]
+    source : sequence of str, optional
         Path or list of paths to the input files
-    source_list : str
+    source_list : str, optional
         Path to a text file containing a list of data file paths
-    tree_name : str
+    tree_name : str, optional
         Name of the tree to use as a reference to count the number of entries.
         If not specified, takes the first tree in the list.
     """
-    # If using source list, read it in
-    if source_list is not None:
-        with open(source_list, "r", encoding="utf-8") as f:
-            source = f.read().splitlines()
+    source = resolve_sources(source, source_list)
 
     # Loop over the list of files in the input
     total_entries = 0
@@ -46,8 +50,8 @@ def main(source, source_list, tree_name):
     print(f"\nTotal number of entries: {total_entries}")
 
 
-if __name__ == "__main__":
-    # Parse the command-line arguments
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
     parser = argparse.ArgumentParser(description="Count entries in dataset")
 
     group = parser.add_mutually_exclusive_group(required=True)
@@ -66,7 +70,14 @@ if __name__ == "__main__":
         "--tree-name", help="TTree name used to count the entries.", type=str
     )
 
-    args = parser.parse_args()
+    return parser
 
-    # Execute the main function
+
+def cli() -> None:
+    """Run the command-line interface."""
+    args = build_parser().parse_args()
     main(args.source, args.source_list, args.tree_name)
+
+
+if __name__ == "__main__":
+    cli()

--- a/bin/larcv/larcv_find_duplicates.py
+++ b/bin/larcv/larcv_find_duplicates.py
@@ -1,16 +1,24 @@
 #!/usr/bin/env python3
 """Finds duplicated files."""
 
+from __future__ import annotations
+
 import argparse
+from collections.abc import Sequence
 
 import numpy as np
 from larcv import larcv  # pylint: disable=W0611
 from ROOT import TFile  # pylint: disable=E0611
 from tqdm import tqdm
-from utils import get_branch_key, get_tree, get_tree_key
+from utils import get_branch_key, get_tree, get_tree_key, resolve_sources
 
 
-def main(source, source_list, output, tree_name):
+def main(
+    source: Sequence[str] | None,
+    source_list: str | None,
+    output: str,
+    tree_name: str | None,
+) -> None:
     """Loops over a list of files and identifies files which contain the same
     set of (run, subrun, event) triplets.
 
@@ -20,20 +28,17 @@ def main(source, source_list, output, tree_name):
 
     Parameters
     ----------
-    source : Union[str, List[str]]
+    source : sequence of str, optional
         Path or list of paths to the input files
-    source_list : str
+    source_list : str, optional
         Path to a text file containing a list of data file paths
     output : str
         Path to the output text file with the list of duplicates
-    tree_name : str
+    tree_name : str, optional
         Name of the tree to use as a reference to count the number of entries.
         If not specified, takes the first tree in the list.
     """
-    # If using source list, read it in
-    if source_list is not None:
-        with open(source_list, "r", encoding="utf-8") as f:
-            source = f.read().splitlines()
+    source = resolve_sources(source, source_list)
 
     # Initialize the output text file
     out_file = open(output, "w", encoding="utf-8")
@@ -58,6 +63,7 @@ def main(source, source_list, output, tree_name):
 
         # Set the values list
         values[idx] = [num_entries, run, subrun, event]
+        f.Close()
 
     # Loop over non-unique files
     print(f"\nChecking for duplicates among {len(source)} files:")
@@ -83,8 +89,8 @@ def main(source, source_list, output, tree_name):
     out_file.close()
 
 
-if __name__ == "__main__":
-    # Parse the command-line arguments
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
     parser = argparse.ArgumentParser(description="Count entries in dataset")
 
     group = parser.add_mutually_exclusive_group(required=True)
@@ -111,7 +117,14 @@ if __name__ == "__main__":
         "--tree-name", help="TTree name used to count the entries.", type=str
     )
 
-    args = parser.parse_args()
+    return parser
 
-    # Execute the main function
+
+def cli() -> None:
+    """Run the command-line interface."""
+    args = build_parser().parse_args()
     main(args.source, args.source_list, args.output, args.tree_name)
+
+
+if __name__ == "__main__":
+    cli()

--- a/bin/larcv/larcv_find_run.py
+++ b/bin/larcv/larcv_find_run.py
@@ -1,35 +1,41 @@
 #!/usr/bin/env python3
 """Builds a list of file which make a data run."""
 
+from __future__ import annotations
+
 import argparse
+from collections.abc import Sequence
 
 from larcv import larcv  # pylint: disable=W0611
 from ROOT import TFile  # pylint: disable=E0611
 from tqdm import tqdm
-from utils import get_branch_key, get_tree, get_tree_key
+from utils import get_branch_key, get_tree, get_tree_key, resolve_sources
 
 
-def main(source, source_list, output, run_number, tree_name):
+def main(
+    source: Sequence[str] | None,
+    source_list: str | None,
+    output: str,
+    run_number: int,
+    tree_name: str | None,
+) -> None:
     """Loops over a list of files and finds those which belong to a certain run.
 
     Parameters
     ----------
-    source : Union[str, List[str]]
+    source : sequence of str, optional
         Path or list of paths to the input files
-    source_list : str
+    source_list : str, optional
         Path to a text file containing a list of data file paths
     output : str
         Path to the output text file with the list of run files
     run_number : int
         Run number to look for
-    tree_name : str
+    tree_name : str, optional
         Name of the tree to use as a reference to get the run number from.
         If not specified, takes the first tree in the list.
     """
-    # If using source list, read it in
-    if source_list is not None:
-        with open(source_list, "r", encoding="utf-8") as f:
-            source = f.read().splitlines()
+    source = resolve_sources(source, source_list)
 
     # Initialize the output text file
     out_file = open(output, "w", encoding="utf-8")
@@ -61,8 +67,8 @@ def main(source, source_list, output, run_number, tree_name):
     out_file.close()
 
 
-if __name__ == "__main__":
-    # Parse the command-line arguments
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
     parser = argparse.ArgumentParser(description="Count entries in dataset")
 
     group = parser.add_mutually_exclusive_group(required=True)
@@ -93,7 +99,14 @@ if __name__ == "__main__":
         "--tree-name", help="TTree name used to count the entries.", type=str
     )
 
-    args = parser.parse_args()
+    return parser
 
-    # Execute the main function
+
+def cli() -> None:
+    """Run the command-line interface."""
+    args = build_parser().parse_args()
     main(args.source, args.source_list, args.output, args.run_number, args.tree_name)
+
+
+if __name__ == "__main__":
+    cli()

--- a/bin/larcv/larcv_inject_run_number.py
+++ b/bin/larcv/larcv_inject_run_number.py
@@ -1,15 +1,17 @@
-"""Script which injects a run number in every event of every tree in a file or
-a list of files.
-"""
+#!/usr/bin/env python3
+"""Inject run numbers into every event and product in LArCV ROOT files."""
+
+from __future__ import annotations
 
 import argparse
 import os
 import tempfile
+from collections.abc import Sequence
+from typing import Any
 
-import numpy as np
 from larcv import larcv  # pylint: disable=W0611
-from ROOT import TFile  # pylint: disable=E0611
 from tqdm import tqdm
+from utils import resolve_sources
 
 # LArCV IO Manager configuration string
 CFG = """
@@ -23,24 +25,30 @@ IOManager: {
 """
 
 
-def initialize_manager(file_path, dest, overwrite, suffix):
+def initialize_manager(
+    file_path: str,
+    dest: str | None,
+    overwrite: bool,
+    suffix: str | None,
+) -> tuple[Any, str]:
     """Initialize an IOManager object given a configuration.
 
     Parameters
     ----------
     file_path : str
         Path to the input file
-    dest : str
+    dest : str, optional
         Destination folder to write the output file to
     overwrite : bool
         If `True`, overwrite the original file
-    suffix : str
+    suffix : str, optional
         Suffix to append to the input file name to form the output file name
 
     Returns
     -------
-    larcv.IOManager
-        IOManager object
+    tuple[larcv.IOManager, str]
+        Initialized manager and its output path. The manager type is dynamic
+        because it is supplied by the LArCV Python bindings.
     """
     # If the destination is provided, direct the output file there
     out_path = file_path
@@ -81,7 +89,16 @@ def initialize_manager(file_path, dest, overwrite, suffix):
     return manager, out_path
 
 
-def main(source, source_list, dest, overwrite, run_number, run_list, offset, suffix):
+def main(
+    source: Sequence[str] | None,
+    source_list: str | None,
+    dest: str | None,
+    overwrite: bool,
+    run_number: int | None,
+    run_list: str | None,
+    offset: int | None,
+    suffix: str | None,
+) -> None:
     """Checks the output of the SPINE process.
 
     The script loops over the input files, fetch the list of keys in the file
@@ -94,30 +111,27 @@ def main(source, source_list, dest, overwrite, run_number, run_list, offset, suf
 
     Parameters
     ----------
-    source : List[str]
+    source : sequence of str, optional
         List of paths to the input files
-    source_list : str
+    source_list : str, optional
         Path to a text file containing a list of data file paths
-    dest : str
+    dest : str, optional
         Destination folder to write the files to
     overwrite : bool
         If `True`, overwrite the original files
-    run_number : int
+    run_number : int, optional
         Run number to inject in the input file list. If it is specied as -1,
         each file is assigned a unique run number
-    run_list : str
+    run_list : str, optional
         Path to a text file containing a list of run numbers to assign to each
         input file
-    offset : int
+    offset : int, optional
         Offset to add to the existing run number for each successive file
-    suffix : str
+    suffix : str, optional
         String to append to the end of the input file names to form the name
         of the output file with the updated run numbers
     """
-    # If using source list, read it in
-    if source_list is not None:
-        with open(source_list, "r", encoding="utf-8") as f:
-            source = f.read().splitlines()
+    source = resolve_sources(source, source_list)
 
     # If using run list, read it in
     run_numbers = None
@@ -157,6 +171,7 @@ def main(source, source_list, dest, overwrite, run_number, run_list, offset, suf
             elif run_numbers is not None:
                 io.set_id(run_numbers[idx], subrun, event)
             else:
+                assert offset is not None
                 io.set_id(run + offset, subrun, event)
 
             # Save
@@ -170,8 +185,8 @@ def main(source, source_list, dest, overwrite, run_number, run_list, offset, suf
             os.rename(out_path, file_path)
 
 
-if __name__ == "__main__":
-    # Parse the command-line arguments
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
     parser = argparse.ArgumentParser(description="Check dataset validity")
 
     group = parser.add_mutually_exclusive_group(required=True)
@@ -219,9 +234,12 @@ if __name__ == "__main__":
         "--suffix", help="Suffix to append to the input file names", type=str
     )
 
-    args = parser.parse_args()
+    return parser
 
-    # Execute the main function
+
+def cli() -> None:
+    """Run the command-line interface."""
+    args = build_parser().parse_args()
     main(
         args.source,
         args.source_list,
@@ -232,3 +250,7 @@ if __name__ == "__main__":
         args.offset,
         args.suffix,
     )
+
+
+if __name__ == "__main__":
+    cli()

--- a/bin/larcv/larcv_tree_sizes.py
+++ b/bin/larcv/larcv_tree_sizes.py
@@ -1,35 +1,41 @@
 #!/usr/bin/env python3
 """Counts the number of events in a LArCV dataset."""
 
+from __future__ import annotations
+
 import argparse
+from collections.abc import Sequence
 from pathlib import Path
 
 from larcv import larcv  # pylint: disable=W0611
 from ROOT import TFile  # pylint: disable=E0611
 from tqdm import tqdm
-from utils import get_tree
+from utils import get_tree, resolve_sources
 
 
-def main(source, source_list, tree_names, suffix=None, replace=False):
+def main(
+    source: Sequence[str] | None,
+    source_list: str | None,
+    tree_names: Sequence[str],
+    suffix: str = "counts",
+    replace: bool = False,
+) -> None:
     """Get the length of a LArCV datasets.
 
     Parameters
     ----------
-    source : Union[str, List[str]]
+    source : sequence of str, optional
         Path or list of paths to the input files
-    source_list : str
+    source_list : str, optional
         Path to a text file containing a list of data file paths
-    tree_names : List[str]
+    tree_names : sequence of str
         Names of the trees to measure each entry count from.
-    suffix : str, optional
+    suffix : str, default "counts"
         Suffix for the output file(s)
     replace : bool, default False
         If True, replace existing output files
     """
-    # If using source list, read it in
-    if source_list is not None:
-        with open(source_list, "r", encoding="utf-8") as f:
-            source = f.read().splitlines()
+    source = resolve_sources(source, source_list)
 
     # Initialize a header for the output files
     header = "entry," + ",".join([f"{name}_count" for name in tree_names]) + "\n"
@@ -84,8 +90,8 @@ def main(source, source_list, tree_names, suffix=None, replace=False):
         tqdm.write(f"- Processed {num_entries} entries for file: {file_path}")
 
 
-if __name__ == "__main__":
-    # Parse the command-line arguments
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
     parser = argparse.ArgumentParser(description="Measure LArCV tree sizes.")
 
     group = parser.add_mutually_exclusive_group(required=True)
@@ -121,7 +127,14 @@ if __name__ == "__main__":
         "--replace", help="Replace existing output files", action="store_true"
     )
 
-    args = parser.parse_args()
+    return parser
 
-    # Execute the main function
+
+def cli() -> None:
+    """Run the command-line interface."""
+    args = build_parser().parse_args()
     main(args.source, args.source_list, args.tree_names, args.suffix, args.replace)
+
+
+if __name__ == "__main__":
+    cli()

--- a/bin/larcv/utils.py
+++ b/bin/larcv/utils.py
@@ -1,6 +1,36 @@
 """Shared helpers for LArCV utility scripts."""
 
+from collections.abc import Sequence
 from typing import Any
+
+
+def resolve_sources(source: Sequence[str] | None, source_list: str | None) -> list[str]:
+    """Resolve the mutually exclusive input-file command-line options.
+
+    Parameters
+    ----------
+    source : sequence of str, optional
+        File paths supplied directly with ``--source``.
+    source_list : str, optional
+        Text file containing one input path per line.
+
+    Returns
+    -------
+    list[str]
+        Concrete list of paths to process.
+
+    Raises
+    ------
+    ValueError
+        If neither input form was provided. ``argparse`` normally prevents
+        this, but the check also makes direct Python calls safe.
+    """
+    if source_list is not None:
+        with open(source_list, "r", encoding="utf-8") as source_file:
+            return source_file.read().splitlines()
+    if source is None:
+        raise ValueError("Either `source` or `source_list` must be provided.")
+    return list(source)
 
 
 def list_tree_keys(root_file: Any) -> list[str]:

--- a/bin/output/README.md
+++ b/bin/output/README.md
@@ -1,3 +1,25 @@
 # Output Scripts
 
 Utilities for checking SPINE processing outputs.
+
+## Compare two HDF5 outputs
+
+`output_compare.py` compares two SPINE HDF5 files event by event. HDF5 region
+references are dereferenced before comparison, so differences in file layout or
+dataset order do not affect the result. Integer, boolean, and string values must
+match exactly; floating-point values use relative and absolute tolerances.
+
+```bash
+python3 bin/output/output_compare.py reference.h5 candidate.h5
+```
+
+The default floating-point tolerances are `rtol=1e-4` and `atol=1e-6`. Use
+exact comparison for deterministic CPU validation:
+
+```bash
+python3 bin/output/output_compare.py reference_cpu.h5 candidate_cpu.h5 --exact
+```
+
+Individual products can be selected or omitted with `--keys` and
+`--skip-keys`, respectively. A mismatch returns exit status 1, which makes the
+script suitable for automated validation.

--- a/bin/output/README.md
+++ b/bin/output/README.md
@@ -4,10 +4,12 @@ Utilities for checking SPINE processing outputs.
 
 ## Compare two HDF5 outputs
 
-`output_compare.py` compares two SPINE HDF5 files event by event. HDF5 region
-references are dereferenced before comparison, so differences in file layout or
-dataset order do not affect the result. Integer, boolean, and string values must
-match exactly; floating-point values use relative and absolute tolerances.
+`output_compare.py` compares two SPINE HDF5 files event by event. It supports
+both the legacy region-reference/VLEN layout (format version 1) and the
+offset-based layout (format version 2), including direct V1-to-V2 comparisons.
+Physical references, offsets, dataset order, and object-field pools are
+normalized before comparison. Integer, boolean, and string values must match
+exactly; floating-point values use relative and absolute tolerances.
 
 ```bash
 python3 bin/output/output_compare.py reference.h5 candidate.h5

--- a/bin/output/README.md
+++ b/bin/output/README.md
@@ -25,3 +25,31 @@ python3 bin/output/output_compare.py reference_cpu.h5 candidate_cpu.h5 --exact
 Individual products can be selected or omitted with `--keys` and
 `--skip-keys`, respectively. A mismatch returns exit status 1, which makes the
 script suitable for automated validation.
+
+## Create a lite V2 HDF5 output
+
+`output_litify.py` structurally reduces an offset-based format-V2 file without
+deserializing events or rebuilding SPINE objects. With no product selection it
+uses the standard production lite product list:
+
+```bash
+python3 bin/output/output_litify.py full.h5 lite.h5
+```
+
+Products can be supplied directly:
+
+```bash
+python3 bin/output/output_litify.py full.h5 lite.h5 \
+  --keys run_info meta reco_particles truth_particles
+```
+
+The script can also read either a small YAML file containing a top-level
+`keys` list or an existing SPINE configuration containing `io.writer.keys`:
+
+```bash
+python3 bin/output/output_litify.py full.h5 lite.h5 --config litify.yaml
+```
+
+Use `--mode fixed_only` to discard every variable-length object attribute.
+The default `lite` mode exactly follows each stored class's established
+`lite=True` policy and therefore retains small relationship arrays.

--- a/bin/output/README.md
+++ b/bin/output/README.md
@@ -2,6 +2,27 @@
 
 Utilities for checking SPINE processing outputs.
 
+## Validate campaign outputs
+
+`output_check_valid.py` maps each source input to its expected SPINE output and
+writes missing or incomplete source paths to a text file suitable for
+resubmission:
+
+```bash
+python3 bin/output/output_check_valid.py \
+  --source-list inputs.txt \
+  --dest /path/to/outputs \
+  --suffix spine \
+  --output retry.txt
+```
+
+For modern HDF5 files it checks the writer's completion marker and source-file
+provenance. Older HDF5 files fall back to entry-count validation. Use
+`--larcv-output` when the campaign produced ROOT rather than HDF5, and
+`--tree-name` to select the reference LArCV tree. `--event-list` accepts
+whitespace- or comma-separated `(run, subrun, event)` triplets when only a
+subset was requested.
+
 ## Compare two HDF5 outputs
 
 `output_compare.py` compares two SPINE HDF5 files event by event. It supports

--- a/bin/output/output_check_valid.py
+++ b/bin/output/output_check_valid.py
@@ -14,11 +14,13 @@ If those markers are absent, the script falls back to the legacy heuristic of
 matching output file names and comparing input/output entry counts.
 """
 
+from __future__ import annotations
+
 import argparse
 import os
+from collections.abc import Sequence
 
 import h5py
-import numpy as np
 from tqdm import tqdm
 
 try:
@@ -29,7 +31,7 @@ except ImportError:  # pragma: no cover - exercised in test_bin without ROOT/LAr
     TFile = None
 
 
-def require_root_larcv():
+def require_root_larcv() -> None:
     """Require ROOT/LArCV support for ROOT-based validation paths.
 
     Raises
@@ -44,7 +46,7 @@ def require_root_larcv():
         )
 
 
-def get_num_entries(file_path, tree_name=None):
+def get_num_entries(file_path: str, tree_name: str | None = None) -> int:
     """Return the number of entries stored in one input or output file.
 
     Parameters
@@ -75,7 +77,7 @@ def get_num_entries(file_path, tree_name=None):
         return len(f["events"])
 
 
-def has_modern_hdf5_markers(out_file):
+def has_modern_hdf5_markers(out_file: h5py.File) -> bool:
     """Check whether an HDF5 output exposes modern completeness metadata.
 
     Parameters
@@ -94,7 +96,7 @@ def has_modern_hdf5_markers(out_file):
     return has_complete or has_source
 
 
-def check_hdf5_source_provenance(file_path, out_file):
+def check_hdf5_source_provenance(file_path: str, out_file: h5py.File) -> bool:
     """Validate top-level source provenance when the output stores it.
 
     Parameters
@@ -131,7 +133,7 @@ def check_hdf5_source_provenance(file_path, out_file):
     )
 
 
-def is_valid_modern_hdf5_output(file_path, out_path):
+def is_valid_modern_hdf5_output(file_path: str, out_path: str) -> bool | None:
     """Validate a modern HDF5 output using completeness and source metadata.
 
     Parameters
@@ -160,8 +162,15 @@ def is_valid_modern_hdf5_output(file_path, out_path):
 
 
 def main(
-    source, source_list, output, dest, suffix, event_list, tree_name, larcv_output
-):
+    source: Sequence[str] | None,
+    source_list: str | None,
+    output: str,
+    dest: str,
+    suffix: str,
+    event_list: str | None,
+    tree_name: str | None,
+    larcv_output: bool,
+) -> None:
     """Check the outputs of a SPINE processing campaign.
 
     The script loops over the requested input files, checks that an output file
@@ -185,9 +194,9 @@ def main(
 
     Parameters
     ----------
-    source : list[str]
+    source : sequence of str, optional
         List of paths to the input files
-    source_list : str
+    source_list : str, optional
         Path to a text file containing a list of data file paths
     output : str
         Path to the output text file with the list of problematic files
@@ -195,10 +204,10 @@ def main(
         Destination directory used by the original SPINE process
     suffix : str
         Suffix added to input file stems by the original SPINE process
-    event_list : str
+    event_list : str, optional
         Path to a file containing a list of events to process. If provided,
         only events appearing on this list are required in the output.
-    tree_name : str
+    tree_name : str, optional
         Name of the ROOT tree to use when counting entries. If not specified,
         the first tree found in each input ROOT file is used.
     larcv_output : bool
@@ -209,21 +218,25 @@ def main(
     if source_list is not None:
         with open(source_list, "r", encoding="utf-8") as f:
             source = f.read().splitlines()
+    if source is None:
+        raise ValueError("Either `source` or `source_list` must be provided.")
+    source = list(source)
 
     # Initialize the output text file
     out_file = open(output, "w", encoding="utf-8")
 
     # If it is provided, parse the list of (run, subrun, event) triplets
+    requested_events: set[tuple[int, int, int]] | None = None
     if event_list is not None:
         with open(event_list, "r", encoding="utf-8") as f:
             lines = f.read().splitlines()
-            line_list = [l.replace(",", " ").split() for l in lines]
-            event_list = [(int(r), int(s), int(e)) for r, s, e in line_list]
+            line_list = [line.replace(",", " ").split() for line in lines]
+            requested_events = {(int(r), int(s), int(e)) for r, s, e in line_list}
 
     # Loop over the list of files in the input
     print("\nChecking existence and completeness of output files.")
     miss_list, inc_list = [], []
-    for idx, file_path in enumerate(tqdm(source)):
+    for file_path in tqdm(source):
         # Find the base name of the input file (without extension)
         base = os.path.basename(file_path)
         stem, _ = os.path.splitext(base)
@@ -250,20 +263,11 @@ def main(
             if is_valid is True:
                 continue
 
-        # Legacy fallback: compare expected and actual entry counts. If ROOT,
-        # fetch the tree name first and optionally filter by event list.
+        # Legacy fallback: compare expected and actual entry counts.
         larcv_input = file_path.endswith(".root")
-        if larcv_input:
-            require_root_larcv()
-            f = TFile(file_path, "r")
-            if tree_name is None:
-                key = [key.GetName() for key in f.GetListOfKeys()][0]
-            else:
-                key = f"{tree_name}_tree"
-            key_b = key.replace("_tree", "_branch")
 
         # Dispatch depending if the event list is provided or not
-        if event_list is None:
+        if requested_events is None:
             # Count the number of entries in the input and legacy output.
             num_entries = get_num_entries(file_path, tree_name=tree_name)
             out_num_entries = get_num_entries(out_path, tree_name=tree_name)
@@ -275,14 +279,21 @@ def main(
 
         else:
             # Fetch the list of (run, subrun, event) triplets that should appear
-            check_list = []
+            check_list: list[tuple[int, int, int]] = []
             if larcv_input:
+                require_root_larcv()
+                f = TFile(file_path, "r")
+                if tree_name is None:
+                    key = [key.GetName() for key in f.GetListOfKeys()][0]
+                else:
+                    key = f"{tree_name}_tree"
+                key_b = key.replace("_tree", "_branch")
                 tree = getattr(f, key)
                 for i in range(tree.GetEntries()):
                     tree.GetEntry(i)
                     branch = getattr(tree, key_b)
                     run, subrun, event = branch.run(), branch.subrun(), branch.event()
-                    if (run, subrun, event) in event_list:
+                    if (run, subrun, event) in requested_events:
                         check_list.append((run, subrun, event))
                 f.Close()
             else:
@@ -307,8 +318,8 @@ def main(
     out_file.close()
 
 
-if __name__ == "__main__":
-    # Parse the command-line arguments
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
     parser = argparse.ArgumentParser(description="Check dataset validity")
 
     group = parser.add_mutually_exclusive_group(required=True)
@@ -359,9 +370,12 @@ if __name__ == "__main__":
         action="store_true",
     )
 
-    args = parser.parse_args()
+    return parser
 
-    # Execute the main function
+
+def cli() -> None:
+    """Run the command-line interface."""
+    args = build_parser().parse_args()
     main(
         args.source,
         args.source_list,
@@ -372,3 +386,7 @@ if __name__ == "__main__":
         args.tree_name,
         args.larcv_output,
     )
+
+
+if __name__ == "__main__":
+    cli()

--- a/bin/output/output_compare.py
+++ b/bin/output/output_compare.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Compare the event content of two SPINE HDF5 output files.
 
-The comparison is semantic rather than bytewise. Event region references are
-dereferenced, structured data products are compared field by field, and HDF5
-layout details such as dataset order and object addresses are ignored.
+The comparison is semantic rather than bytewise. Legacy region references and
+version-2 integer offsets are normalized, structured data products are compared
+field by field, and HDF5 layout details such as dataset order, object addresses,
+and variable-field pools are ignored.
 
 Integer, boolean, and string values must always agree exactly. Floating-point
 values are compared with configurable absolute and relative tolerances, unless
@@ -19,6 +20,7 @@ from typing import Any
 
 import h5py
 import numpy as np
+import yaml
 
 
 @dataclass
@@ -76,7 +78,90 @@ class ComparisonResult:
             self.differences.append(f"{path}: {message}")
 
 
-def load_event_value(in_file: h5py.File, event: np.void, key: str) -> Any:
+def get_format_version(in_file: h5py.File) -> int:
+    """Return the declared SPINE HDF5 layout version."""
+    version = 1
+    if "info" in in_file:
+        version = int(in_file["info"].attrs.get("format_version", 1))
+    if version not in (1, 2):
+        raise ValueError(f"Unsupported HDF5 format version {version}.")
+    return version
+
+
+def get_product_keys(in_file: h5py.File, format_version: int) -> set[str]:
+    """Return the event data products exposed by one SPINE HDF5 file."""
+    events = in_file["events"]
+    assert isinstance(events, h5py.Dataset)
+    if format_version == 1:
+        return set(events.dtype.names or ())
+    return set(in_file.keys()) - {"events", "info"}
+
+
+def _decode_attribute(value: Any) -> Any:
+    """Decode byte-valued HDF5 attributes."""
+    return value.decode() if isinstance(value, bytes) else value
+
+
+def load_objects_v2(group: h5py.Group, event_index: int) -> Any:
+    """Load V2 object rows into their logical V1 structured representation."""
+    fixed = group["fixed"]
+    event_offsets = group["event_offsets"]
+    variables = group["variables"]
+    assert isinstance(fixed, h5py.Dataset)
+    assert isinstance(event_offsets, h5py.Dataset)
+    assert isinstance(variables, h5py.Group)
+
+    first, last = (int(value) for value in event_offsets[event_index : event_index + 2])
+    rows = fixed[first:last]
+    fixed_names = [
+        name for name in rows.dtype.names or () if not name.startswith("_var_offsets_")
+    ]
+    dtype_specs: list[tuple[str, Any]] = [
+        (name, rows.dtype.fields[name][0]) for name in fixed_names
+    ]
+    pools = sorted(variables.items(), key=lambda item: int(item[0].split("_")[-1]))
+    for _, pool in pools:
+        fields = yaml.safe_load(pool.attrs["fields"])
+        kind = _decode_attribute(pool.attrs["kind"])
+        values = pool["values"]
+        dtype = (
+            h5py.string_dtype() if kind == "string" else h5py.vlen_dtype(values.dtype)
+        )
+        dtype_specs.extend((name, dtype) for name in fields)
+
+    result = np.empty(len(rows), dtype=np.dtype(dtype_specs))
+    for name in fixed_names:
+        result[name] = rows[name]
+
+    for pool_name, pool in pools:
+        fields = yaml.safe_load(pool.attrs["fields"])
+        kind = _decode_attribute(pool.attrs["kind"])
+        values = pool["values"]
+        pool_index = int(pool_name.split("_")[-1])
+        bounds = rows[f"_var_offsets_{pool_index}"]
+        base = int(bounds[0, 0]) if len(bounds) else 0
+        terminal = int(bounds[-1, -1]) if len(bounds) else base
+        event_values = values[base:terminal]
+        for field_index, name in enumerate(fields):
+            for row_index in range(len(rows)):
+                start = int(bounds[row_index, field_index]) - base
+                stop = int(bounds[row_index, field_index + 1]) - base
+                value = event_values[start:stop]
+                if kind == "string":
+                    value = value.tobytes().decode("utf-8")
+                result[name][row_index] = value
+
+    if bool(group.attrs["scalar"]):
+        return result[0]
+    return result
+
+
+def load_event_value(
+    in_file: h5py.File,
+    event_index: int,
+    key: str,
+    format_version: int,
+) -> Any:
     """Load one event-level value from a SPINE HDF5 file.
 
     This mirrors the dereferencing performed by
@@ -89,16 +174,77 @@ def load_event_value(in_file: h5py.File, event: np.void, key: str) -> Any:
     ----------
     in_file : h5py.File
         Open SPINE HDF5 file.
-    event : numpy.void
-        Structured row from the file's ``events`` dataset.
+    event_index : int
+        Event row index.
     key : str
         Event data-product name.
+    format_version : int
+        Physical SPINE HDF5 layout version.
 
     Returns
     -------
     Any
         Dereferenced event value.
     """
+    if format_version == 2:
+        group = in_file[key]
+        if not isinstance(group, h5py.Group) or "kind" not in group.attrs:
+            raise ValueError(f"V2 product '{key}' is not a recognized product group.")
+
+        kind = _decode_attribute(group.attrs["kind"])
+        if kind in {"array", "string"}:
+            values = group["values"]
+            offsets = group["event_offsets"]
+            start, stop = (
+                int(value) for value in offsets[event_index : event_index + 2]
+            )
+            value = values[start:stop]
+            if kind == "string":
+                return value.tobytes().decode("utf-8")
+            if bool(group.attrs["scalar"]):
+                value = value[0]
+            return value
+
+        if kind == "objects":
+            return load_objects_v2(group, event_index)
+
+        if kind == "list":
+            values = group["values"]
+            element_offsets = group["element_offsets"]
+            event_offsets = group["event_offsets"]
+            first, last = (
+                int(value) for value in event_offsets[event_index : event_index + 2]
+            )
+            bounds = element_offsets[first : last + 1]
+            result = np.empty(last - first, dtype=object)
+            base = int(bounds[0]) if len(bounds) else 0
+            terminal = int(bounds[-1]) if len(bounds) else base
+            event_values = values[base:terminal]
+            for index in range(last - first):
+                start = int(bounds[index]) - base
+                stop = int(bounds[index + 1]) - base
+                result[index] = event_values[start:stop]
+            return result
+
+        if kind == "multi_list":
+            result = []
+            elements = sorted(
+                group.items(), key=lambda item: int(item[0].split("_")[-1])
+            )
+            for _, element in elements:
+                values = element["values"]
+                offsets = element["event_offsets"]
+                start, stop = (
+                    int(value) for value in offsets[event_index : event_index + 2]
+                )
+                result.append(values[start:stop])
+            return result
+
+        raise ValueError(f"Unrecognized V2 product kind '{kind}' for key '{key}'.")
+
+    events = in_file["events"]
+    assert isinstance(events, h5py.Dataset)
+    event = events[event_index]
     region_ref = event[key]
     dataset = in_file[key]
 
@@ -216,6 +362,40 @@ def compare_values(
         If `True`, require bit-for-bit floating-point equality, with NaNs at
         matching positions treated as equal.
     """
+    reference_sequence = isinstance(reference, (list, tuple))
+    candidate_sequence = isinstance(candidate, (list, tuple))
+    if reference_sequence or candidate_sequence:
+        if not reference_sequence or not candidate_sequence:
+            result.add_difference(
+                path,
+                (
+                    "container type differs "
+                    f"({type(reference).__name__} != {type(candidate).__name__})"
+                ),
+            )
+            return
+        if len(reference) != len(candidate):
+            result.add_difference(
+                path, f"length differs ({len(reference)} != {len(candidate)})"
+            )
+            return
+        for index, (ref_value, candidate_value) in enumerate(zip(reference, candidate)):
+            compare_values(
+                ref_value,
+                candidate_value,
+                f"{path}[{index}]",
+                result,
+                rtol,
+                atol,
+                exact,
+            )
+        return
+
+    if isinstance(reference, (bytes, np.bytes_)):
+        reference = bytes(reference).decode("utf-8")
+    if isinstance(candidate, (bytes, np.bytes_)):
+        candidate = bytes(candidate).decode("utf-8")
+
     reference = np.asarray(reference)
     candidate = np.asarray(candidate)
 
@@ -228,7 +408,7 @@ def compare_values(
     ref_fields = reference.dtype.names
     candidate_fields = candidate.dtype.names
     if ref_fields is not None or candidate_fields is not None:
-        if ref_fields != candidate_fields:
+        if set(ref_fields or ()) != set(candidate_fields or ()):
             result.add_difference(
                 path, f"structured fields differ ({ref_fields} != {candidate_fields})"
             )
@@ -352,8 +532,15 @@ def compare_files(
             )
             return result
 
-        reference_keys = set(reference_events.dtype.names or ())
-        candidate_keys = set(candidate_events.dtype.names or ())
+        try:
+            reference_version = get_format_version(reference_file)
+            candidate_version = get_format_version(candidate_file)
+        except ValueError as error:
+            result.add_difference("format", str(error))
+            return result
+
+        reference_keys = get_product_keys(reference_file, reference_version)
+        candidate_keys = get_product_keys(candidate_file, candidate_version)
         requested_keys = set(keys) if keys is not None else reference_keys
         skipped_keys = set(skip_keys or ())
         selected_keys = requested_keys - skipped_keys
@@ -381,14 +568,16 @@ def compare_files(
         common_keys = sorted(selected_keys & reference_keys & candidate_keys)
         result.num_events = len(reference_events)
         result.num_products = len(reference_events) * len(common_keys)
-        for event_idx, (reference_event, candidate_event) in enumerate(
-            zip(reference_events, candidate_events)
-        ):
+        for event_idx in range(len(reference_events)):
             for key in common_keys:
                 path = f"event[{event_idx}].{key}"
                 try:
-                    reference = load_event_value(reference_file, reference_event, key)
-                    candidate = load_event_value(candidate_file, candidate_event, key)
+                    reference = load_event_value(
+                        reference_file, event_idx, key, reference_version
+                    )
+                    candidate = load_event_value(
+                        candidate_file, event_idx, key, candidate_version
+                    )
                     compare_values(
                         reference,
                         candidate,

--- a/bin/output/output_compare.py
+++ b/bin/output/output_compare.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+"""Compare the event content of two SPINE HDF5 output files.
+
+The comparison is semantic rather than bytewise. Event region references are
+dereferenced, structured data products are compared field by field, and HDF5
+layout details such as dataset order and object addresses are ignored.
+
+Integer, boolean, and string values must always agree exactly. Floating-point
+values are compared with configurable absolute and relative tolerances, unless
+``--exact`` is requested.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+
+
+@dataclass
+class ComparisonResult:
+    """Accumulate comparison statistics and human-readable differences.
+
+    Attributes
+    ----------
+    num_events : int
+        Number of events compared.
+    num_products : int
+        Number of event-level data products compared.
+    num_values : int
+        Number of scalar leaf values compared.
+    num_mismatches : int
+        Total number of comparison failures. A failure may describe a shape,
+        schema, or one-or-more-value mismatch.
+    max_abs_diff : float
+        Largest absolute floating-point difference observed.
+    max_rel_diff : float
+        Largest relative floating-point difference observed. This is infinite
+        when a nonzero candidate value is compared with a zero reference.
+    differences : list[str]
+        First ``max_differences`` human-readable mismatch descriptions.
+    max_differences : int
+        Maximum number of descriptions retained while counting all failures.
+    """
+
+    num_events: int = 0
+    num_products: int = 0
+    num_values: int = 0
+    num_mismatches: int = 0
+    max_abs_diff: float = 0.0
+    max_rel_diff: float = 0.0
+    differences: list[str] = field(default_factory=list)
+    max_differences: int = 20
+
+    @property
+    def agrees(self) -> bool:
+        """Return whether no comparison failures were found."""
+        return self.num_mismatches == 0
+
+    def add_difference(self, path: str, message: str) -> None:
+        """Record one mismatch while bounding retained report text.
+
+        Parameters
+        ----------
+        path : str
+            Event/product path at which the mismatch occurred.
+        message : str
+            Concise description of the mismatch.
+        """
+        self.num_mismatches += 1
+        if len(self.differences) < self.max_differences:
+            self.differences.append(f"{path}: {message}")
+
+
+def load_event_value(in_file: h5py.File, event: np.void, key: str) -> Any:
+    """Load one event-level value from a SPINE HDF5 file.
+
+    This mirrors the dereferencing performed by
+    :class:`spine.io.read.HDF5Reader`, but deliberately leaves serialized
+    objects as NumPy structured arrays. Avoiding class reconstruction makes
+    the utility usable across SPINE versions and exposes precise field paths
+    in mismatch reports.
+
+    Parameters
+    ----------
+    in_file : h5py.File
+        Open SPINE HDF5 file.
+    event : numpy.void
+        Structured row from the file's ``events`` dataset.
+    key : str
+        Event data-product name.
+
+    Returns
+    -------
+    Any
+        Dereferenced event value.
+    """
+    region_ref = event[key]
+    dataset = in_file[key]
+
+    if isinstance(dataset, h5py.Dataset):
+        value = dataset[region_ref]
+        if bool(dataset.attrs.get("scalar", False)):
+            value = value[0]
+        elif dataset.ndim > 1:
+            value = value.reshape(-1, dataset.shape[1])
+        return value
+
+    if isinstance(dataset, h5py.Group):
+        index = dataset["index"]
+        element_refs = index[region_ref].flatten()
+        if index.ndim == 1:
+            elements = dataset["elements"]
+            values = np.empty(len(element_refs), dtype=object)
+            for idx, reference in enumerate(element_refs):
+                value = elements[reference]
+                if elements.ndim > 1:
+                    value = value.reshape(-1, elements.shape[1])
+                values[idx] = value
+            return values
+
+        values = []
+        for idx, reference in enumerate(element_refs):
+            elements = dataset[f"element_{idx}"]
+            value = elements[reference]
+            if elements.ndim > 1:
+                value = value.reshape(-1, elements.shape[1])
+            values.append(value)
+        return values
+
+    raise TypeError(f"Data product '{key}' is neither a dataset nor a group.")
+
+
+def _format_index(index: tuple[int, ...]) -> str:
+    """Format a NumPy index for inclusion in a comparison path."""
+    return "".join(f"[{value}]" for value in index)
+
+
+def _compare_float_arrays(
+    reference: np.ndarray,
+    candidate: np.ndarray,
+    path: str,
+    result: ComparisonResult,
+    rtol: float,
+    atol: float,
+    exact: bool,
+) -> None:
+    """Compare floating-point arrays and update numeric diagnostics."""
+    result.num_values += reference.size
+    if not reference.size:
+        return
+
+    finite_pairs = np.isfinite(reference) & np.isfinite(candidate)
+    if np.any(finite_pairs):
+        abs_diff = np.abs(candidate[finite_pairs] - reference[finite_pairs])
+        result.max_abs_diff = max(result.max_abs_diff, float(np.max(abs_diff)))
+        denominator = np.abs(reference[finite_pairs])
+        rel_diff = np.divide(
+            abs_diff,
+            denominator,
+            out=np.full(abs_diff.shape, np.inf, dtype=np.float64),
+            where=denominator != 0,
+        )
+        zero_equal = (denominator == 0) & (abs_diff == 0)
+        rel_diff[zero_equal] = 0.0
+        result.max_rel_diff = max(result.max_rel_diff, float(np.max(rel_diff)))
+
+    if exact:
+        matches = (reference == candidate) | (np.isnan(reference) & np.isnan(candidate))
+    else:
+        matches = np.isclose(reference, candidate, rtol=rtol, atol=atol, equal_nan=True)
+
+    if np.all(matches):
+        return
+
+    mismatch_count = int(np.count_nonzero(~matches))
+    mismatch_index = tuple(np.argwhere(~matches)[0])
+    indexed_path = f"{path}{_format_index(mismatch_index)}"
+    ref_value = reference[mismatch_index]
+    candidate_value = candidate[mismatch_index]
+    result.add_difference(
+        indexed_path,
+        (
+            f"floating values differ ({ref_value!r} != {candidate_value!r}); "
+            f"{mismatch_count}/{reference.size} values outside tolerance"
+        ),
+    )
+
+
+def compare_values(
+    reference: Any,
+    candidate: Any,
+    path: str,
+    result: ComparisonResult,
+    rtol: float,
+    atol: float,
+    exact: bool,
+) -> None:
+    """Recursively compare two dereferenced HDF5 values.
+
+    Parameters
+    ----------
+    reference, candidate : Any
+        Values loaded from the reference and candidate files.
+    path : str
+        Human-readable path to the values.
+    result : ComparisonResult
+        Mutable accumulator for statistics and differences.
+    rtol, atol : float
+        Relative and absolute floating-point tolerances.
+    exact : bool
+        If `True`, require bit-for-bit floating-point equality, with NaNs at
+        matching positions treated as equal.
+    """
+    reference = np.asarray(reference)
+    candidate = np.asarray(candidate)
+
+    if reference.shape != candidate.shape:
+        result.add_difference(
+            path, f"shape differs ({reference.shape} != {candidate.shape})"
+        )
+        return
+
+    ref_fields = reference.dtype.names
+    candidate_fields = candidate.dtype.names
+    if ref_fields is not None or candidate_fields is not None:
+        if ref_fields != candidate_fields:
+            result.add_difference(
+                path, f"structured fields differ ({ref_fields} != {candidate_fields})"
+            )
+            return
+        for name in ref_fields or ():
+            compare_values(
+                reference[name],
+                candidate[name],
+                f"{path}.{name}",
+                result,
+                rtol,
+                atol,
+                exact,
+            )
+        return
+
+    if reference.dtype != candidate.dtype:
+        result.add_difference(
+            path, f"dtype differs ({reference.dtype} != {candidate.dtype})"
+        )
+        return
+
+    if reference.dtype.kind == "O":
+        for index in np.ndindex(reference.shape):
+            compare_values(
+                reference[index],
+                candidate[index],
+                f"{path}{_format_index(index)}",
+                result,
+                rtol,
+                atol,
+                exact,
+            )
+        return
+
+    if reference.dtype.kind in "fc" and candidate.dtype.kind in "fc":
+        _compare_float_arrays(reference, candidate, path, result, rtol, atol, exact)
+        return
+
+    result.num_values += reference.size
+    matches = reference == candidate
+    if np.all(matches):
+        return
+
+    mismatch_count = int(np.count_nonzero(~matches))
+    mismatch_index = tuple(np.argwhere(~matches)[0])
+    indexed_path = f"{path}{_format_index(mismatch_index)}"
+    result.add_difference(
+        indexed_path,
+        (
+            f"values differ ({reference[mismatch_index]!r} != "
+            f"{candidate[mismatch_index]!r}); "
+            f"{mismatch_count}/{reference.size} values differ"
+        ),
+    )
+
+
+def compare_files(
+    reference_path: str | Path,
+    candidate_path: str | Path,
+    *,
+    rtol: float = 1.0e-4,
+    atol: float = 1.0e-6,
+    exact: bool = False,
+    keys: list[str] | None = None,
+    skip_keys: list[str] | None = None,
+    max_differences: int = 20,
+) -> ComparisonResult:
+    """Compare the event content of two SPINE HDF5 output files.
+
+    Parameters
+    ----------
+    reference_path, candidate_path : str or pathlib.Path
+        Paths to the reference and candidate SPINE HDF5 files.
+    rtol : float, default 1e-4
+        Relative tolerance for floating-point values.
+    atol : float, default 1e-6
+        Absolute tolerance for floating-point values near zero.
+    exact : bool, default False
+        Require exact floating-point equality. The tolerance arguments are
+        ignored when this option is enabled.
+    keys : list[str], optional
+        Restrict comparison to these event data products.
+    skip_keys : list[str], optional
+        Event data products to omit from the comparison.
+    max_differences : int, default 20
+        Maximum number of mismatch descriptions retained in the result.
+
+    Returns
+    -------
+    ComparisonResult
+        Comparison statistics and mismatch descriptions.
+    """
+    if rtol < 0 or atol < 0:
+        raise ValueError("Floating-point tolerances must be nonnegative.")
+    if max_differences < 0:
+        raise ValueError("max_differences must be nonnegative.")
+
+    result = ComparisonResult(max_differences=max_differences)
+    with (
+        h5py.File(reference_path, "r") as reference_file,
+        h5py.File(candidate_path, "r") as candidate_file,
+    ):
+        for label, in_file in (
+            ("reference", reference_file),
+            ("candidate", candidate_file),
+        ):
+            if "events" not in in_file:
+                result.add_difference(label, "file has no 'events' dataset")
+                return result
+            if not isinstance(in_file["events"], h5py.Dataset):
+                result.add_difference(label, "'events' is not a dataset")
+                return result
+
+        reference_events = reference_file["events"]
+        candidate_events = candidate_file["events"]
+        if len(reference_events) != len(candidate_events):
+            result.add_difference(
+                "events",
+                f"count differs ({len(reference_events)} != {len(candidate_events)})",
+            )
+            return result
+
+        reference_keys = set(reference_events.dtype.names or ())
+        candidate_keys = set(candidate_events.dtype.names or ())
+        requested_keys = set(keys) if keys is not None else reference_keys
+        skipped_keys = set(skip_keys or ())
+        selected_keys = requested_keys - skipped_keys
+
+        missing_reference = selected_keys - reference_keys
+        missing_candidate = selected_keys - candidate_keys
+        if missing_reference:
+            result.add_difference(
+                "events",
+                f"reference is missing products {sorted(missing_reference)}",
+            )
+        if missing_candidate:
+            result.add_difference(
+                "events",
+                f"candidate is missing products {sorted(missing_candidate)}",
+            )
+        if keys is None:
+            extra_candidate = (candidate_keys - reference_keys) - skipped_keys
+            if extra_candidate:
+                result.add_difference(
+                    "events",
+                    f"candidate has extra products {sorted(extra_candidate)}",
+                )
+
+        common_keys = sorted(selected_keys & reference_keys & candidate_keys)
+        result.num_events = len(reference_events)
+        result.num_products = len(reference_events) * len(common_keys)
+        for event_idx, (reference_event, candidate_event) in enumerate(
+            zip(reference_events, candidate_events)
+        ):
+            for key in common_keys:
+                path = f"event[{event_idx}].{key}"
+                try:
+                    reference = load_event_value(reference_file, reference_event, key)
+                    candidate = load_event_value(candidate_file, candidate_event, key)
+                    compare_values(
+                        reference,
+                        candidate,
+                        path,
+                        result,
+                        rtol,
+                        atol,
+                        exact,
+                    )
+                except (KeyError, TypeError, ValueError) as error:
+                    result.add_difference(path, str(error))
+
+    return result
+
+
+def format_result(
+    result: ComparisonResult,
+    reference_path: str | Path,
+    candidate_path: str | Path,
+    *,
+    rtol: float,
+    atol: float,
+    exact: bool,
+) -> str:
+    """Format a complete command-line report for a comparison result."""
+    mode = "exact" if exact else f"rtol={rtol:g}, atol={atol:g}"
+    status = "PASS" if result.agrees else "FAIL"
+    lines = [
+        f"{status}: {reference_path} vs {candidate_path}",
+        f"Mode: {mode}",
+        (
+            f"Compared: {result.num_events} events, "
+            f"{result.num_products} event products, "
+            f"{result.num_values} scalar values"
+        ),
+        (
+            f"Maximum floating difference: abs={result.max_abs_diff:.8g}, "
+            f"rel={result.max_rel_diff:.8g}"
+        ),
+    ]
+    if not result.agrees:
+        lines.append(f"Mismatches: {result.num_mismatches}")
+        lines.extend(f"- {difference}" for difference in result.differences)
+        hidden = result.num_mismatches - len(result.differences)
+        if hidden > 0:
+            lines.append(f"- ... {hidden} additional mismatches not shown")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Compare the event content of two SPINE HDF5 output files."
+    )
+    parser.add_argument("reference", help="Reference SPINE HDF5 file.")
+    parser.add_argument("candidate", help="Candidate SPINE HDF5 file.")
+    parser.add_argument(
+        "--rtol",
+        type=float,
+        default=1.0e-4,
+        help="Relative floating-point tolerance (default: %(default)g).",
+    )
+    parser.add_argument(
+        "--atol",
+        type=float,
+        default=1.0e-6,
+        help="Absolute floating-point tolerance (default: %(default)g).",
+    )
+    parser.add_argument(
+        "--exact",
+        action="store_true",
+        help="Require exact floating-point agreement; ignore tolerances.",
+    )
+    parser.add_argument(
+        "--keys",
+        nargs="+",
+        help="Compare only the listed event data products.",
+    )
+    parser.add_argument(
+        "--skip-keys",
+        nargs="+",
+        help="Omit the listed event data products.",
+    )
+    parser.add_argument(
+        "--max-differences",
+        type=int,
+        default=20,
+        help="Maximum mismatch descriptions to print (default: %(default)d).",
+    )
+    return parser
+
+
+def main() -> int:
+    """Run the command-line HDF5 comparison."""
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        result = compare_files(
+            args.reference,
+            args.candidate,
+            rtol=args.rtol,
+            atol=args.atol,
+            exact=args.exact,
+            keys=args.keys,
+            skip_keys=args.skip_keys,
+            max_differences=args.max_differences,
+        )
+    except (OSError, ValueError) as error:
+        parser.error(str(error))
+
+    print(
+        format_result(
+            result,
+            args.reference,
+            args.candidate,
+            rtol=args.rtol,
+            atol=args.atol,
+            exact=args.exact,
+        )
+    )
+    return 0 if result.agrees else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/output/output_compare.py
+++ b/bin/output/output_compare.py
@@ -102,6 +102,22 @@ def _decode_attribute(value: Any) -> Any:
     return value.decode() if isinstance(value, bytes) else value
 
 
+def _require_dataset(parent: h5py.File | h5py.Group, name: str) -> h5py.Dataset:
+    """Return a named child dataset or fail with a schema error."""
+    child = parent[name]
+    if not isinstance(child, h5py.Dataset):
+        raise TypeError(f"Expected '{child.name}' to be an HDF5 dataset.")
+    return child
+
+
+def _require_group(parent: h5py.File | h5py.Group, name: str) -> h5py.Group:
+    """Return a named child group or fail with a schema error."""
+    child = parent[name]
+    if not isinstance(child, h5py.Group):
+        raise TypeError(f"Expected '{child.name}' to be an HDF5 group.")
+    return child
+
+
 def load_objects_v2(group: h5py.Group, event_index: int) -> Any:
     """Load V2 object rows into their logical V1 structured representation."""
     fixed = group["fixed"]
@@ -193,8 +209,8 @@ def load_event_value(
 
         kind = _decode_attribute(group.attrs["kind"])
         if kind in {"array", "string"}:
-            values = group["values"]
-            offsets = group["event_offsets"]
+            values = _require_dataset(group, "values")
+            offsets = _require_dataset(group, "event_offsets")
             start, stop = (
                 int(value) for value in offsets[event_index : event_index + 2]
             )
@@ -209,9 +225,9 @@ def load_event_value(
             return load_objects_v2(group, event_index)
 
         if kind == "list":
-            values = group["values"]
-            element_offsets = group["element_offsets"]
-            event_offsets = group["event_offsets"]
+            values = _require_dataset(group, "values")
+            element_offsets = _require_dataset(group, "element_offsets")
+            event_offsets = _require_dataset(group, "event_offsets")
             first, last = (
                 int(value) for value in event_offsets[event_index : event_index + 2]
             )
@@ -231,9 +247,10 @@ def load_event_value(
             elements = sorted(
                 group.items(), key=lambda item: int(item[0].split("_")[-1])
             )
-            for _, element in elements:
-                values = element["values"]
-                offsets = element["event_offsets"]
+            for name, _ in elements:
+                element = _require_group(group, name)
+                values = _require_dataset(element, "values")
+                offsets = _require_dataset(element, "event_offsets")
                 start, stop = (
                     int(value) for value in offsets[event_index : event_index + 2]
                 )
@@ -257,10 +274,10 @@ def load_event_value(
         return value
 
     if isinstance(dataset, h5py.Group):
-        index = dataset["index"]
+        index = _require_dataset(dataset, "index")
         element_refs = index[region_ref].flatten()
         if index.ndim == 1:
-            elements = dataset["elements"]
+            elements = _require_dataset(dataset, "elements")
             values = np.empty(len(element_refs), dtype=object)
             for idx, reference in enumerate(element_refs):
                 value = elements[reference]
@@ -271,7 +288,7 @@ def load_event_value(
 
         values = []
         for idx, reference in enumerate(element_refs):
-            elements = dataset[f"element_{idx}"]
+            elements = _require_dataset(dataset, f"element_{idx}")
             value = elements[reference]
             if elements.ndim > 1:
                 value = value.reshape(-1, elements.shape[1])
@@ -523,8 +540,8 @@ def compare_files(
                 result.add_difference(label, "'events' is not a dataset")
                 return result
 
-        reference_events = reference_file["events"]
-        candidate_events = candidate_file["events"]
+        reference_events = _require_dataset(reference_file, "events")
+        candidate_events = _require_dataset(candidate_file, "events")
         if len(reference_events) != len(candidate_events):
             result.add_difference(
                 "events",

--- a/bin/output/output_litify.py
+++ b/bin/output/output_litify.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Create a compact output directly from a V2 SPINE HDF5 file."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+from typing import Any
+
+import yaml
+
+from spine.io.transform import DEFAULT_LITE_KEYS, litify_hdf5
+
+
+def load_keys(config_path: str) -> list[str]:
+    """Load product keys from a small or full SPINE YAML configuration."""
+    with open(config_path, encoding="utf-8") as config_file:
+        config: Any = yaml.safe_load(config_file)
+    if not isinstance(config, dict):
+        raise TypeError("Litify configuration must contain a mapping.")
+
+    keys = config.get("keys")
+    if keys is None:
+        writer = config.get("io", {}).get("writer", {})
+        keys = writer.get("keys")
+    if not isinstance(keys, list) or not all(isinstance(key, str) for key in keys):
+        raise ValueError(
+            "Configuration must define a string list under `keys` or "
+            "`io.writer.keys`."
+        )
+    return keys
+
+
+def resolve_keys(
+    cli_keys: Sequence[str] | None,
+    config_path: str | None,
+) -> tuple[str, ...]:
+    """Resolve CLI/config product selection with an explicit precedence."""
+    if cli_keys is not None and config_path is not None:
+        raise ValueError("Use either `--keys` or `--config`, not both.")
+    if cli_keys is not None:
+        return tuple(cli_keys)
+    if config_path is not None:
+        return tuple(load_keys(config_path))
+    return DEFAULT_LITE_KEYS
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Structurally litify a format-V2 SPINE HDF5 output without "
+            "deserializing events or rebuilding classes."
+        )
+    )
+    parser.add_argument("source", help="Input V2 HDF5 file.")
+    parser.add_argument("target", help="Output lite HDF5 file.")
+    selection = parser.add_mutually_exclusive_group()
+    selection.add_argument(
+        "--keys",
+        nargs="+",
+        metavar="PRODUCT",
+        help="Products to retain. Administrative index products are automatic.",
+    )
+    selection.add_argument(
+        "--config",
+        help=(
+            "YAML file containing `keys`, or an existing SPINE configuration "
+            "containing `io.writer.keys`."
+        ),
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("lite", "fixed_only"),
+        default="lite",
+        help="Retain the standard lite fields or fixed fields only.",
+    )
+    parser.add_argument(
+        "--block-size",
+        type=int,
+        default=4096,
+        help="Object rows processed per fixed-table block.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace an existing output atomically.",
+    )
+    return parser
+
+
+def main() -> None:
+    """Parse arguments and run structural litification."""
+    args = build_parser().parse_args()
+    keys = resolve_keys(args.keys, args.config)
+    litify_hdf5(
+        args.source,
+        args.target,
+        keys=keys,
+        mode=args.mode,
+        overwrite=args.overwrite,
+        block_size=args.block_size,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/run.py
+++ b/bin/run.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+"""Run the primary SPINE command-line interface from a source checkout."""
+
+from __future__ import annotations
+
 import os
 import sys
 
@@ -10,5 +14,11 @@ if src_path not in sys.path:
 # Import and run the CLI
 from spine.bin.cli import cli
 
-if __name__ == "__main__":
+
+def main() -> None:
+    """Execute the SPINE command-line interface."""
     cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/api/ana.rst
+++ b/docs/source/api/ana.rst
@@ -13,6 +13,25 @@ Module Index
 
 Use this package when the goal is to turn reconstructed SPINE outputs into metrics, derived tables, plots, or physics-study inputs.
 
+Event and columnar processing
+-----------------------------
+
+Analysis scripts implement ``AnaBase.process`` for the default event-oriented
+path. Scripts which can preserve their semantics on projected product chunks
+may additionally implement ``AnaBase.process_columnar``. The
+``AnaBase.run_columnar`` wrapper applies the same required/optional key
+contract without slicing individual events, while
+``AnaManager(columnar=True)`` checks every configured module during
+initialization.
+
+Columnar support is deliberately opt-in. A manager refuses columnar execution
+if any configured script only implements the event path, preventing partially
+written analysis outputs. Enable the mode on the HDF5 reader with
+``columnar: true``; this is an all-or-nothing execution policy for the analysis
+configuration. Individual scripts declare their required fields through
+``columnar_requests`` and receive projected columns plus event-boundary
+metadata through ``process_columnar``.
+
 .. autosummary::
    :toctree: generated
 

--- a/docs/source/api/io.rst
+++ b/docs/source/api/io.rst
@@ -47,6 +47,36 @@ File Writers
    write.CSVWriter
    write.StageHDF5Writer
 
+HDF5 format versions
+--------------------
+
+Flat SPINE HDF5 files are self-describing. The ``/info`` attributes separate
+the producing software release from the physical file layout:
+
+- ``spine_version`` identifies the SPINE release which produced the file.
+- ``format`` is ``spine_hdf5`` for flat event files.
+- ``format_version`` is ``1`` for the legacy region-reference/VLEN layout or
+  ``2`` for the offset-based layout.
+
+Files written before explicit layout versioning have no ``format_version`` and
+are treated as version 1. :class:`read.HDF5Reader` detects both layouts
+automatically. Select version 2 for new output explicitly during its rollout:
+
+.. code-block:: yaml
+
+   writer:
+     name: hdf5
+     format_version: 2
+
+Version 2 keeps derived scalar and fixed-width properties directly available
+in each product's ``fixed`` compound dataset. Variable-length properties use
+dtype-specific pools under ``variables``. Each pool declares its ordered field
+names in the ``fields`` attribute and has one flat ``values`` dataset. The
+corresponding integer offset row is stored directly in the object's ``fixed``
+record. Product ``event_offsets`` map event ``i`` to rows
+``event_offsets[i]:event_offsets[i + 1]`` without HDF5 region references.
+Appending data with a different format version is rejected.
+
 Datasets
 --------
 

--- a/docs/source/api/io.rst
+++ b/docs/source/api/io.rst
@@ -93,6 +93,28 @@ attributes retain their class defaults, so derived properties which depend on
 them must not be used. Set ``build_classes: false`` to retain the stored
 derived fields directly in the returned object dictionaries.
 
+Analysis-only workflows may instead request projected multi-event chunks:
+
+.. code-block:: yaml
+
+   io:
+     reader:
+       name: hdf5
+       file_keys: output.h5
+       columnar: true
+       chunk_size: 1024
+
+Columnar mode is a reader-wide policy. The analysis manager supplies the union
+of fields requested by its scripts, and the reader returns flattened object
+columns with an ``event_offsets`` boundary vector for each product. Version 2
+uses its native offsets and fixed compound rows; version 1 projects the legacy
+compound dataset through event region references. Legacy files must already
+contain every requested scalar field, such as ``best_match_id``.
+
+The driver currently restricts columnar mode to analysis-only configurations:
+all configured scripts must implement ``process_columnar``, and model,
+construction, post-processing, and ordinary output-writer blocks are rejected.
+
 Datasets
 --------
 

--- a/docs/source/api/io.rst
+++ b/docs/source/api/io.rst
@@ -77,6 +77,22 @@ record. Product ``event_offsets`` map event ``i`` to rows
 ``event_offsets[i]:event_offsets[i + 1]`` without HDF5 region references.
 Appending data with a different format version is rejected.
 
+For high-level workflows which need only scalar and fixed-width object
+attributes, the V2 reader can skip all variable-value pools:
+
+.. code-block:: yaml
+
+   dataset:
+     name: hdf5
+     fixed_only: true
+
+Full loading remains the default. ``fixed_only`` is intentionally restricted
+to format version 2 files and omits variable attributes such as indexes,
+matches, strings, and variable-width vectors. When classes are rebuilt, those
+attributes retain their class defaults, so derived properties which depend on
+them must not be used. Set ``build_classes: false`` to retain the stored
+derived fields directly in the returned object dictionaries.
+
 Datasets
 --------
 

--- a/src/spine/ana/__init__.py
+++ b/src/spine/ana/__init__.py
@@ -5,7 +5,9 @@ post-processing outputs, usually to write CSV summaries for diagnostics,
 calibration studies, and reconstruction-quality metrics.
 
 ``AnaManager`` orchestrates configured analysis modules and handles batched
-input dictionaries in the driver workflow.
+input dictionaries in the driver workflow. Individual analyzers may also
+implement an optional columnar hook for projected-product execution
+without changing their default event-oriented behavior.
 """
 
 from .manager import AnaManager

--- a/src/spine/ana/base.py
+++ b/src/spine/ana/base.py
@@ -378,6 +378,37 @@ class AnaBase(ABC):
             Update to the input dictionary
         """
         # Fetch the necessary information
+        data_filter = self._filter_data(data, entry)
+
+        # Fetch the base dictionary
+        self.base_dict = self.get_base_dict(data_filter)
+
+        # Run the analysis script
+        return self.process(data_filter)
+
+    def _filter_data(
+        self,
+        data: Mapping[str, Any],
+        entry: int | None = None,
+    ) -> dict[str, Any]:
+        """Select declared inputs and optionally isolate one batch entry.
+
+        The same key contract is shared by event and columnar processing.
+        Columnar callers omit ``entry`` so arrays, tables, and event-offset
+        vectors remain intact.
+
+        Parameters
+        ----------
+        data : Mapping[str, Any]
+            Available data products.
+        entry : int, optional
+            Batch entry to isolate for event processing.
+
+        Returns
+        -------
+        dict[str, Any]
+            Requested required and optional products which are available.
+        """
         data_filter = {}
         for key, req in self.keys.items():
             # If this key is needed, check that it exists
@@ -393,11 +424,85 @@ class AnaBase(ABC):
                 if entry is not None:
                     data_filter[key] = data[key][entry]
 
-        # Fetch the base dictionary
-        self.base_dict = self.get_base_dict(data_filter)
+        return data_filter
 
-        # Run the analysis script
-        return self.process(data_filter)
+    @property
+    def supports_columnar(self) -> bool:
+        """Whether this analyzer implements the optional columnar hook."""
+        return type(self).process_columnar is not AnaBase.process_columnar
+
+    def run_columnar(self, data: Mapping[str, Any]) -> Any:
+        """Run this analyzer once on a columnar product chunk.
+
+        Unlike :meth:`__call__`, this method does not construct a scalar
+        ``base_dict`` or iterate over events. A columnar implementation owns
+        its chunk-level output strategy and receives each declared product in
+        its original bulk representation.
+
+        Parameters
+        ----------
+        data : Mapping[str, Any]
+            Columnar products and their event-boundary metadata.
+
+        Returns
+        -------
+        Any
+            Optional products to merge into the shared columnar mapping.
+
+        Raises
+        ------
+        NotImplementedError
+            If the analyzer does not implement :meth:`process_columnar`.
+        """
+        if not self.supports_columnar:
+            raise NotImplementedError(
+                f"Analysis script `{self.name}` does not implement "
+                "`process_columnar`."
+            )
+
+        requests = self.columnar_requests()
+        data_filter = {}
+        administrative = {"index", "file_index", "file_entry_index"}
+        for key, required in self.keys.items():
+            if key in administrative:
+                if required and key not in data:
+                    raise KeyError(
+                        f"Analysis script `{self.name}` is missing an essential "
+                        f"columnar input: `{key}`."
+                    )
+                if key in data:
+                    data_filter[key] = data[key]
+        for key, (_, required) in requests.items():
+            if required and key not in data:
+                raise KeyError(
+                    f"Analysis script `{self.name}` is missing an essential "
+                    f"columnar input: `{key}`."
+                )
+            if key in data:
+                data_filter[key] = data[key]
+
+        return self.process_columnar(data_filter)
+
+    def columnar_requests(
+        self,
+    ) -> dict[str, tuple[tuple[str, ...] | None, bool]]:
+        """Describe products required by this analyzer's columnar hook.
+
+        ``None`` requests every directly projectable field for a product.
+        Subclasses should override this method when they can provide a narrower
+        field projection.
+
+        Returns
+        -------
+        dict
+            Product names mapped to ``(fields, required)`` tuples.
+        """
+        administrative = {"index", "file_index", "file_entry_index"}
+        return {
+            key: (None, required)
+            for key, required in self.keys.items()
+            if key not in administrative
+        }
 
     def get_index(self, obj: Any) -> Any:
         """Get a certain pre-defined index attribute of an object.
@@ -453,3 +558,19 @@ class AnaBase(ABC):
             Filtered data dictionary for one entry
         """
         raise NotImplementedError("Must define the `process` function")
+
+    def process_columnar(self, data: Mapping[str, Any]) -> Any:
+        """Optionally process one bulk columnar data chunk.
+
+        Subclasses opt into columnar execution by overriding this method.
+        Implementations should operate directly on projected columns and
+        event-offset vectors rather than rebuilding per-event data classes.
+        The event-oriented :meth:`process` method remains mandatory and is the
+        default execution path.
+
+        Parameters
+        ----------
+        data : Mapping[str, Any]
+            Filtered columnar products requested by :attr:`keys`.
+        """
+        raise NotImplementedError

--- a/src/spine/ana/manager.py
+++ b/src/spine/ana/manager.py
@@ -29,6 +29,7 @@ class AnaManager(ModuleManager[AnaBase]):
         cfg: Mapping[str, Any],
         log_dir: str | None = None,
         prefix: str | None = None,
+        columnar: bool = False,
     ) -> None:
         """Initialize the analysis manager.
 
@@ -41,7 +42,14 @@ class AnaManager(ModuleManager[AnaBase]):
         prefix : str, optional
             Input file prefix. If requested, it will be used to prefix
             all the output CSV files.
+        columnar : bool, default False
+            If `True`, require every configured analyzer to implement
+            :meth:`AnaBase.process_columnar`.
         """
+        if not isinstance(columnar, bool):
+            raise TypeError("`columnar` must be a boolean.")
+        self.columnar = columnar
+
         # Parse the analysis block configuration
         config = dict(cfg)
 
@@ -65,6 +73,19 @@ class AnaManager(ModuleManager[AnaBase]):
             buffer_size=buffer_size,
             **config,
         )
+
+        if self.columnar:
+            unsupported = [
+                key
+                for key, module in self.modules.items()
+                if not module.supports_columnar
+            ]
+            if unsupported:
+                raise ValueError(
+                    "Columnar analysis requires every analysis script to "
+                    "implement `process_columnar`. Unsupported modules: "
+                    f"{unsupported}."
+                )
 
     def parse_config(
         self,
@@ -136,6 +157,70 @@ class AnaManager(ModuleManager[AnaBase]):
         """
         for module in self.modules.values():
             module.flush_writers()
+
+    @property
+    def supports_columnar(self) -> bool:
+        """Whether every configured analyzer supports columnar execution."""
+        return all(module.supports_columnar for module in self.modules.values())
+
+    def columnar_requests(
+        self,
+    ) -> dict[str, tuple[tuple[str, ...] | None, bool]]:
+        """Merge product projections requested by all configured analyzers."""
+        requests: dict[str, tuple[set[str] | None, bool]] = {}
+        for module in self.modules.values():
+            for key, (fields, required) in module.columnar_requests().items():
+                incoming = None if fields is None else set(fields)
+                if key not in requests:
+                    requests[key] = (incoming, required)
+                    continue
+
+                current, current_required = requests[key]
+                merged = (
+                    None
+                    if current is None or incoming is None
+                    else current.union(incoming)
+                )
+                requests[key] = (merged, current_required or required)
+
+        return {
+            key: (
+                None if fields is None else tuple(sorted(fields)),
+                required,
+            )
+            for key, (fields, required) in requests.items()
+        }
+
+    def process_columnar(self, data: dict[str, Any]) -> None:
+        """Run configured analyzers once on a shared columnar product chunk.
+
+        Capability validation is performed during manager construction.
+        Returned mappings are merged in configuration order, matching the
+        dependency behavior of ordinary event processing.
+
+        Parameters
+        ----------
+        data : dict[str, Any]
+            Columnar products and event-boundary metadata. Updated in place
+            with products returned by analyzers.
+
+        Raises
+        ------
+        RuntimeError
+            If this manager was not configured for columnar execution.
+        """
+        if not self.columnar:
+            raise RuntimeError(
+                "This analysis manager was not configured for columnar execution."
+            )
+
+        self.watch.reset_if_active()
+        for module_key, module in self.modules.items():
+            self.watch.start(module_key)
+            result = module.run_columnar(data)
+            self.watch.stop(module_key)
+            if result is not None:
+                data.update(result)
 
     def __del__(self) -> None:
         """Destructor to ensure analysis writers are closed.

--- a/src/spine/ana/script/save.py
+++ b/src/spine/ana/script/save.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+import numpy as np
+
 from spine.ana.base import AnaBase
 from spine.data.out import (
     RecoFragment,
@@ -141,11 +143,11 @@ class SaveAna(AnaBase):
             for prefix in self.prefixes:
                 for obj_name in self.obj_type:
                     if prefix == "reco" and match_mode != "truth_to_reco":
-                        keys[f"{obj_name}_matches_r2t"] = True
-                        keys[f"{obj_name}_matches_r2t_overlap"] = True
+                        keys[f"{obj_name}_matches_r2t"] = False
+                        keys[f"{obj_name}_matches_r2t_overlap"] = False
                     if prefix == "truth" and match_mode != "reco_to_truth":
-                        keys[f"{obj_name}_matches_t2r"] = True
-                        keys[f"{obj_name}_matches_t2r_overlap"] = True
+                        keys[f"{obj_name}_matches_t2r"] = False
+                        keys[f"{obj_name}_matches_t2r_overlap"] = False
 
         self.update_keys(keys)
 
@@ -155,6 +157,155 @@ class SaveAna(AnaBase):
 
         if len(self.writers) == 0:
             raise ValueError("Must request to save something.")
+
+    def columnar_requests(
+        self,
+    ) -> dict[str, tuple[tuple[str, ...] | None, bool]]:
+        """Request fixed object columns needed by the columnar save path."""
+        requests: dict[str, tuple[tuple[str, ...] | None, bool]] = {
+            "run_info": (("run", "subrun", "event"), False)
+        }
+        other_prefix = {"reco": "truth", "truth": "reco"}
+        for key in self.obj_keys:
+            attrs = self.attrs[key]
+            if attrs is None:
+                raise ValueError(
+                    "Columnar save requires an explicit attribute list for " f"`{key}`."
+                )
+            default_obj = self.default_objs[key]
+            variable = set(attrs).intersection(default_obj._var_length_attrs)
+            if variable:
+                raise ValueError(
+                    "Columnar save currently supports fixed attributes only; "
+                    f"`{key}` requested variable fields {sorted(variable)}."
+                )
+
+            fields = set(attrs)
+            prefix, obj_type = key.split("_")
+            other = other_prefix[prefix]
+            if (
+                self.match_mode is not None
+                and self.match_mode != f"{other}_to_{prefix}"
+            ):
+                fields.update(("best_match_id", "best_match_overlap"))
+            requests[key] = (tuple(sorted(fields)), True)
+
+        return requests
+
+    @staticmethod
+    def _event_rows(offsets: np.ndarray) -> np.ndarray:
+        """Map each flattened object row to its chunk-local event."""
+        return np.repeat(
+            np.arange(len(offsets) - 1, dtype=np.int64),
+            np.diff(offsets),
+        )
+
+    @staticmethod
+    def _expand_columnar_attrs(
+        product: Mapping[str, Any],
+        attrs: Sequence[str],
+        default_obj: Any,
+    ) -> dict[str, np.ndarray]:
+        """Expand scalar and fixed-width columns using scalar_dict names."""
+        result = {}
+        for attr in attrs:
+            values = np.asarray(product[attr])
+            if values.ndim == 1:
+                result[attr] = values
+                continue
+
+            if values.ndim != 2:
+                raise ValueError(
+                    f"Columnar attribute `{attr}` must be scalar or fixed-width, "
+                    f"got shape {values.shape}."
+                )
+            labels = (
+                default_obj._axes
+                if attr in default_obj._pos_attrs + default_obj._vec_attrs
+                else tuple(str(i) for i in range(values.shape[1]))
+            )
+            for i, label in enumerate(labels):
+                result[f"{attr}_{label}"] = values[:, i]
+
+        return result
+
+    @staticmethod
+    def _repeat_event_column(values: Any, counts: np.ndarray) -> np.ndarray:
+        """Broadcast one event-level value onto every object row."""
+        return np.repeat(np.asarray(values), counts, axis=0)
+
+    def _columnar_base(
+        self,
+        data: Mapping[str, Any],
+        counts: np.ndarray,
+    ) -> dict[str, np.ndarray]:
+        """Build event metadata columns repeated for one object collection."""
+        result = {
+            "index": self._repeat_event_column(data["index"], counts),
+            "file_index": self._repeat_event_column(data["file_index"], counts),
+        }
+        if "file_entry_index" in data:
+            result["file_entry_index"] = self._repeat_event_column(
+                data["file_entry_index"], counts
+            )
+        if "run_info" in data:
+            run_info = data["run_info"]
+            # Match RunInfo.scalar_dict ordering rather than the compound
+            # dataset's field ordering, which HDF5 does not preserve.
+            for name in ("run", "subrun", "event"):
+                if name in run_info:
+                    result[name] = self._repeat_event_column(run_info[name], counts)
+        return result
+
+    def process_columnar(self, data: Mapping[str, Any]) -> None:
+        """Write projected object columns and best-match joins in bulk."""
+        other_prefix = {"reco": "truth", "truth": "reco"}
+        for key in self.obj_keys:
+            prefix, obj_type = key.split("_")
+            other = other_prefix[prefix]
+            attrs = self.attrs[key]
+            assert attrs is not None
+            product = data[key]
+            offsets = np.asarray(product["event_offsets"], dtype=np.int64)
+            counts = np.diff(offsets)
+            row_dict = self._columnar_base(data, counts)
+            source_columns = self._expand_columnar_attrs(
+                product, attrs, self.default_objs[key]
+            )
+
+            if self.match_mode is None or self.match_mode == f"{other}_to_{prefix}":
+                row_dict.update(source_columns)
+                self.writers[key].append_columns(row_dict)
+                continue
+
+            target_key = f"{other}_{obj_type}"
+            target = data[target_key]
+            target_offsets = np.asarray(target["event_offsets"], dtype=np.int64)
+            event_rows = self._event_rows(offsets)
+            match_ids = np.asarray(product["best_match_id"], dtype=np.int64)
+            target_counts = np.diff(target_offsets)
+            valid = (match_ids >= 0) & (match_ids < target_counts[event_rows])
+            target_rows = target_offsets[event_rows] + np.maximum(match_ids, 0)
+
+            attrs_other = self.attrs[target_key]
+            assert attrs_other is not None
+            target_columns = self._expand_columnar_attrs(
+                target, attrs_other, self.default_objs[target_key]
+            )
+            target_defaults = self.default_objs[target_key].scalar_dict(
+                attrs_other, self.lengths
+            )
+
+            row_dict.update(
+                {f"{prefix}_{name}": values for name, values in source_columns.items()}
+            )
+            for name, values in target_columns.items():
+                default = target_defaults[name]
+                joined = np.full(len(match_ids), default, dtype=values.dtype)
+                joined[valid] = values[target_rows[valid]]
+                row_dict[f"{other}_{name}"] = joined
+            row_dict["match_overlap"] = np.asarray(product["best_match_overlap"])
+            self.writers[key].append_columns(row_dict)
 
     def process(self, data: Mapping[str, Any]) -> None:
         """Store the information from one entry.
@@ -183,7 +334,21 @@ class SaveAna(AnaBase):
                 match_suffix = f"{prefix[0]}2{other[0]}"
                 match_key = f"{obj_type[:-1]}_matches_{match_suffix}"
                 attrs_other = self.attrs[f"{other}_{obj_type}"]
-                for idx, (obj_i, obj_j) in enumerate(data[match_key]):
+                if match_key in data:
+                    pairs = data[match_key]
+                    overlaps = data[f"{match_key}_overlap"]
+                else:
+                    targets = data[f"{other}_{obj_type}"]
+                    pairs, overlaps = [], []
+                    for source in data[key]:
+                        match_id = source.best_match_id
+                        target = (
+                            targets[match_id] if 0 <= match_id < len(targets) else None
+                        )
+                        pairs.append((source, target))
+                        overlaps.append(source.best_match_overlap)
+
+                for idx, (obj_i, obj_j) in enumerate(pairs):
                     src_dict = obj_i.scalar_dict(attrs, lengths)
                     if obj_j is not None:
                         tgt_dict = obj_j.scalar_dict(attrs_other, lengths)
@@ -193,7 +358,7 @@ class SaveAna(AnaBase):
 
                     src_dict = {f"{prefix}_{k}": v for k, v in src_dict.items()}
                     tgt_dict = {f"{other}_{k}": v for k, v in tgt_dict.items()}
-                    overlap = data[f"{match_key}_overlap"][idx]
+                    overlap = overlaps[idx]
 
                     row_dict = {**src_dict, **tgt_dict}
                     row_dict.update({"match_overlap": overlap})

--- a/src/spine/ana/template.py
+++ b/src/spine/ana/template.py
@@ -24,7 +24,13 @@ __all__ = ["TemplateAna"]
 
 
 class TemplateAna(AnaBase):
-    """Template analysis script showing the expected AnaBase interface."""
+    """Template analysis script showing the expected AnaBase interface.
+
+    An analyzer which can consume projected product chunks may additionally
+    override ``process_columnar(data)``. The columnar method receives the same
+    declared keys without per-entry slicing; analyzers should only implement
+    it when they can preserve the semantics of their event path.
+    """
 
     # Name of the analysis script (as specified in the configuration)
     name = "template"
@@ -90,3 +96,38 @@ class TemplateAna(AnaBase):
 
                 # Write the row to file
                 self.append("template", **out)
+
+    def process_columnar(self, data: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Process a projected product chunk without rebuilding event objects.
+
+        This example assumes ``prod`` is represented as a mapping containing
+        NumPy-like columns and an ``event_offsets`` boundary vector. A real
+        analyzer should request only the columns it needs from the columnar
+        reader, perform bulk operations where possible, and use the offsets
+        when event grouping matters.
+
+        Parameters
+        ----------
+        data : Mapping[str, Any]
+            Filtered bulk products requested by this analyzer.
+
+        Returns
+        -------
+        Mapping[str, Any]
+            Optional bulk columns made available to later analyzers.
+        """
+        product = data["prod"]
+        start_points = product["start_point"]
+        end_points = product["end_point"]
+        event_offsets = product["event_offsets"]
+
+        # Vectorized over every object in the chunk. No particle objects or
+        # per-event loop are constructed merely to subtract these columns.
+        displacements = end_points - start_points
+
+        return {
+            "displacements": {
+                "values": displacements,
+                "event_offsets": event_offsets,
+            }
+        }

--- a/src/spine/data/base.py
+++ b/src/spine/data/base.py
@@ -44,7 +44,7 @@ Note: Direction vectors (unit vectors) typically have no units metadata since
 they are unitless normalized directions.
 """
 
-from dataclasses import dataclass, fields, replace
+from dataclasses import MISSING, dataclass, fields, replace
 from enum import IntEnum
 from types import UnionType
 from typing import (
@@ -613,6 +613,61 @@ class DataBase:
                 if key not in cls._derived_attrs
             }
         )
+
+    @classmethod
+    def from_dict_trusted(cls, cls_dict: dict[str, Any]) -> "DataBase":
+        """Build an object from trusted, schema-controlled serialized data.
+
+        This constructor is reserved for readers whose physical schema was
+        derived from the data class itself. It reproduces dataclass field
+        population and default factories, but bypasses the generated
+        ``__init__``, validated ``__setattr__``, and semantic
+        ``__post_init__`` checks which ordinary user input requires.
+
+        Subclasses may initialize non-field runtime state in
+        :meth:`_post_deserialize`. Stored derived properties are ignored, as
+        they are in :meth:`from_dict`, and remain computed from the loaded
+        object state.
+
+        Parameters
+        ----------
+        cls_dict : dict
+            Trusted serialized attributes to load.
+
+        Returns
+        -------
+        DataBase
+            Reconstructed object.
+        """
+        cls._ensure_cached_attrs()
+        obj = cls.__new__(cls)
+        for cls_field in cls._fields:
+            name = cls_field.name
+            value: Any
+            if name in cls_dict:
+                value = cls_dict[name]
+                if name in cls._str_attrs and isinstance(value, bytes):
+                    value = value.decode()
+                if name in cls._bool_attrs:
+                    if isinstance(value, np.ndarray) and value.dtype == np.uint8:
+                        value = bool(value.item())
+                    elif isinstance(value, np.generic) and value.dtype == np.uint8:
+                        value = bool(value.item())
+
+            elif cls_field.default is not MISSING:
+                value = cls_field.default
+
+            else:
+                assert cls_field.default_factory is not MISSING
+                value = cls_field.default_factory()
+
+            object.__setattr__(obj, name, value)
+
+        obj._post_deserialize()
+        return obj
+
+    def _post_deserialize(self) -> None:
+        """Initialize runtime-only state after trusted deserialization."""
 
     @classmethod
     def _ensure_cached_attrs(cls) -> None:

--- a/src/spine/data/larcv/meta.py
+++ b/src/spine/data/larcv/meta.py
@@ -82,6 +82,10 @@ class ImageMetaBase(DataBase):
                 "Upper must be equal to lower + size * count (within numerical precision)"
             )
 
+    def _post_deserialize(self) -> None:
+        """Restore runtime state omitted from trusted serialized fields."""
+        object.__setattr__(self, "_index_multipliers", None)
+
     @property
     def index_multipliers(self) -> np.ndarray:
         """Get the index multipliers for converting between pixel coordinates

--- a/src/spine/data/out/base.py
+++ b/src/spine/data/out/base.py
@@ -44,6 +44,10 @@ class OutBase(PosDataBase):
         List of true object IDs this object is matched to
     match_overlaps : np.ndarray
         List of match overlaps (IoU) between the object and its matches
+    best_match_id : int
+        ID of the highest-overlap matched object, or -1 when unmatched
+    best_match_overlap : float
+        Overlap with the highest-overlap matched object, or -1 when unmatched
     is_cathode_crosser : bool
         True if the particle crossed a cathode, i.e. if it is made up
         of space points coming from > 1 TPC in one module
@@ -144,6 +148,18 @@ class OutBase(PosDataBase):
             Sum of all depositions that make up the object
         """
         return np.sum(self.depositions).item()
+
+    @property
+    @stored_property
+    def best_match_id(self) -> int:
+        """ID of the best matched object, or -1 when no match exists."""
+        return int(self.match_ids[0]) if len(self.match_ids) else -1
+
+    @property
+    @stored_property
+    def best_match_overlap(self) -> float:
+        """Overlap with the best matched object, or -1 when unmatched."""
+        return float(self.match_overlaps[0]) if len(self.match_overlaps) else -1.0
 
     @property
     @stored_property(dtype=np.int32)

--- a/src/spine/driver.py
+++ b/src/spine/driver.py
@@ -575,17 +575,51 @@ class Driver:
         post-processors. When used after a model, the model output must be
         unwrapped first.
         """
+        # If analysis scripts are not requested, skip initialization. Columnar
+        # reader mode, however, requires at least one analysis script.
         self.ana = None
         if ana is None:
+            if getattr(self.io, "columnar", False):
+                raise ValueError(
+                    "Columnar reader mode requires at least one analysis script."
+                )
             return
 
+        # Check for incompatible modules when columnar reader mode is requested
+        if getattr(self.io, "columnar", False):
+            incompatible = []
+            if self.model is not None:
+                incompatible.append("model")
+            if self.builder is not None:
+                incompatible.append("build")
+            if self.post is not None:
+                incompatible.append("post")
+            if self.io.has_writer:
+                incompatible.append("writer")
+            if incompatible:
+                raise ValueError(
+                    "Columnar reader mode currently supports analysis-only "
+                    f"workflows; remove: {', '.join(incompatible)}."
+                )
+
+        # Check the information is unwrapped before running analysis scripts
         if self.model is not None and not self.unwrap:
             raise ValueError("Must unwrap the model output to run analysis scripts.")
 
+        # Initialize the analysis manager
         self.watch.initialize("ana")
+        columnar = getattr(self.io, "columnar", False)
         self.ana = AnaManager(
-            dict(ana), log_dir=self.log_dir, prefix=self.io.log_prefix
+            dict(ana),
+            log_dir=self.log_dir,
+            prefix=self.io.log_prefix,
+            columnar=columnar,
         )
+
+        # If columnar reader mode is requested, configure the I/O manager to request
+        # the necessary columns needed by the analysis scripts.
+        if columnar:
+            self.io.configure_columnar(self.ana.columnar_requests())
 
     def initialize_log(self) -> None:
         """Initialize CSV and optional TensorBoard logging backends."""
@@ -785,7 +819,10 @@ class Driver:
         # 6. Run scripts, if requested
         if self.ana is not None:
             self.watch.start("ana")
-            self.ana(data)
+            if getattr(self.io, "columnar", False):
+                self.ana.process_columnar(data)
+            else:
+                self.ana(data)
             self.watch.stop("ana")
             self.watch.update(self.ana.watch, "ana")
 

--- a/src/spine/io/dataset/hdf5.py
+++ b/src/spine/io/dataset/hdf5.py
@@ -140,7 +140,10 @@ class HDF5Dataset(BaseDataset):
                 **kwargs,
             )
         else:
-            self.reader = HDF5Reader(**kwargs)
+            self.reader = HDF5Reader(
+                keys=tuple(self.keys) if self.keys is not None else None,
+                **kwargs,
+            )
 
         # Initialize the augmenter
         self.build_augmenter(augment)

--- a/src/spine/io/dataset/hdf5.py
+++ b/src/spine/io/dataset/hdf5.py
@@ -140,6 +140,10 @@ class HDF5Dataset(BaseDataset):
                 **kwargs,
             )
         else:
+            # Push the dataset's product selection into the reader. This is a
+            # physical I/O projection, not merely a post-read dictionary
+            # filter: neither V1 references nor V2 product groups outside the
+            # requested schema are dereferenced/read.
             self.reader = HDF5Reader(
                 keys=tuple(self.keys) if self.keys is not None else None,
                 **kwargs,

--- a/src/spine/io/manager.py
+++ b/src/spine/io/manager.py
@@ -138,6 +138,7 @@ class IOManager:
         self.unwrapper = None
         self.reader = None
         self.writer = None
+        self.columnar = False
         self.iterations = iterations
         self.epochs = epochs
         self.distributed = distributed
@@ -247,7 +248,10 @@ class IOManager:
 
         self.watch.initialize("read")
         self.reader = reader_factory(reader)
-        self.iter_per_epoch = len(self.reader)
+        self.columnar = bool(getattr(self.reader, "columnar", False))
+        self.iter_per_epoch = (
+            self.reader.num_chunks if self.columnar else len(self.reader)
+        )
 
         # Post-processors already run on the input file, if available from the reader
         # metadata, are recorded here for use by the driver when determining which
@@ -320,7 +324,7 @@ class IOManager:
         """
         if self.reader is None:
             raise RuntimeError("Cannot determine length without an initialized reader.")
-        return len(self.reader)
+        return self.iter_per_epoch if self.columnar else len(self.reader)
 
     @property
     def has_loader(self) -> bool:
@@ -331,6 +335,15 @@ class IOManager:
     def has_writer(self) -> bool:
         """Whether this manager owns an output writer."""
         return self.writer is not None
+
+    def configure_columnar(
+        self,
+        requests: dict[str, tuple[tuple[str, ...] | None, bool]],
+    ) -> None:
+        """Pass an analyzer-derived projection to a columnar reader."""
+        if not self.columnar or self.reader is None:
+            raise RuntimeError("I/O is not configured for columnar reading.")
+        self.reader.configure_columnar(requests)
 
     def _name_max(self, path: str = ".") -> int:
         """Return the maximum filename component length for a path."""
@@ -473,7 +486,18 @@ class IOManager:
             raise RuntimeError("Cannot load data without an initialized reader.")
 
         self.watch.start("read")
-        if entry is not None:
+        if self.columnar:
+            if (
+                entry is None
+                or run is not None
+                or subrun is not None
+                or event is not None
+            ):
+                raise ValueError(
+                    "Columnar readers accept only a sequential chunk index."
+                )
+            data = self.reader.get_columnar(entry)
+        elif entry is not None:
             data = self.reader.get(entry)
         else:
             data = self.reader.get_run_event(run, subrun, event)

--- a/src/spine/io/read/hdf5.py
+++ b/src/spine/io/read/hdf5.py
@@ -1,7 +1,7 @@
 """Contains a reader class dedicated to loading data from HDF5 files."""
 
 import os
-from dataclasses import fields
+from dataclasses import dataclass, fields
 from typing import Any
 from warnings import warn
 
@@ -19,15 +19,28 @@ __all__ = ["HDF5Reader"]
 
 
 class HDF5Reader(ReaderBase):
-    """Class which reads information stored in HDF5 files.
+    """Read event data from versioned SPINE HDF5 files.
 
     This class inherits from the :class:`ReaderBase` class. It provides
-    methods to load HDF5 files and extract their data products. The files
-    must be structured as follows:
+    methods to load HDF5 files and extract their data products. Two physical
+    layouts are supported:
 
-      - An `events` dataset with all the region references
-      - One dataset per data product corresponding to each region reference in
-        the `events` dataset
+    - Version 1 is the legacy layout. Each row of ``events`` is a compound
+      record of HDF5 region references into top-level product datasets.
+      Variable object attributes use HDF5 VLEN fields.
+    - Version 2 stores each product in a top-level group and uses monotonic
+      integer offset arrays to delimit events, objects, and variable fields.
+      Its ``events`` dataset is deliberately retained as the authoritative
+      event axis, but contains no product references.
+
+    The reader detects the layout independently for every input file. This
+    allows one logical dataset to span legacy and V2 files without exposing
+    layout differences to callers. Files which predate explicit
+    ``info.attrs["format_version"]`` metadata are interpreted as V1.
+
+    Product projection is performed before any product dataset is accessed.
+    This is particularly useful for V2 because product names live at the file
+    root rather than in the ``events`` compound dtype.
     """
 
     name: str = "hdf5"
@@ -105,7 +118,9 @@ class HDF5Reader(ReaderBase):
             rejected.
         keys : sequence[str], optional
             Data products to load. If omitted, load every product. This is a
-            true reader-level projection and avoids reading unrequested data.
+            true reader-level projection and avoids reading unrequested data
+            in either layout. Source-provenance products remain eligible so
+            reader-owned runtime indexes can be reconstructed.
         """
         # Process the list of files
         self.process_file_paths(file_keys, file_list, limit_num_files, max_print_files)
@@ -114,6 +129,26 @@ class HDF5Reader(ReaderBase):
         self.ignore_incomplete = ignore_incomplete
         self._handle_pid: int | None = None
         self._file_handles: dict[int, h5py.File] = {}
+
+        # V2 object schemas are immutable for the lifetime of a file. Cache
+        # their decoded attribute metadata so event reads do not repeatedly
+        # invoke YAML or rediscover logical fields from compound dtypes.
+        # Only plain Python values are cached; h5py objects remain tied to the
+        # process-local file-handle lifecycle above.
+        self._v2_object_schemas: dict[
+            tuple[str, str],
+            tuple[
+                str,
+                bool,
+                tuple[str, ...],
+                tuple[tuple[str, int, bool, tuple[str, ...]], ...],
+            ],
+        ] = {}
+        self._v2_object_handles: dict[
+            tuple[str, str],
+            tuple[h5py.Dataset, h5py.Dataset, tuple[h5py.Dataset, ...]],
+        ] = {}
+        self._v2_product_handles: dict[tuple[str, str], _V2ProductHandles] = {}
         self.requested_keys = set(keys) if keys is not None else None
         self.file_format_versions: list[int] = []
 
@@ -144,6 +179,8 @@ class HDF5Reader(ReaderBase):
                 assert isinstance(
                     events, h5py.Dataset
                 ), "'events' is not a dataset in the HDF5 file."
+                # Explicit layout metadata was introduced with V2. Its absence
+                # is therefore an unambiguous legacy-file marker, not an error.
                 format_version = 1
                 if "info" in in_file:
                     format_version = int(in_file["info"].attrs.get("format_version", 1))
@@ -161,6 +198,7 @@ class HDF5Reader(ReaderBase):
 
                     info = in_file[run_info_key]
                     if format_version == 1:
+                        # V1 object fields are columns of one compound dataset.
                         assert isinstance(
                             info, h5py.Dataset
                         ), f"{run_info_key} is not a dataset in the HDF5 file."
@@ -168,7 +206,10 @@ class HDF5Reader(ReaderBase):
                             k in info.dtype.names for k in ["run", "subrun", "event"]
                         ), f"{run_info_key} dataset missing required fields."
                         columns = (info["run"], info["subrun"], info["event"])
+
                     else:
+                        # In V2, derived and fixed-width fields remain directly
+                        # queryable in the product's compound `fixed` dataset.
                         assert isinstance(info, h5py.Group)
                         fixed = info["fixed"]
                         assert isinstance(fixed, h5py.Dataset)
@@ -230,6 +271,8 @@ class HDF5Reader(ReaderBase):
                 pass
 
         self._file_handles = {}
+        self._v2_object_handles = {}
+        self._v2_product_handles = {}
         self._handle_pid = None
 
     def __del__(self) -> None:
@@ -308,7 +351,12 @@ class HDF5Reader(ReaderBase):
         return cfg
 
     def process_version(self) -> str:
-        """Returns the SPINE release version used to produce the HDF5 file.
+        """Return the SPINE software release which produced the first file.
+
+        ``spine_version`` identifies software and must not be confused with
+        ``format_version``, which selects the physical HDF5 layout. The
+        historical ``version`` attribute remains as a fallback for files
+        written before these concepts were named separately.
 
         Returns
         -------
@@ -358,6 +406,9 @@ class HDF5Reader(ReaderBase):
                 events, h5py.Dataset
             ), "'events' is not a dataset in the HDF5 file."
 
+            # Dispatch on the physical layout of the file containing this
+            # entry. `file_format_versions` is parallel to `file_paths`, so a
+            # single reader can transparently span V1 and V2 files.
             if self.file_format_versions[file_idx] == 1:
                 event = events[entry_idx]
                 names = getattr(getattr(event, "dtype", None), "names", None)
@@ -368,6 +419,8 @@ class HDF5Reader(ReaderBase):
                 else:
                     raise ValueError("Event entry does not have named fields.")
             else:
+                # V2 product membership is represented by top-level groups,
+                # not fields in the events dtype.
                 for key in in_file.keys():
                     if key not in {"events", "info"} and self.should_load_key(key):
                         self.load_key_v2(in_file, entry_idx, data, key)
@@ -381,7 +434,23 @@ class HDF5Reader(ReaderBase):
         return data
 
     def should_load_key(self, key: str) -> bool:
-        """Return whether a product belongs to the requested projection."""
+        """Return whether a product belongs to the reader projection.
+
+        Source-provenance keys are always admitted when present. They are
+        administrative inputs used by :meth:`get_source_provenance`, rather
+        than ordinary user-requested products, and are required to preserve
+        source entry identity across an HDF5 round trip.
+
+        Parameters
+        ----------
+        key : str
+            Stored data-product name.
+
+        Returns
+        -------
+        bool
+            ``True`` when the product should be read from disk.
+        """
         return (
             self.requested_keys is None
             or key in self.requested_keys
@@ -399,42 +468,130 @@ class HDF5Reader(ReaderBase):
         data: dict[str, Any],
         key: str,
     ) -> None:
-        """Load one product from an offset-based V2 group."""
-        group = in_file[key]
-        if not isinstance(group, h5py.Group) or "kind" not in group.attrs:
-            raise ValueError(f"V2 product '{key}' is not a recognized product group.")
-        kind = group.attrs["kind"]
-        if isinstance(kind, bytes):
-            kind = kind.decode()
+        """Load one event product from an offset-based V2 group.
+
+        Every V2 product advertises a ``kind`` attribute which determines its
+        physical schema:
+
+        - ``array`` and ``string`` use ``values`` plus ``event_offsets``.
+        - ``objects`` use compound ``fixed`` rows, per-event object offsets,
+          and flat variable-field pools.
+        - ``list`` represents a variable number of same-width arrays. Its
+          ``event_offsets`` delimit elements and ``element_offsets`` delimit
+          values.
+        - ``multi_list`` represents a fixed number of differently shaped
+          arrays using one child group per list position.
+
+        Offset arrays follow the boundary convention that item ``i`` occupies
+        ``offsets[i]:offsets[i + 1]``. An offset dataset for ``N`` items
+        therefore contains ``N + 1`` entries. Empty items are represented by
+        equal adjacent offsets and require no special sentinel.
+
+        Parameters
+        ----------
+        in_file : h5py.File
+            Open file containing the product.
+        entry_idx : int
+            File-local event index.
+        data : dict
+            Event dictionary to update with the decoded value.
+        key : str
+            Top-level V2 product-group name.
+        """
+        cache_key = (os.fspath(in_file.filename), key)
+        product = self._v2_product_handles.get(cache_key) if self.keep_open else None
+        if product is None:
+            group = in_file[key]
+            if not isinstance(group, h5py.Group) or "kind" not in group.attrs:
+                raise ValueError(
+                    f"V2 product '{key}' is not a recognized product group."
+                )
+            kind = _decode_string_attribute(group.attrs["kind"], "kind")
+
+            # Resolve the physical datasets once for persistent readers. Name
+            # lookup and attribute decoding are surprisingly visible when
+            # repeated for every product of every event.
+            if kind in {"array", "string"}:
+                product = _V2ProductHandles(
+                    kind=kind,
+                    values=_require_dataset(group, "values"),
+                    event_offsets=_require_dataset(group, "event_offsets"),
+                    scalar=bool(group.attrs["scalar"]),
+                )
+            elif kind == "objects":
+                product = _V2ProductHandles(kind=kind, object_group=group)
+            elif kind == "list":
+                product = _V2ProductHandles(
+                    kind=kind,
+                    values=_require_dataset(group, "values"),
+                    element_offsets=_require_dataset(group, "element_offsets"),
+                    event_offsets=_require_dataset(group, "event_offsets"),
+                )
+            elif kind == "multi_list":
+                elements = []
+                for name in sorted(
+                    group.keys(), key=lambda item: int(item.split("_")[-1])
+                ):
+                    element = _require_group(group, name)
+                    elements.append(
+                        (
+                            _require_dataset(element, "values"),
+                            _require_dataset(element, "event_offsets"),
+                        )
+                    )
+                product = _V2ProductHandles(kind=kind, elements=tuple(elements))
+            else:
+                raise ValueError(
+                    f"Unrecognized V2 product kind '{kind}' for key '{key}'."
+                )
+
+            if self.keep_open:
+                self._v2_product_handles[cache_key] = product
+
+        kind = product.kind
 
         if kind == "array":
-            values = group["values"]
-            offsets = group["event_offsets"]
+            values = product.values
+            offsets = product.event_offsets
+            assert values is not None and offsets is not None
             start, stop = (int(v) for v in offsets[entry_idx : entry_idx + 2])
             result = values[start:stop]
-            if group.attrs["scalar"]:
+            if product.scalar:
                 result = result[0]
             data[key] = result
             return
 
         if kind == "string":
-            values = group["values"]
-            offsets = group["event_offsets"]
+            # Strings are explicit UTF-8 byte spans rather than HDF5 VLEN
+            # strings, so their physical representation is predictable.
+            values = product.values
+            offsets = product.event_offsets
+            assert values is not None and offsets is not None
             start, stop = (int(v) for v in offsets[entry_idx : entry_idx + 2])
             data[key] = values[start:stop].tobytes().decode("utf-8")
             return
 
         if kind == "objects":
-            self.load_objects_v2(group, entry_idx, data, key)
+            assert product.object_group is not None
+            self.load_objects_v2(product.object_group, entry_idx, data, key)
             return
 
         if kind == "list":
-            values = group["values"]
-            element_offsets = group["element_offsets"]
-            event_offsets = group["event_offsets"]
+            # First map the event to a range of logical elements, then map
+            # every element to its slice in the shared values dataset.
+            values = product.values
+            element_offsets = product.element_offsets
+            event_offsets = product.event_offsets
+            assert (
+                values is not None
+                and element_offsets is not None
+                and event_offsets is not None
+            )
             first, last = (int(v) for v in event_offsets[entry_idx : entry_idx + 2])
             bounds = element_offsets[first : last + 1]
             result = np.empty(last - first, dtype=object)
+            # Read the event's complete span once. The individual arrays below
+            # are inexpensive slices of this in-memory block.
             base = int(bounds[0]) if len(bounds) else 0
             terminal = int(bounds[-1]) if len(bounds) else base
             event_values = values[base:terminal]
@@ -447,16 +604,11 @@ class HDF5Reader(ReaderBase):
 
         if kind == "multi_list":
             result = []
-            for name in sorted(group.keys(), key=lambda item: int(item.split("_")[-1])):
-                element = group[name]
-                values = element["values"]
-                offsets = element["event_offsets"]
+            for values, offsets in product.elements:
                 start, stop = (int(v) for v in offsets[entry_idx : entry_idx + 2])
                 result.append(values[start:stop])
             data[key] = result
             return
-
-        raise ValueError(f"Unrecognized V2 product kind '{kind}' for key '{key}'.")
 
     def load_objects_v2(
         self,
@@ -465,27 +617,118 @@ class HDF5Reader(ReaderBase):
         data: dict[str, Any],
         key: str,
     ) -> None:
-        """Load an object collection from fixed rows and flat variable fields."""
-        fixed = group["fixed"]
-        event_offsets = group["event_offsets"]
-        variables = group["variables"]
-        assert isinstance(fixed, h5py.Dataset)
-        assert isinstance(event_offsets, h5py.Dataset)
-        assert isinstance(variables, h5py.Group)
+        """Load one V2 object collection and optionally rebuild its classes.
+
+        A V2 object product separates attributes by storage behavior:
+
+        - ``fixed`` contains one compound row per object. Scalar, enum,
+          fixed-width, and derived properties live here and can be consumed by
+          external HDF5 tools without importing SPINE.
+        - ``variables/pool_N/values`` concatenates variable-length fields which
+          share a physical dtype. Strings use UTF-8 byte pools.
+        - ``_var_offsets_N`` in each fixed row contains ``F + 1`` absolute
+          boundaries for the ``F`` fields listed in the pool's ``fields``
+          attribute.
+
+        Only the object and variable-value spans touched by this event are
+        read. Logical dictionaries are then passed to ``DataBase.from_dict``;
+        when ``build_classes=False`` those dictionaries are returned directly.
+
+        Parameters
+        ----------
+        group : h5py.Group
+            V2 object product group.
+        entry_idx : int
+            File-local event index.
+        data : dict
+            Event dictionary to update.
+        key : str
+            Name under which to store the reconstructed collection.
+        """
+        # Dataset dtypes and group attributes do not vary by event. In
+        # particular, parsing each pool's YAML-encoded field list here used to
+        # be a significant fraction of V2 read time. Cache only decoded Python
+        # metadata, rather than h5py handles, so keep_open=False and fork-safe
+        # handle reopening continue to work normally.
+        file_name = os.fspath(group.file.filename)
+        group_name = group.name
+        if group_name is None:
+            raise ValueError("V2 object group must have a file path.")
+        schema_key = (file_name, group_name)
+        schema = self._v2_object_schemas.get(schema_key)
+        if schema is None:
+            fixed = _require_dataset(group, "fixed")
+            variables = _require_group(group, "variables")
+            class_name = _decode_string_attribute(
+                group.attrs["class_name"], "class_name"
+            )
+            scalar = bool(group.attrs["scalar"])
+            fixed_names = tuple(
+                name
+                for name in fixed.dtype.names or ()
+                if not name.startswith("_var_offsets_")
+            )
+            decoded_pool_specs: list[tuple[str, int, bool, tuple[str, ...]]] = []
+            for pool_name, pool in sorted(
+                variables.items(),
+                key=lambda item: int(item[0].split("_")[-1]),
+            ):
+                if not isinstance(pool, h5py.Group):
+                    raise TypeError(f"V2 variable pool '{pool_name}' must be a group.")
+                pool_index = int(pool_name.split("_")[-1])
+                kind = _decode_string_attribute(pool.attrs["kind"], "kind")
+                fields_value = yaml.safe_load(
+                    _decode_string_attribute(pool.attrs["fields"], "fields")
+                )
+                if not isinstance(fields_value, list) or not all(
+                    isinstance(name, str) for name in fields_value
+                ):
+                    raise TypeError(
+                        f"V2 variable pool '{pool_name}' fields must be "
+                        "a list of strings."
+                    )
+                fields = tuple(fields_value)
+                decoded_pool_specs.append(
+                    (pool_name, pool_index, kind == "string", fields)
+                )
+            schema = (
+                class_name,
+                scalar,
+                fixed_names,
+                tuple(decoded_pool_specs),
+            )
+            self._v2_object_schemas[schema_key] = schema
+
+        class_name, scalar, fixed_names, pool_specs = schema
+
+        # Persistent readers can also retain direct dataset handles. This
+        # removes several group-name lookups per variable pool and event. The
+        # cache is cleared whenever the owning file handles are closed or a
+        # reader crosses a process boundary.
+        handles = self._v2_object_handles.get(schema_key) if self.keep_open else None
+        if handles is None:
+            fixed = _require_dataset(group, "fixed")
+            event_offsets = _require_dataset(group, "event_offsets")
+            pool_values = []
+            for pool_name, _, _, _ in pool_specs:
+                values = _require_dataset(group, f"variables/{pool_name}/values")
+                pool_values.append(values)
+            handles = (fixed, event_offsets, tuple(pool_values))
+            if self.keep_open:
+                self._v2_object_handles[schema_key] = handles
+
+        fixed, event_offsets, pool_values = handles
+
+        # Select only the compound object rows owned by this event.
         first, last = (int(v) for v in event_offsets[entry_idx : entry_idx + 2])
         rows = fixed[first:last]
-        class_name = group.attrs["class_name"]
-        if isinstance(class_name, bytes):
-            class_name = class_name.decode()
         obj_class = self.resolve_object_class(class_name, rows)
 
         variable_values: dict[str, list[Any]] = {}
-        for pool_name, pool in variables.items():
-            values = pool["values"]
-            pool_index = int(pool_name.split("_")[-1])
+        for values, (_, pool_index, is_string, fields) in zip(pool_values, pool_specs):
             bounds = rows[f"_var_offsets_{pool_index}"]
-            is_string = pool.attrs["kind"] == "string"
-            fields = yaml.safe_load(pool.attrs["fields"])
+            # Pool offsets are absolute across the file. Read the enclosing
+            # event span once and subtract `base` for local NumPy slicing.
             base = int(bounds[0, 0]) if len(bounds) else 0
             terminal = int(bounds[-1, -1]) if len(bounds) else base
             event_values = values[base:terminal]
@@ -500,14 +743,11 @@ class HDF5Reader(ReaderBase):
                     loaded.append(value)
                 variable_values[name] = loaded
 
-        names = rows.dtype.names or ()
+        # Offset helper columns are physical metadata and are intentionally
+        # excluded from the logical object dictionaries.
         result = []
         for i, row in enumerate(rows):
-            obj_dict = {
-                name: row[name]
-                for name in names
-                if not name.startswith("_var_offsets_")
-            }
+            obj_dict = {name: row[name] for name in fixed_names}
             obj_dict.update(
                 {name: values[i] for name, values in variable_values.items()}
             )
@@ -515,7 +755,7 @@ class HDF5Reader(ReaderBase):
                 result.append(obj_class.from_dict(obj_dict))
             else:
                 result.append(obj_dict)
-        if group.attrs["scalar"]:
+        if scalar:
             result = result[0]
         data[key] = result
 
@@ -665,6 +905,44 @@ class HDF5Reader(ReaderBase):
 
         else:
             raise ValueError(f"Dataset for key '{key}' is neither a group nor dataset.")
+
+
+@dataclass(frozen=True)
+class _V2ProductHandles:
+    """Resolved HDF5 objects needed to load one V2 product."""
+
+    kind: str
+    values: h5py.Dataset | None = None
+    event_offsets: h5py.Dataset | None = None
+    scalar: bool = False
+    object_group: h5py.Group | None = None
+    element_offsets: h5py.Dataset | None = None
+    elements: tuple[tuple[h5py.Dataset, h5py.Dataset], ...] = ()
+
+
+def _require_dataset(parent: h5py.File | h5py.Group, name: str) -> h5py.Dataset:
+    """Return a named child dataset or fail with a schema error."""
+    child = parent[name]
+    if not isinstance(child, h5py.Dataset):
+        raise TypeError(f"Expected '{child.name}' to be an HDF5 dataset.")
+    return child
+
+
+def _require_group(parent: h5py.File | h5py.Group, name: str) -> h5py.Group:
+    """Return a named child group or fail with a schema error."""
+    child = parent[name]
+    if not isinstance(child, h5py.Group):
+        raise TypeError(f"Expected '{child.name}' to be an HDF5 group.")
+    return child
+
+
+def _decode_string_attribute(value: Any, name: str) -> str:
+    """Normalize one required byte/string-valued HDF5 attribute."""
+    if isinstance(value, bytes):
+        value = value.decode()
+    if not isinstance(value, str):
+        raise TypeError(f"HDF5 attribute '{name}' must be a string.")
+    return value
 
 
 def _get_reader_pid() -> int:

--- a/src/spine/io/read/hdf5.py
+++ b/src/spine/io/read/hdf5.py
@@ -52,6 +52,7 @@ class HDF5Reader(ReaderBase):
         keep_open: bool = True,
         swmr: bool = False,
         ignore_incomplete: bool = False,
+        keys: list[str] | tuple[str, ...] | None = None,
     ) -> None:
         """Initalize the HDF5 file reader.
 
@@ -102,6 +103,9 @@ class HDF5Reader(ReaderBase):
             If `True`, allow opening files marked as incomplete. By default,
             files with an explicit `info.attrs["complete"] = False` marker are
             rejected.
+        keys : sequence[str], optional
+            Data products to load. If omitted, load every product. This is a
+            true reader-level projection and avoids reading unrequested data.
         """
         # Process the list of files
         self.process_file_paths(file_keys, file_list, limit_num_files, max_print_files)
@@ -110,6 +114,8 @@ class HDF5Reader(ReaderBase):
         self.ignore_incomplete = ignore_incomplete
         self._handle_pid: int | None = None
         self._file_handles: dict[int, h5py.File] = {}
+        self.requested_keys = set(keys) if keys is not None else None
+        self.file_format_versions: list[int] = []
 
         # If an entry list is requested based on run/subrun/event ID, create map
         if run_event_list is not None or skip_run_event_list is not None:
@@ -138,6 +144,14 @@ class HDF5Reader(ReaderBase):
                 assert isinstance(
                     events, h5py.Dataset
                 ), "'events' is not a dataset in the HDF5 file."
+                format_version = 1
+                if "info" in in_file:
+                    format_version = int(in_file["info"].attrs.get("format_version", 1))
+                if format_version not in (1, 2):
+                    raise ValueError(
+                        f"Unsupported HDF5 format version {format_version} in '{path}'."
+                    )
+                self.file_format_versions.append(format_version)
 
                 # If requested, register the (run, subrun, event) information
                 if create_run_map:
@@ -146,14 +160,24 @@ class HDF5Reader(ReaderBase):
                     ), f"Must provide {run_info_key} to create run map"
 
                     info = in_file[run_info_key]
-                    assert isinstance(
-                        info, h5py.Dataset
-                    ), f"{run_info_key} is not a dataset in the HDF5 file."
-                    assert all(
-                        k in info.dtype.names for k in ["run", "subrun", "event"]
-                    ), f"{run_info_key} dataset missing required fields."
+                    if format_version == 1:
+                        assert isinstance(
+                            info, h5py.Dataset
+                        ), f"{run_info_key} is not a dataset in the HDF5 file."
+                        assert all(
+                            k in info.dtype.names for k in ["run", "subrun", "event"]
+                        ), f"{run_info_key} dataset missing required fields."
+                        columns = (info["run"], info["subrun"], info["event"])
+                    else:
+                        assert isinstance(info, h5py.Group)
+                        fixed = info["fixed"]
+                        assert isinstance(fixed, h5py.Dataset)
+                        assert all(
+                            k in fixed.dtype.names for k in ["run", "subrun", "event"]
+                        ), f"{run_info_key} dataset missing required fields."
+                        columns = (fixed["run"], fixed["subrun"], fixed["event"])
 
-                    for r, s, e in zip(info["run"], info["subrun"], info["event"]):
+                    for r, s, e in zip(*columns):
                         run_info.append((r, s, e))
 
                 # Update the total number of entries
@@ -294,10 +318,11 @@ class HDF5Reader(ReaderBase):
         # Fetch the string-form configuration
         with h5py.File(self.file_paths[0], "r") as in_file:
             assert "info" in in_file, "HDF5 file missing 'info' group."
+            attrs = in_file["info"].attrs
             assert (
-                "version" in in_file["info"].attrs
-            ), "HDF5 file 'info' group missing 'version' attribute."
-            version = in_file["info"].attrs["version"]
+                "spine_version" in attrs or "version" in attrs
+            ), "HDF5 file 'info' group missing a SPINE version attribute."
+            version = attrs.get("spine_version", attrs.get("version"))
 
         assert isinstance(version, str), "'version' attribute is not a string."
         return version
@@ -333,13 +358,19 @@ class HDF5Reader(ReaderBase):
                 events, h5py.Dataset
             ), "'events' is not a dataset in the HDF5 file."
 
-            event = events[entry_idx]
-            names = getattr(getattr(event, "dtype", None), "names", None)
-            if names is not None:
-                for key in names:
-                    self.load_key(in_file, event, data, key)
+            if self.file_format_versions[file_idx] == 1:
+                event = events[entry_idx]
+                names = getattr(getattr(event, "dtype", None), "names", None)
+                if names is not None:
+                    for key in names:
+                        if self.should_load_key(key):
+                            self.load_key(in_file, event, data, key)
+                else:
+                    raise ValueError("Event entry does not have named fields.")
             else:
-                raise ValueError("Event entry does not have named fields.")
+                for key in in_file.keys():
+                    if key not in {"events", "info"} and self.should_load_key(key):
+                        self.load_key_v2(in_file, entry_idx, data, key)
         finally:
             if should_close:
                 in_file.close()
@@ -348,6 +379,145 @@ class HDF5Reader(ReaderBase):
         data["index"] = idx
 
         return data
+
+    def should_load_key(self, key: str) -> bool:
+        """Return whether a product belongs to the requested projection."""
+        return (
+            self.requested_keys is None
+            or key in self.requested_keys
+            or key
+            in {
+                "source_file_index",
+                "source_file_entry_index",
+            }
+        )
+
+    def load_key_v2(
+        self,
+        in_file: h5py.File,
+        entry_idx: int,
+        data: dict[str, Any],
+        key: str,
+    ) -> None:
+        """Load one product from an offset-based V2 group."""
+        group = in_file[key]
+        if not isinstance(group, h5py.Group) or "kind" not in group.attrs:
+            raise ValueError(f"V2 product '{key}' is not a recognized product group.")
+        kind = group.attrs["kind"]
+        if isinstance(kind, bytes):
+            kind = kind.decode()
+
+        if kind == "array":
+            values = group["values"]
+            offsets = group["event_offsets"]
+            start, stop = (int(v) for v in offsets[entry_idx : entry_idx + 2])
+            result = values[start:stop]
+            if group.attrs["scalar"]:
+                result = result[0]
+            data[key] = result
+            return
+
+        if kind == "string":
+            values = group["values"]
+            offsets = group["event_offsets"]
+            start, stop = (int(v) for v in offsets[entry_idx : entry_idx + 2])
+            data[key] = values[start:stop].tobytes().decode("utf-8")
+            return
+
+        if kind == "objects":
+            self.load_objects_v2(group, entry_idx, data, key)
+            return
+
+        if kind == "list":
+            values = group["values"]
+            element_offsets = group["element_offsets"]
+            event_offsets = group["event_offsets"]
+            first, last = (int(v) for v in event_offsets[entry_idx : entry_idx + 2])
+            bounds = element_offsets[first : last + 1]
+            result = np.empty(last - first, dtype=object)
+            base = int(bounds[0]) if len(bounds) else 0
+            terminal = int(bounds[-1]) if len(bounds) else base
+            event_values = values[base:terminal]
+            for i in range(last - first):
+                start = int(bounds[i]) - base
+                stop = int(bounds[i + 1]) - base
+                result[i] = event_values[start:stop]
+            data[key] = result
+            return
+
+        if kind == "multi_list":
+            result = []
+            for name in sorted(group.keys(), key=lambda item: int(item.split("_")[-1])):
+                element = group[name]
+                values = element["values"]
+                offsets = element["event_offsets"]
+                start, stop = (int(v) for v in offsets[entry_idx : entry_idx + 2])
+                result.append(values[start:stop])
+            data[key] = result
+            return
+
+        raise ValueError(f"Unrecognized V2 product kind '{kind}' for key '{key}'.")
+
+    def load_objects_v2(
+        self,
+        group: h5py.Group,
+        entry_idx: int,
+        data: dict[str, Any],
+        key: str,
+    ) -> None:
+        """Load an object collection from fixed rows and flat variable fields."""
+        fixed = group["fixed"]
+        event_offsets = group["event_offsets"]
+        variables = group["variables"]
+        assert isinstance(fixed, h5py.Dataset)
+        assert isinstance(event_offsets, h5py.Dataset)
+        assert isinstance(variables, h5py.Group)
+        first, last = (int(v) for v in event_offsets[entry_idx : entry_idx + 2])
+        rows = fixed[first:last]
+        class_name = group.attrs["class_name"]
+        if isinstance(class_name, bytes):
+            class_name = class_name.decode()
+        obj_class = self.resolve_object_class(class_name, rows)
+
+        variable_values: dict[str, list[Any]] = {}
+        for pool_name, pool in variables.items():
+            values = pool["values"]
+            pool_index = int(pool_name.split("_")[-1])
+            bounds = rows[f"_var_offsets_{pool_index}"]
+            is_string = pool.attrs["kind"] == "string"
+            fields = yaml.safe_load(pool.attrs["fields"])
+            base = int(bounds[0, 0]) if len(bounds) else 0
+            terminal = int(bounds[-1, -1]) if len(bounds) else base
+            event_values = values[base:terminal]
+            for j, name in enumerate(fields):
+                loaded = []
+                for i in range(last - first):
+                    start = int(bounds[i, j]) - base
+                    stop = int(bounds[i, j + 1]) - base
+                    value = event_values[start:stop]
+                    if is_string:
+                        value = value.tobytes().decode("utf-8")
+                    loaded.append(value)
+                variable_values[name] = loaded
+
+        names = rows.dtype.names or ()
+        result = []
+        for i, row in enumerate(rows):
+            obj_dict = {
+                name: row[name]
+                for name in names
+                if not name.startswith("_var_offsets_")
+            }
+            obj_dict.update(
+                {name: values[i] for name, values in variable_values.items()}
+            )
+            if self.build_classes:
+                result.append(obj_class.from_dict(obj_dict))
+            else:
+                result.append(obj_dict)
+        if group.attrs["scalar"]:
+            result = result[0]
+        data[key] = result
 
     @staticmethod
     def resolve_object_class(class_name: str, array: np.ndarray) -> type:

--- a/src/spine/io/read/hdf5.py
+++ b/src/spine/io/read/hdf5.py
@@ -59,6 +59,7 @@ class HDF5Reader(ReaderBase):
         skip_run_event_list: list[list[int]] | None = None,
         create_run_map: bool = False,
         build_classes: bool = True,
+        fixed_only: bool = False,
         skip_unknown_attrs: bool = False,
         run_info_key: str = "run_info",
         allow_missing: bool = False,
@@ -96,6 +97,15 @@ class HDF5Reader(ReaderBase):
             For large files, this can be quite expensive (must load every entry).
         build_classes : bool, default True
             If the stored object is a class, build it back
+        fixed_only : bool, default False
+            If `True`, load only the fixed compound rows of V2 object
+            products and do not access their variable-value pools. This is
+            useful for high-level consumers which need scalar and fixed-width
+            attributes only. It is not supported for V1 files. When classes
+            are rebuilt, omitted variable attributes retain their class
+            defaults; derived properties which depend on them are therefore
+            not reliable. With `build_classes=False`, stored derived fields
+            remain available directly in the returned dictionaries.
         skip_unknown_attrs : bool, default False
             If `True`, allow a loaded object to have unrecognized attributes.
             This allows backward compatibility with old files, but use with
@@ -127,6 +137,7 @@ class HDF5Reader(ReaderBase):
         self.keep_open = keep_open
         self.swmr = swmr
         self.ignore_incomplete = ignore_incomplete
+        self.fixed_only = fixed_only
         self._handle_pid: int | None = None
         self._file_handles: dict[int, h5py.File] = {}
 
@@ -226,6 +237,14 @@ class HDF5Reader(ReaderBase):
                 file_index.append(i * np.ones(num_entries, dtype=np.int64))
                 self.file_offsets[i] = self.num_entries
                 self.num_entries += num_entries
+
+        if self.fixed_only and any(
+            version != 2 for version in self.file_format_versions
+        ):
+            raise ValueError(
+                "`fixed_only=True` is supported only for HDF5 format "
+                "version 2 files."
+            )
 
         # Dump the number of entries to load
         logger.info("Total number of entries in the file(s): %d\n", self.num_entries)
@@ -631,8 +650,13 @@ class HDF5Reader(ReaderBase):
           attribute.
 
         Only the object and variable-value spans touched by this event are
-        read. Logical dictionaries are then passed to ``DataBase.from_dict``;
-        when ``build_classes=False`` those dictionaries are returned directly.
+        read. When classes are requested, the dictionaries are passed to the
+        trusted V2 constructor. The physical schema was generated directly
+        from the SPINE data class, so repeating assignment validation, array
+        normalization, and semantic post-initialization would add substantial
+        CPU cost without protecting against user-provided input. V1 continues
+        to use the conservative public constructor. When
+        ``build_classes=False``, dictionaries are returned directly.
 
         Parameters
         ----------
@@ -658,7 +682,6 @@ class HDF5Reader(ReaderBase):
         schema = self._v2_object_schemas.get(schema_key)
         if schema is None:
             fixed = _require_dataset(group, "fixed")
-            variables = _require_group(group, "variables")
             class_name = _decode_string_attribute(
                 group.attrs["class_name"], "class_name"
             )
@@ -669,28 +692,32 @@ class HDF5Reader(ReaderBase):
                 if not name.startswith("_var_offsets_")
             )
             decoded_pool_specs: list[tuple[str, int, bool, tuple[str, ...]]] = []
-            for pool_name, pool in sorted(
-                variables.items(),
-                key=lambda item: int(item[0].split("_")[-1]),
-            ):
-                if not isinstance(pool, h5py.Group):
-                    raise TypeError(f"V2 variable pool '{pool_name}' must be a group.")
-                pool_index = int(pool_name.split("_")[-1])
-                kind = _decode_string_attribute(pool.attrs["kind"], "kind")
-                fields_value = yaml.safe_load(
-                    _decode_string_attribute(pool.attrs["fields"], "fields")
-                )
-                if not isinstance(fields_value, list) or not all(
-                    isinstance(name, str) for name in fields_value
+            if not self.fixed_only:
+                variables = _require_group(group, "variables")
+                for pool_name, pool in sorted(
+                    variables.items(),
+                    key=lambda item: int(item[0].split("_")[-1]),
                 ):
-                    raise TypeError(
-                        f"V2 variable pool '{pool_name}' fields must be "
-                        "a list of strings."
+                    if not isinstance(pool, h5py.Group):
+                        raise TypeError(
+                            f"V2 variable pool '{pool_name}' must be a group."
+                        )
+                    pool_index = int(pool_name.split("_")[-1])
+                    kind = _decode_string_attribute(pool.attrs["kind"], "kind")
+                    fields_value = yaml.safe_load(
+                        _decode_string_attribute(pool.attrs["fields"], "fields")
                     )
-                fields = tuple(fields_value)
-                decoded_pool_specs.append(
-                    (pool_name, pool_index, kind == "string", fields)
-                )
+                    if not isinstance(fields_value, list) or not all(
+                        isinstance(name, str) for name in fields_value
+                    ):
+                        raise TypeError(
+                            f"V2 variable pool '{pool_name}' fields must be "
+                            "a list of strings."
+                        )
+                    fields = tuple(fields_value)
+                    decoded_pool_specs.append(
+                        (pool_name, pool_index, kind == "string", fields)
+                    )
             schema = (
                 class_name,
                 scalar,
@@ -752,7 +779,7 @@ class HDF5Reader(ReaderBase):
                 {name: values[i] for name, values in variable_values.items()}
             )
             if self.build_classes:
-                result.append(obj_class.from_dict(obj_dict))
+                result.append(obj_class.from_dict_trusted(obj_dict))
             else:
                 result.append(obj_dict)
         if scalar:

--- a/src/spine/io/read/hdf5.py
+++ b/src/spine/io/read/hdf5.py
@@ -60,6 +60,8 @@ class HDF5Reader(ReaderBase):
         create_run_map: bool = False,
         build_classes: bool = True,
         fixed_only: bool = False,
+        columnar: bool = False,
+        chunk_size: int = 1024,
         skip_unknown_attrs: bool = False,
         run_info_key: str = "run_info",
         allow_missing: bool = False,
@@ -106,6 +108,13 @@ class HDF5Reader(ReaderBase):
             defaults; derived properties which depend on them are therefore
             not reliable. With `build_classes=False`, stored derived fields
             remain available directly in the returned dictionaries.
+        columnar : bool, default False
+            If `True`, expose projected object products in multi-event chunks
+            through :meth:`get_columnar`. Event/class loading remains the
+            default. Columnar projection is configured by the analysis manager
+            before processing begins.
+        chunk_size : int, default 1024
+            Maximum number of selected events in one columnar chunk.
         skip_unknown_attrs : bool, default False
             If `True`, allow a loaded object to have unrecognized attributes.
             This allows backward compatibility with old files, but use with
@@ -138,6 +147,11 @@ class HDF5Reader(ReaderBase):
         self.swmr = swmr
         self.ignore_incomplete = ignore_incomplete
         self.fixed_only = fixed_only
+        self.columnar = columnar
+        if chunk_size <= 0:
+            raise ValueError("`chunk_size` must be a positive integer.")
+        self.chunk_size = chunk_size
+        self._columnar_requests: dict[str, tuple[tuple[str, ...] | None, bool]] = {}
         self._handle_pid: int | None = None
         self._file_handles: dict[int, h5py.File] = {}
 
@@ -276,6 +290,227 @@ class HDF5Reader(ReaderBase):
 
         # Process the SPINE version used to produced the HDF5 file
         self.version = self.process_version()
+
+    @property
+    def num_chunks(self) -> int:
+        """Number of chunks exposed by the configured columnar reader."""
+        return (len(self) + self.chunk_size - 1) // self.chunk_size
+
+    def configure_columnar(
+        self,
+        requests: dict[str, tuple[tuple[str, ...] | None, bool]],
+    ) -> None:
+        """Install the analyzer-derived product projection."""
+        if not self.columnar:
+            raise RuntimeError("Cannot configure columnar projection in event mode.")
+        self._columnar_requests = dict(requests)
+
+    def get_columnar(self, idx: int) -> dict[str, Any]:
+        """Load one projected multi-event chunk without rebuilding classes."""
+        if not self.columnar:
+            raise RuntimeError("Columnar loading was not enabled for this reader.")
+        if idx < 0 or idx >= self.num_chunks:
+            raise IndexError(
+                f"Chunk {idx} out of bounds for columnar reader with "
+                f"{self.num_chunks} chunks."
+            )
+        if not self._columnar_requests:
+            raise RuntimeError("Columnar product projection was not configured.")
+
+        first = idx * self.chunk_size
+        last = min(first + self.chunk_size, len(self))
+        selected = self.entry_index[first:last]
+        file_indices = self.file_index[selected]
+        local_entries = selected - self.file_offsets[file_indices]
+        data: dict[str, Any] = {
+            "index": np.arange(first, last, dtype=np.int64),
+            "file_index": file_indices.astype(np.int64, copy=False),
+            "file_entry_index": local_entries.astype(np.int64, copy=False),
+        }
+
+        # Preserve selected event order while grouping adjacent entries from
+        # the same file into one physical access unit.
+        file_runs: list[tuple[int, np.ndarray]] = []
+        run_start = 0
+        for i in range(1, len(selected) + 1):
+            if i == len(selected) or file_indices[i] != file_indices[run_start]:
+                file_runs.append(
+                    (
+                        int(file_indices[run_start]),
+                        local_entries[run_start:i].astype(np.int64, copy=False),
+                    )
+                )
+                run_start = i
+
+        for key, (requested_fields, required) in self._columnar_requests.items():
+            pieces = []
+            missing = False
+            for file_idx, entries in file_runs:
+                in_file, should_close = self._open_file(file_idx)
+                try:
+                    if key not in in_file:
+                        missing = True
+                        continue
+                    version = self.file_format_versions[file_idx]
+                    if version == 1:
+                        piece = self._load_columnar_objects_v1(
+                            in_file, key, entries, requested_fields
+                        )
+                    else:
+                        piece = self._load_columnar_objects_v2(
+                            in_file, key, entries, requested_fields
+                        )
+                    pieces.append(piece)
+                finally:
+                    if should_close:
+                        in_file.close()
+
+            if missing:
+                if required:
+                    raise KeyError(
+                        f"Required columnar product `{key}` is missing from "
+                        "one or more input files."
+                    )
+                continue
+            if pieces:
+                data[key] = self._merge_columnar_products(pieces)
+
+        return data
+
+    @staticmethod
+    def _contiguous_runs(entries: np.ndarray) -> list[tuple[int, int]]:
+        """Convert ordered entry IDs into inclusive-exclusive runs."""
+        if not len(entries):
+            return []
+        runs = []
+        first = previous = int(entries[0])
+        for value_raw in entries[1:]:
+            value = int(value_raw)
+            if value != previous + 1:
+                runs.append((first, previous + 1))
+                first = value
+            previous = value
+        runs.append((first, previous + 1))
+        return runs
+
+    def _load_columnar_objects_v2(
+        self,
+        in_file: h5py.File,
+        key: str,
+        entries: np.ndarray,
+        requested_fields: tuple[str, ...] | None,
+    ) -> dict[str, Any]:
+        """Project fixed object columns and event boundaries from V2."""
+        group = _require_group(in_file, key)
+        kind = _decode_string_attribute(group.attrs["kind"], "kind")
+        if kind != "objects":
+            raise TypeError(
+                f"Columnar product `{key}` must be an object collection, got `{kind}`."
+            )
+        fixed = _require_dataset(group, "fixed")
+        offsets = _require_dataset(group, "event_offsets")
+        available = tuple(
+            name
+            for name in fixed.dtype.names or ()
+            if not name.startswith("_var_offsets_")
+        )
+        fields_to_read = available if requested_fields is None else requested_fields
+        missing = set(fields_to_read).difference(available)
+        if missing:
+            raise KeyError(
+                f"Columnar product `{key}` is missing fixed fields "
+                f"{sorted(missing)}."
+            )
+
+        rows = []
+        counts = []
+        for first, last in self._contiguous_runs(entries):
+            bounds = offsets[first : last + 1]
+            start, stop = int(bounds[0]), int(bounds[-1])
+            if fields_to_read:
+                rows.append(fixed.fields(fields_to_read)[start:stop])
+            counts.extend(np.diff(bounds).astype(np.int64, copy=False))
+        result = {}
+        if fields_to_read:
+            combined = (
+                np.concatenate(rows)
+                if rows
+                else np.empty(
+                    0,
+                    dtype=np.dtype(
+                        [(name, fixed.dtype[name]) for name in fields_to_read]
+                    ),
+                )
+            )
+            result.update({name: combined[name] for name in fields_to_read})
+        result["event_offsets"] = np.concatenate(
+            ([0], np.cumsum(counts, dtype=np.int64))
+        )
+        return result
+
+    def _load_columnar_objects_v1(
+        self,
+        in_file: h5py.File,
+        key: str,
+        entries: np.ndarray,
+        requested_fields: tuple[str, ...] | None,
+    ) -> dict[str, Any]:
+        """Project compound object fields through legacy event references."""
+        dataset = _require_dataset(in_file, key)
+        available = tuple(dataset.dtype.names or ())
+        fields_to_read = available if requested_fields is None else requested_fields
+        missing = set(fields_to_read).difference(available)
+        if missing:
+            raise KeyError(
+                f"Legacy columnar product `{key}` is missing fields "
+                f"{sorted(missing)}."
+            )
+        events = _require_dataset(in_file, "events")
+        rows = []
+        counts = []
+        for entry in entries:
+            event = events[int(entry)]
+            names = getattr(getattr(event, "dtype", None), "names", ())
+            if key not in names:
+                raise KeyError(f"Legacy event does not reference product `{key}`.")
+            if fields_to_read:
+                values = dataset.fields(fields_to_read)[event[key]]
+                rows.append(values)
+                counts.append(len(values))
+            else:
+                # V1 has no event-offset dataset, so obtaining the row count
+                # still requires resolving its legacy region reference.
+                counts.append(len(dataset[event[key]]))
+        result = {}
+        if fields_to_read:
+            combined = (
+                np.concatenate(rows)
+                if rows
+                else np.empty(
+                    0,
+                    dtype=np.dtype(
+                        [(name, dataset.dtype[name]) for name in fields_to_read]
+                    ),
+                )
+            )
+            result.update({name: combined[name] for name in fields_to_read})
+        result["event_offsets"] = np.concatenate(
+            ([0], np.cumsum(counts, dtype=np.int64))
+        )
+        return result
+
+    @staticmethod
+    def _merge_columnar_products(pieces: list[dict[str, Any]]) -> dict[str, Any]:
+        """Concatenate file-local columnar products into one chunk."""
+        names = tuple(name for name in pieces[0] if name != "event_offsets")
+        result = {
+            name: np.concatenate([piece[name] for piece in pieces]) for name in names
+        }
+        counts = np.concatenate([np.diff(piece["event_offsets"]) for piece in pieces])
+        result["event_offsets"] = np.concatenate(
+            ([0], np.cumsum(counts, dtype=np.int64))
+        )
+        return result
 
     def close(self) -> None:
         """Close any persistent HDF5 handles owned by this reader.

--- a/src/spine/io/transform/__init__.py
+++ b/src/spine/io/transform/__init__.py
@@ -1,0 +1,5 @@
+"""Direct transformations of persisted SPINE I/O formats."""
+
+from .hdf5 import DEFAULT_LITE_KEYS, litify_hdf5
+
+__all__ = ["DEFAULT_LITE_KEYS", "litify_hdf5"]

--- a/src/spine/io/transform/hdf5.py
+++ b/src/spine/io/transform/hdf5.py
@@ -1,0 +1,368 @@
+"""Structural transformations for offset-based SPINE HDF5 files."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Sequence
+from typing import Any
+
+import h5py
+import numpy as np
+import yaml
+
+import spine.data
+
+__all__ = ["DEFAULT_LITE_KEYS", "litify_hdf5"]
+
+
+DEFAULT_LITE_KEYS = (
+    "run_info",
+    "meta",
+    "reco_particles",
+    "truth_particles",
+    "reco_interactions",
+    "truth_interactions",
+)
+"""Products retained by the standard production lite-output workflow."""
+
+_ADMINISTRATIVE_KEYS = (
+    "index",
+    "source_file_index",
+    "source_file_entry_index",
+)
+
+
+def _copy_attrs(source: h5py.AttributeManager, target: h5py.AttributeManager) -> None:
+    """Copy HDF5 attributes without interpreting their values."""
+    for key, value in source.items():
+        target[key] = value
+
+
+def _require_v2(in_file: h5py.File, path: str) -> None:
+    """Validate that an input file uses the structural V2 layout."""
+    if "events" not in in_file or "info" not in in_file:
+        raise ValueError(f"'{path}' is not a complete SPINE HDF5 output.")
+    version = int(in_file["info"].attrs.get("format_version", 1))
+    if version != 2:
+        raise ValueError(
+            "Structural litification requires HDF5 format version 2; "
+            f"'{path}' uses version {version}."
+        )
+
+
+def _lite_skip_fields(class_name: str) -> set[str]:
+    """Return fields omitted by a data class's established lite policy."""
+    cls = getattr(spine.data, class_name, None)
+    if cls is None or not hasattr(cls, "attr_names"):
+        raise ValueError(
+            f"Cannot resolve stored object class '{class_name}' to determine "
+            "its lite attribute policy."
+        )
+    full = set(
+        cls.attr_names(
+            include_derived=True,
+            include_skipped=False,
+            lite=False,
+        )
+    )
+    lite = set(
+        cls.attr_names(
+            include_derived=True,
+            include_skipped=False,
+            lite=True,
+        )
+    )
+    return full.difference(lite)
+
+
+def _decode_fields(pool: h5py.Group) -> tuple[str, ...]:
+    """Decode and validate a V2 variable pool's ordered field names."""
+    value = pool.attrs.get("fields")
+    if isinstance(value, bytes):
+        value = value.decode()
+    if not isinstance(value, str):
+        raise TypeError(f"Variable pool '{pool.name}' has no string field metadata.")
+    fields = yaml.safe_load(value)
+    if not isinstance(fields, list) or not all(
+        isinstance(field, str) for field in fields
+    ):
+        raise TypeError(
+            f"Variable pool '{pool.name}' fields must decode to a string list."
+        )
+    return tuple(fields)
+
+
+def _dataset_kwargs(dataset: h5py.Dataset) -> dict[str, Any]:
+    """Return reusable physical creation options from a source dataset."""
+    kwargs: dict[str, Any] = {}
+    if dataset.chunks is not None:
+        kwargs["chunks"] = dataset.chunks
+    if dataset.compression is not None:
+        kwargs["compression"] = dataset.compression
+        kwargs["compression_opts"] = dataset.compression_opts
+    if dataset.shuffle:
+        kwargs["shuffle"] = True
+    if dataset.fletcher32:
+        kwargs["fletcher32"] = True
+    if dataset.scaleoffset is not None:
+        kwargs["scaleoffset"] = dataset.scaleoffset
+    return kwargs
+
+
+def _copy_object_group(
+    source: h5py.Group,
+    target: h5py.Group,
+    *,
+    mode: str,
+    block_size: int,
+) -> None:
+    """Copy one object product while omitting selected variable attributes."""
+    _copy_attrs(source.attrs, target.attrs)
+    class_name = source.attrs.get("class_name")
+    if isinstance(class_name, bytes):
+        class_name = class_name.decode()
+    if not isinstance(class_name, str):
+        raise TypeError(f"Object product '{source.name}' has no class name.")
+
+    source_fixed = source["fixed"]
+    source_offsets = source["event_offsets"]
+    source_variables = source["variables"]
+    if not isinstance(source_fixed, h5py.Dataset):
+        raise TypeError(f"Object product '{source.name}' has no fixed dataset.")
+    if not isinstance(source_offsets, h5py.Dataset):
+        raise TypeError(f"Object product '{source.name}' has no event offsets.")
+    if not isinstance(source_variables, h5py.Group):
+        raise TypeError(f"Object product '{source.name}' has no variable group.")
+
+    drop_fields = (
+        set().union(*(_decode_fields(pool) for pool in source_variables.values()))
+        if mode == "fixed_only" and len(source_variables)
+        else _lite_skip_fields(class_name)
+    )
+    ordinary_names = tuple(
+        name
+        for name in source_fixed.dtype.names or ()
+        if not name.startswith("_var_offsets_")
+    )
+    fixed_dtype: list[tuple[Any, ...]] = [
+        (name, source_fixed.dtype.fields[name][0]) for name in ordinary_names
+    ]
+
+    target_variables = target.create_group("variables")
+    pool_specs: list[
+        tuple[h5py.Group, h5py.Group, str, str, tuple[int, ...], tuple[str, ...]]
+    ] = []
+    for source_pool_name, source_pool_obj in source_variables.items():
+        if not isinstance(source_pool_obj, h5py.Group):
+            raise TypeError(f"Variable pool '{source_pool_name}' is not a group.")
+        source_fields = _decode_fields(source_pool_obj)
+        keep_indices = tuple(
+            i for i, field in enumerate(source_fields) if field not in drop_fields
+        )
+        if not keep_indices:
+            continue
+
+        target_pool_name = f"pool_{len(pool_specs)}"
+        target_pool = target_variables.create_group(target_pool_name)
+        _copy_attrs(source_pool_obj.attrs, target_pool.attrs)
+        kept_fields = tuple(source_fields[i] for i in keep_indices)
+        target_pool.attrs["fields"] = yaml.safe_dump(list(kept_fields))
+
+        source_values = source_pool_obj["values"]
+        if not isinstance(source_values, h5py.Dataset):
+            raise TypeError(f"Variable pool '{source_pool_obj.name}' has no values.")
+        target_values = target_pool.create_dataset(
+            "values",
+            (0,),
+            maxshape=(None,),
+            dtype=source_values.dtype,
+            **_dataset_kwargs(source_values),
+        )
+        _copy_attrs(source_values.attrs, target_values.attrs)
+
+        old_pool_index = int(source_pool_name.rsplit("_", 1)[-1])
+        source_helper = f"_var_offsets_{old_pool_index}"
+        target_helper = f"_var_offsets_{len(pool_specs)}"
+        if source_helper not in (source_fixed.dtype.names or ()):
+            raise KeyError(
+                f"Object product '{source.name}' is missing helper "
+                f"column '{source_helper}'."
+            )
+        fixed_dtype.append((target_helper, np.int64, len(kept_fields) + 1))
+        pool_specs.append(
+            (
+                source_pool_obj,
+                target_pool,
+                source_helper,
+                target_helper,
+                keep_indices,
+                kept_fields,
+            )
+        )
+
+    target_fixed = target.create_dataset(
+        "fixed",
+        source_fixed.shape,
+        maxshape=source_fixed.maxshape,
+        dtype=np.dtype(fixed_dtype),
+        **_dataset_kwargs(source_fixed),
+    )
+    _copy_attrs(source_fixed.attrs, target_fixed.attrs)
+    source.copy(source_offsets, target, name="event_offsets")
+
+    num_rows = len(source_fixed)
+    for first in range(0, num_rows, block_size):
+        last = min(first + block_size, num_rows)
+        source_rows = source_fixed[first:last]
+        target_rows: Any = np.empty(last - first, dtype=target_fixed.dtype)
+        for name in ordinary_names:
+            target_rows[name] = source_rows[name]
+
+        for (
+            source_pool,
+            target_pool,
+            source_helper,
+            target_helper,
+            keep_indices,
+            _,
+        ) in pool_specs:
+            source_values = source_pool["values"]
+            target_values = target_pool["values"]
+            assert isinstance(source_values, h5py.Dataset)
+            assert isinstance(target_values, h5py.Dataset)
+
+            source_bounds = source_rows[source_helper]
+            target_bounds = np.empty(
+                (last - first, len(keep_indices) + 1), dtype=np.int64
+            )
+            cursor = len(target_values)
+            chunks = []
+            for row_idx, bounds in enumerate(source_bounds):
+                target_bounds[row_idx, 0] = cursor
+                for field_idx, source_field_idx in enumerate(keep_indices):
+                    start = int(bounds[source_field_idx])
+                    stop = int(bounds[source_field_idx + 1])
+                    chunk = source_values[start:stop]
+                    chunks.append(chunk)
+                    cursor += len(chunk)
+                    target_bounds[row_idx, field_idx + 1] = cursor
+
+            combined = (
+                np.concatenate(chunks)
+                if chunks
+                else np.empty(0, dtype=target_values.dtype)
+            )
+            old_size = len(target_values)
+            target_values.resize(old_size + len(combined), axis=0)
+            if len(combined):
+                target_values[old_size:] = combined
+            target_rows[target_helper] = target_bounds
+
+        target_fixed[first:last] = target_rows
+
+
+def litify_hdf5(
+    source_path: str,
+    target_path: str,
+    *,
+    keys: Sequence[str] = DEFAULT_LITE_KEYS,
+    mode: str = "lite",
+    overwrite: bool = False,
+    block_size: int = 4096,
+) -> None:
+    """Create a structurally reduced copy of a V2 SPINE HDF5 output.
+
+    Parameters
+    ----------
+    source_path : str
+        Input SPINE HDF5 path.
+    target_path : str
+        Destination path. The input is never modified in place.
+    keys : sequence[str], default DEFAULT_LITE_KEYS
+        Physics products to retain. Administrative index/provenance products
+        are retained automatically when available.
+    mode : {'lite', 'fixed_only'}, default 'lite'
+        ``lite`` reproduces the class-level ``lite=True`` storage policy.
+        ``fixed_only`` removes every variable-length object attribute.
+    overwrite : bool, default False
+        Replace an existing destination atomically.
+    block_size : int, default 4096
+        Number of object rows processed per fixed-table block.
+    """
+    if mode not in ("lite", "fixed_only"):
+        raise ValueError(f"Unsupported litification mode '{mode}'.")
+    if block_size <= 0:
+        raise ValueError("`block_size` must be positive.")
+
+    source_path = os.path.abspath(os.path.expanduser(source_path))
+    target_path = os.path.abspath(os.path.expanduser(target_path))
+    if source_path == target_path:
+        raise ValueError("Input and output paths must be different.")
+    if not os.path.isfile(source_path):
+        raise FileNotFoundError(f"Input HDF5 file not found: {source_path}")
+    if os.path.exists(target_path) and not overwrite:
+        raise FileExistsError(f"Output already exists: {target_path}")
+
+    target_dir = os.path.dirname(target_path)
+    os.makedirs(target_dir, exist_ok=True)
+    descriptor, temporary_path = tempfile.mkstemp(
+        prefix=f".{os.path.basename(target_path)}.",
+        suffix=".tmp",
+        dir=target_dir,
+    )
+    os.close(descriptor)
+
+    try:
+        with (
+            h5py.File(source_path, "r") as source,
+            h5py.File(temporary_path, "w") as target,
+        ):
+            _require_v2(source, source_path)
+            _copy_attrs(source.attrs, target.attrs)
+            source.copy("events", target)
+            source.copy("info", target)
+            info = target["info"]
+            assert isinstance(info, h5py.Group)
+            info.attrs["complete"] = False
+
+            requested = tuple(dict.fromkeys(keys))
+            missing = [key for key in requested if key not in source]
+            if missing:
+                raise KeyError(f"Requested products are missing: {missing}.")
+
+            selected = list(requested)
+            for key in _ADMINISTRATIVE_KEYS:
+                if key in source and key not in selected:
+                    selected.append(key)
+            if "source" in source and "source" not in selected:
+                selected.append("source")
+
+            for key in selected:
+                product = source[key]
+                if (
+                    isinstance(product, h5py.Group)
+                    and product.attrs.get("kind") == "objects"
+                ):
+                    target_product = target.create_group(key)
+                    _copy_object_group(
+                        product,
+                        target_product,
+                        mode=mode,
+                        block_size=block_size,
+                    )
+                else:
+                    source.copy(key, target)
+
+            info.attrs["litified"] = True
+            info.attrs["litify_mode"] = mode
+            info.attrs["litify_keys"] = yaml.safe_dump(list(requested))
+            info.attrs["complete"] = True
+            target.flush()
+
+        os.chmod(temporary_path, os.stat(source_path).st_mode & 0o666)
+        os.replace(temporary_path, target_path)
+    except Exception:
+        if os.path.exists(temporary_path):
+            os.unlink(temporary_path)
+        raise

--- a/src/spine/io/write/csv.py
+++ b/src/spine/io/write/csv.py
@@ -1,6 +1,7 @@
 """Module to write log files to CSV."""
 
 import os
+from collections.abc import Iterable, Mapping
 from types import TracebackType
 from typing import Any
 
@@ -159,7 +160,12 @@ class CSVWriter:
         and the file exists, otherwise in write mode.
         """
         if self.file_handle is None:
-            mode = "a" if self.append_file and os.path.isfile(self.file_name) else "w"
+            mode = (
+                "a"
+                if (self.append_file or self.keys is not None)
+                and os.path.isfile(self.file_name)
+                else "w"
+            )
             if mode == "w":
                 dir_name = os.path.dirname(self.file_name)
                 if dir_name:
@@ -197,14 +203,16 @@ class CSVWriter:
         data : dict
             Dictionary containing the output of the reconstruction chain
         """
-        # Save the list of keys to store
-        self.keys = list(data.keys())
-
-        # Open the file handle if not already open
+        # Open before recording the initialized keys. This distinguishes a
+        # first write, which may overwrite, from reopening an existing writer,
+        # which must append without replacing its earlier rows.
         self.open()
 
         # File handle is guaranteed to be open here
         assert self.file_handle is not None
+
+        # Save the list of keys to store
+        self.keys = list(data.keys())
 
         # Create a header and write it to file
         header_str = ",".join(self.keys)
@@ -260,8 +268,36 @@ class CSVWriter:
         result_str = ",".join([str(data[k]) for k in self.keys])
         self.file_handle.write(result_str + "\n")
 
+    def append_columns(self, data: Mapping[str, Any]) -> None:
+        """Append equal-length columns without constructing row dictionaries.
+
+        Parameters
+        ----------
+        data : Mapping[str, Sequence]
+            Ordered output columns. Every column must have the same length.
+        """
+        keys = list(data)
+        if self.keys is None:
+            self.create({key: None for key in keys})
+        elif keys != self.keys:
+            raise AssertionError(
+                "Columnar CSV keys must match the initialized header. "
+                f"Expected {self.keys}, got {keys}."
+            )
+
+        lengths = {len(data[key]) for key in keys}
+        if len(lengths) > 1:
+            raise ValueError("All columnar CSV fields must have the same length.")
+        count = lengths.pop() if lengths else 0
+        if self.file_handle is None:
+            self.open()
+        assert self.file_handle is not None
+        self.file_handle.writelines(
+            ",".join(str(data[key][i]) for key in keys) + "\n" for i in range(count)
+        )
+
     @staticmethod
-    def array_diff(array_x: list[str], array_y: list[str]) -> set[str]:
+    def array_diff(array_x: Iterable[str], array_y: Iterable[str]) -> set[str]:
         """Compare the content of two arrays.
 
         This functions returns the elemnts of the first array that

--- a/src/spine/io/write/hdf5.py
+++ b/src/spine/io/write/hdf5.py
@@ -15,11 +15,25 @@ __all__ = ["HDF5Writer"]
 
 
 class HDF5Writer:
-    """Writes data to an HDF5 file.
+    """Write reconstruction data using a versioned SPINE HDF5 layout.
 
     Builds an HDF5 file to store the input and/or the output of the
     reconstruction chain. It can also be used to append an existing HDF5 file
     with information coming out of the analysis tools.
+
+    The writer separates the SPINE software version from the physical storage
+    version. ``spine_version`` records the producing release, while
+    ``format_version`` selects one of two on-disk layouts:
+
+    - V1 stores event-level HDF5 region references and uses HDF5 VLEN dtypes
+      for variable object attributes.
+    - V2 replaces those references and VLEN fields with flat datasets and
+      integer offsets. It appends complete batches collectively to reduce
+      dataset-resize and small-write overhead.
+
+    V1 remains the default during the V2 rollout. Readers auto-detect both
+    layouts, but a writer must use one layout consistently for the lifetime of
+    a file.
 
     Typical configuration should look like:
 
@@ -37,6 +51,9 @@ class HDF5Writer:
     """
 
     name = "hdf5"
+    # `format_name` identifies this family of files. The integer version below
+    # identifies its physical schema and is intentionally independent of the
+    # package release in `spine.version.__version__`.
     format_name = "spine_hdf5"
     legacy_format_version = 1
     current_format_version = 2
@@ -106,7 +123,8 @@ class HDF5Writer:
             Physical HDF5 layout version. Version 1 is the legacy
             region-reference/VLEN layout. Version 2 stores event and object
             boundaries as integer offsets and variable object attributes in
-            flat datasets.
+            flat datasets. The choice is persisted in
+            ``info.attrs["format_version"]`` and cannot change when appending.
         """
         # Build the output file name(s) from the input prefix(es) if not provided
         self.file_names = self.get_file_names(
@@ -321,6 +339,8 @@ class HDF5Writer:
 
             try:
                 out_file.create_group("info")
+                # Keep the historical `version` attribute for old consumers,
+                # while giving software and physical layout explicit names.
                 out_file["info"].attrs["version"] = __version__
                 out_file["info"].attrs["spine_version"] = __version__
                 out_file["info"].attrs["format"] = self.format_name
@@ -343,7 +363,25 @@ class HDF5Writer:
         self._entries_since_flush_by_file_id[file_id] = 0
 
     def _validate_append_format(self, out_file: h5py.File, file_name: str) -> None:
-        """Ensure an existing output file uses the requested physical layout."""
+        """Ensure an existing output file uses the requested physical layout.
+
+        Mixing layouts in one file would invalidate all event-boundary
+        assumptions: V1 events contain region references, whereas V2 product
+        groups maintain independent offset arrays. Files without explicit
+        layout metadata predate V2 and are therefore treated as V1.
+
+        Parameters
+        ----------
+        out_file : h5py.File
+            Existing file opened for append.
+        file_name : str
+            File name included in validation errors.
+
+        Raises
+        ------
+        ValueError
+            If metadata is missing or the stored and requested versions differ.
+        """
         if "info" not in out_file:
             raise ValueError(f"Cannot append to '{file_name}': missing info group.")
         stored_version = int(
@@ -811,7 +849,7 @@ class HDF5Writer:
         return object_dtype
 
     def initialize_datasets(
-        self, out_file: h5py.File, type_dict: dict[str, DataFormat]
+        self, out_file: h5py.Group, type_dict: dict[str, DataFormat]
     ) -> None:
         """Create place hodlers for all the datasets to be filled.
 
@@ -875,24 +913,55 @@ class HDF5Writer:
         )
 
     def initialize_datasets_v2(
-        self, out_file: h5py.File, type_dict: dict[str, DataFormat]
+        self, out_file: h5py.Group, type_dict: dict[str, DataFormat]
     ) -> None:
-        """Create the offset-based version-2 dataset layout."""
+        """Create the offset-based version-2 dataset layout.
+
+        Every logical product is represented by a top-level group with a
+        ``kind`` attribute. The product kind determines which flat datasets
+        and offset levels are required:
+
+        - Arrays and strings have ``values`` and ``event_offsets``.
+        - Object collections have compound ``fixed`` rows, ``event_offsets``,
+          and one or more dtype-homogeneous variable pools.
+        - Lists of same-width arrays add ``element_offsets`` between the event
+          and value levels.
+        - Fixed-length lists of differently shaped arrays use one child group
+          per list position.
+
+        All offset datasets begin with zero. Appending ``N`` logical items adds
+        ``N`` terminal offsets, preserving the invariant
+        ``len(offsets) == num_items + 1``. Equal adjacent offsets represent an
+        empty item.
+
+        Parameters
+        ----------
+        out_file : h5py.File
+            Newly created output file.
+        type_dict : dict[str, DataFormat]
+            Logical product formats inferred from the first input batch.
+        """
         self.event_dtype = np.dtype(np.int64)
         for key, val in type_dict.items():
             group = out_file.create_group(key)
             group.attrs["scalar"] = val.scalar
 
             if val.class_name is not None:
+                # Fixed and derived attributes stay in a normal compound
+                # dataset. Only attributes represented as VLEN in the logical
+                # dtype are moved into flat pools.
                 group.attrs["kind"] = "objects"
                 group.attrs["class_name"] = val.class_name
                 assert isinstance(val.dtype, list)
                 fixed_dtype, variable_pools = self.split_object_dtype_v2(val.dtype)
-                fixed_dtype.extend(
+                storage_dtype: list[tuple[Any, ...]] = list(fixed_dtype)
+                storage_dtype.extend(
                     (f"_var_offsets_{i}", np.int64, len(fields) + 1)
                     for i, (_, _, fields) in enumerate(variable_pools)
                 )
-                group.create_dataset("fixed", (0,), maxshape=(None,), dtype=fixed_dtype)
+                group.create_dataset(
+                    "fixed", (0,), maxshape=(None,), dtype=storage_dtype
+                )
                 group.create_dataset(
                     "event_offsets",
                     data=np.zeros(1, dtype=np.int64),
@@ -900,6 +969,8 @@ class HDF5Writer:
                 )
                 variables = group.create_group("variables")
                 for i, (dtype, is_string, fields) in enumerate(variable_pools):
+                    # Pooling fields by dtype limits dataset count while
+                    # retaining one deterministic ordered field list.
                     pool = variables.create_group(f"pool_{i}")
                     pool.attrs["kind"] = "string" if is_string else "array"
                     pool.attrs["fields"] = yaml.safe_dump(fields)
@@ -909,6 +980,9 @@ class HDF5Writer:
                     )
 
             elif not isinstance(val.width, list):
+                # A simple product needs one event-to-value offset level.
+                # Strings are encoded explicitly so V2 contains no HDF5 VLEN
+                # datatype anywhere in its product tree.
                 dtype = np.dtype(val.dtype)
                 is_string = h5py.check_dtype(vlen=dtype) is str
                 group.attrs["kind"] = "string" if is_string else "array"
@@ -925,6 +999,8 @@ class HDF5Writer:
                 )
 
             elif val.merge:
+                # The event contains a variable number of arrays which share a
+                # width and can therefore occupy one values dataset.
                 group.attrs["kind"] = "list"
                 width = val.width[0]
                 shape = (0, width) if width else (0,)
@@ -944,6 +1020,8 @@ class HDF5Writer:
                 )
 
             else:
+                # Differently shaped list positions cannot share a rectangular
+                # values dataset. Each position gets an independent event span.
                 group.attrs["kind"] = "multi_list"
                 for i, width in enumerate(val.width):
                     element = group.create_group(f"element_{i}")
@@ -958,8 +1036,9 @@ class HDF5Writer:
                         maxshape=(None,),
                     )
 
-        # V2 retains an event axis for counting and future event-level metadata,
-        # but it contains no HDF5 references.
+        # V2 retains an event axis for counting, global indexing, completeness
+        # checks, and future event-level metadata. Product boundaries live in
+        # their own groups, so these rows contain no HDF5 references.
         out_file.create_dataset(
             "events", (0,), maxshape=(None,), dtype=self.event_dtype
         )
@@ -968,7 +1047,27 @@ class HDF5Writer:
     def split_object_dtype_v2(
         obj_dtype: list[tuple[str, type]],
     ) -> tuple[list[tuple[str, type]], list[tuple[np.dtype, bool, list[str]]]]:
-        """Separate fixed columns and pool VLEN columns by physical dtype."""
+        """Partition a logical object dtype into fixed columns and flat pools.
+
+        ``get_object_dtype`` expresses variable arrays and strings using HDF5
+        VLEN dtypes because that description is also consumed by V1. V2 uses
+        the VLEN base dtype only as schema information; no VLEN dtype is
+        created on disk. Variable fields with the same base dtype share one
+        values pool, while strings use a distinct ``uint8`` UTF-8 pool.
+
+        Parameters
+        ----------
+        obj_dtype : list[tuple[str, type]]
+            Ordered logical object-field specifications.
+
+        Returns
+        -------
+        fixed_dtype : list[tuple[str, type]]
+            Scalar and fixed-width compound-dataset fields.
+        variable_pools : list[tuple[np.dtype, bool, list[str]]]
+            One tuple per flat pool containing its value dtype, string flag,
+            and ordered logical field names.
+        """
         fixed_dtype = []
         pool_map: dict[tuple[str, bool], tuple[np.dtype, bool, list[str]]] = {}
         for spec in obj_dtype:
@@ -1015,7 +1114,9 @@ class HDF5Writer:
         if not self.ready:
             self.create(data, cfg, append=self.append)
 
-        # Append file(s)
+        # Append file(s). V1 preserves its entry-at-a-time path for backward
+        # compatibility. V2 handles the complete batch together so each flat
+        # values/offset dataset is resized at most once per product and batch.
         if not self.split or len(self.file_names) == 1:
             out_file, should_close = self._get_output_handle(0)
             try:
@@ -1056,7 +1157,7 @@ class HDF5Writer:
                 self._max_written_file_id = max_file_id
 
     def append_entry(
-        self, out_file: h5py.File, data: dict[str, Any], batch_id: int
+        self, out_file: h5py.Group, data: dict[str, Any], batch_id: int
     ) -> None:
         """Stores one entry.
 
@@ -1093,19 +1194,52 @@ class HDF5Writer:
         event_ds[event_id] = event
 
     def append_entry_v2(
-        self, out_file: h5py.File, data: dict[str, Any], batch_id: int
+        self, out_file: h5py.Group, data: dict[str, Any], batch_id: int
     ) -> None:
-        """Append one entry using flat values and integer offsets."""
+        """Append one entry through the collective V2 implementation.
+
+        This compatibility wrapper keeps :meth:`append_entry` useful to
+        callers which explicitly write individual entries. The physical write
+        path remains batch-oriented, with a one-element batch.
+
+        Parameters
+        ----------
+        out_file : h5py.File
+            Output file initialized with the V2 schema.
+        data : dict
+            Batched data-product dictionary.
+        batch_id : int
+            Index of the entry within ``data``.
+        """
         self.append_entries_v2(out_file, data, np.asarray([batch_id], dtype=np.int64))
 
     def append_entries_v2(
-        self, out_file: h5py.File, data: dict[str, Any], batch_ids: np.ndarray
+        self, out_file: h5py.Group, data: dict[str, Any], batch_ids: np.ndarray
     ) -> None:
-        """Append a batch while resizing each V2 dataset only once."""
+        """Append selected batch entries using collective V2 writes.
+
+        Products are committed first and the authoritative ``events`` axis is
+        extended last. During normal operation the writer's ``complete=False``
+        marker protects readers from observing a partially written batch. On
+        successful finalization every product has exactly one event boundary
+        per row in ``events``.
+
+        Parameters
+        ----------
+        out_file : h5py.File
+            Output file initialized with the V2 schema.
+        data : dict
+            Batched data-product dictionary.
+        batch_ids : np.ndarray
+            Ordered indexes of entries to append. Split output uses a subset of
+            the input batch here.
+        """
         assert self.keys is not None
         for key in self.keys:
             self.append_key_batch_v2(out_file, data, key, batch_ids)
 
+        # Rows carry their own monotonic IDs today. Their primary contract is
+        # the stable event count/axis; product lookup uses product offsets.
         events = out_file["events"]
         assert isinstance(events, h5py.Dataset)
         event_id = len(events)
@@ -1116,12 +1250,28 @@ class HDF5Writer:
 
     def append_key_batch_v2(
         self,
-        out_file: h5py.File,
+        out_file: h5py.Group,
         data: dict[str, Any],
         key: str,
         batch_ids: np.ndarray,
     ) -> None:
-        """Append multiple events for one V2 product in collective slices."""
+        """Append multiple events for one V2 product in collective slices.
+
+        The product group's ``kind`` is the only physical-layout dispatch.
+        Logical :class:`DataFormat` metadata is used to normalize scalar versus
+        collection inputs before they enter the common offset helpers.
+
+        Parameters
+        ----------
+        out_file : h5py.File
+            Output file containing the product group.
+        data : dict
+            Batched data-product dictionary.
+        key : str
+            Product to append.
+        batch_ids : np.ndarray
+            Ordered indexes of entries to append.
+        """
         assert self.type_dict is not None
         val = self.type_dict[key]
         group = out_file[key]
@@ -1129,6 +1279,8 @@ class HDF5Writer:
         kind = group.attrs["kind"]
 
         if kind == "objects":
+            # Normalize scalar object products to one-object collections so the
+            # storage helper only needs one representation.
             batches = []
             for batch_id in batch_ids:
                 obj = data[key] if np.isscalar(data[key]) else data[key][batch_id]
@@ -1137,6 +1289,7 @@ class HDF5Writer:
             return
 
         if kind in {"array", "string"}:
+            # Build one array per event, then concatenate and resize once.
             arrays = []
             for batch_id in batch_ids:
                 if np.isscalar(data[key]):
@@ -1153,16 +1306,22 @@ class HDF5Writer:
 
         array_lists = [data[key][batch_id] for batch_id in batch_ids]
         if kind == "list":
+            # Flatten event -> element -> value. The two offset levels preserve
+            # both collection boundaries without region references.
             arrays = [array for array_list in array_lists for array in array_list]
-            self.append_values_with_offsets_v2(
-                group["values"], group["element_offsets"], arrays
-            )
+            values = group["values"]
+            element_offsets = group["element_offsets"]
             event_offsets = group["event_offsets"]
+            assert isinstance(values, h5py.Dataset)
+            assert isinstance(element_offsets, h5py.Dataset)
+            assert isinstance(event_offsets, h5py.Dataset)
+            self.append_values_with_offsets_v2(values, element_offsets, arrays)
             counts = [len(array_list) for array_list in array_lists]
             self.append_lengths_v2(event_offsets, counts)
             return
 
         assert kind == "multi_list"
+        # Each list position owns a separate rectangular values dataset.
         for i, name in enumerate(
             sorted(group.keys(), key=lambda item: int(item.split("_")[-1]))
         ):
@@ -1174,7 +1333,21 @@ class HDF5Writer:
 
     @staticmethod
     def append_lengths_v2(offsets: h5py.Dataset, lengths: Any) -> None:
-        """Append terminal offsets derived from a sequence of lengths."""
+        """Extend a boundary array from a sequence of item lengths.
+
+        The existing final offset is the absolute base of the append. For
+        lengths ``[a, b]``, the method appends ``base + a`` and
+        ``base + a + b``. Zero lengths intentionally repeat the previous
+        boundary and represent empty items.
+
+        Parameters
+        ----------
+        offsets : h5py.Dataset
+            One-dimensional monotonic ``int64`` boundary dataset whose initial
+            value is zero.
+        lengths : array-like
+            Number of values contributed by each newly appended logical item.
+        """
         lengths = np.asarray(lengths, dtype=np.int64)
         if not len(lengths):
             return
@@ -1190,7 +1363,21 @@ class HDF5Writer:
         offsets: h5py.Dataset,
         arrays: list[np.ndarray],
     ) -> None:
-        """Append multiple variable arrays with one values resize and one offset resize."""
+        """Append variable arrays and their boundaries with collective resizes.
+
+        Arrays are concatenated in logical order. The values dataset and offset
+        dataset are each resized once, which is the central write-side
+        performance advantage over per-object region references/VLEN payloads.
+
+        Parameters
+        ----------
+        values : h5py.Dataset
+            Flat destination dataset.
+        offsets : h5py.Dataset
+            Boundary dataset corresponding to ``values``.
+        arrays : list[np.ndarray]
+            Ordered variable-length arrays to append.
+        """
         lengths = np.asarray([len(array) for array in arrays], dtype=np.int64)
         first = len(values)
         combined = np.concatenate(arrays) if arrays else np.empty(0, dtype=values.dtype)
@@ -1201,7 +1388,15 @@ class HDF5Writer:
 
     @classmethod
     def append_array_batch_v2(cls, group: h5py.Group, arrays: list[np.ndarray]) -> None:
-        """Append several event arrays while resizing values and offsets once."""
+        """Append one array per event to a simple V2 product group.
+
+        Parameters
+        ----------
+        group : h5py.Group
+            Group containing ``values`` and ``event_offsets``.
+        arrays : list[np.ndarray]
+            Ordered event payloads.
+        """
         values = group["values"]
         offsets = group["event_offsets"]
         assert isinstance(values, h5py.Dataset)
@@ -1212,7 +1407,29 @@ class HDF5Writer:
     def store_object_batches_v2(
         cls, group: h5py.Group, batches: list[Any], lite: bool
     ) -> None:
-        """Store several events of objects with collective dataset appends."""
+        """Store object batches in fixed rows and dtype-specific value pools.
+
+        Objects are flattened in event order. Each logical object contributes
+        one compound ``fixed`` row. For a variable pool containing ``F``
+        fields, the corresponding fixed-row helper column contains ``F + 1``
+        absolute offsets; adjacent boundaries delimit each field in the pool's
+        shared values dataset. The final ``event_offsets`` update maps events
+        back to their ranges of fixed rows.
+
+        Derived properties returned by ``obj.as_dict`` are stored alongside
+        ordinary fixed attributes. This is intentional: consumers which read
+        HDF5 directly, without SPINE classes, retain access to the advertised
+        object summaries.
+
+        Parameters
+        ----------
+        group : h5py.Group
+            V2 object product group.
+        batches : list
+            Ordered per-event object collections.
+        lite : bool
+            Passed to ``as_dict`` to omit configured heavy attributes.
+        """
         fixed = group["fixed"]
         event_offsets = group["event_offsets"]
         variables = group["variables"]
@@ -1220,8 +1437,10 @@ class HDF5Writer:
         assert isinstance(event_offsets, h5py.Dataset)
         assert isinstance(variables, h5py.Group)
 
+        # Flatten once so fixed columns and every variable pool share exactly
+        # the same object-row order.
         object_dicts = [obj.as_dict(lite) for batch in batches for obj in batch]
-        rows = np.empty(len(object_dicts), dtype=fixed.dtype)
+        rows: Any = np.empty(len(object_dicts), dtype=fixed.dtype)
         if object_dicts:
             for name in fixed.dtype.names or ():
                 if not name.startswith("_var_offsets_"):
@@ -1232,9 +1451,25 @@ class HDF5Writer:
             values = pool["values"]
             assert isinstance(values, h5py.Dataset)
             is_string = pool.attrs["kind"] == "string"
-            fields = yaml.safe_load(pool.attrs["fields"])
+            fields_attr = pool.attrs["fields"]
+            if isinstance(fields_attr, bytes):
+                fields_attr = fields_attr.decode()
+            if not isinstance(fields_attr, str):
+                raise TypeError(
+                    f"V2 variable pool '{pool_name}' fields must be a string."
+                )
+            fields = yaml.safe_load(fields_attr)
+            if not isinstance(fields, list) or not all(
+                isinstance(name, str) for name in fields
+            ):
+                raise TypeError(
+                    f"V2 variable pool '{pool_name}' fields must decode "
+                    "to a list of strings."
+                )
             chunks = []
             offset_rows = np.empty((len(object_dicts), len(fields) + 1), dtype=np.int64)
+            # Offsets are absolute in the full pool, not relative to this
+            # batch. This makes appends independent and permits direct slicing.
             cursor = len(values)
             for i, obj in enumerate(object_dicts):
                 offset_rows[i, 0] = cursor
@@ -1265,6 +1500,8 @@ class HDF5Writer:
                 pool_index = int(pool_name.split("_")[-1])
                 rows[f"_var_offsets_{pool_index}"] = offset_rows
 
+        # Commit fixed rows only after their variable offset columns have been
+        # populated. Event boundaries are appended last.
         first_object = len(fixed)
         fixed.resize(first_object + len(object_dicts), axis=0)
         if len(object_dicts):
@@ -1274,7 +1511,7 @@ class HDF5Writer:
 
     def append_key(
         self,
-        out_file: h5py.File,
+        out_file: h5py.Group,
         event: np.ndarray,
         data: dict[str, Any],
         key: str,
@@ -1336,7 +1573,7 @@ class HDF5Writer:
 
     @staticmethod
     def store(
-        out_file: h5py.File, event: np.ndarray, key: str, array: np.ndarray
+        out_file: h5py.Group, event: np.ndarray, key: str, array: np.ndarray
     ) -> None:
         """Stores an `ndarray` in the file and stores its mapping in the event
         dataset.
@@ -1369,7 +1606,7 @@ class HDF5Writer:
 
     @staticmethod
     def store_jagged(
-        out_file: h5py.File,
+        out_file: h5py.Group,
         event: np.ndarray,
         key: str,
         array_list: list[np.ndarray],
@@ -1431,7 +1668,10 @@ class HDF5Writer:
 
     @staticmethod
     def store_flat(
-        out_file: h5py.File, event: np.ndarray, key: str, array_list: list[np.ndarray]
+        out_file: h5py.Group,
+        event: np.ndarray,
+        key: str,
+        array_list: list[np.ndarray],
     ) -> None:
         """Stores a concatenated list of arrays in the file and stores its
         index mapping in the event dataset to break them.
@@ -1491,7 +1731,7 @@ class HDF5Writer:
 
     @staticmethod
     def store_objects(
-        out_file: h5py.File,
+        out_file: h5py.Group,
         event: np.ndarray,
         key: str,
         array: np.ndarray,

--- a/src/spine/io/write/hdf5.py
+++ b/src/spine/io/write/hdf5.py
@@ -37,6 +37,10 @@ class HDF5Writer:
     """
 
     name = "hdf5"
+    format_name = "spine_hdf5"
+    legacy_format_version = 1
+    current_format_version = 2
+    supported_format_versions = (legacy_format_version, current_format_version)
     source_index_keys = {
         "file_index": "source_file_index",
         "file_entry_index": "source_file_entry_index",
@@ -57,6 +61,7 @@ class HDF5Writer:
         lite: bool = False,
         keep_open: bool = True,
         flush_frequency: int | None = None,
+        format_version: int = legacy_format_version,
     ) -> None:
         """Initializes the basics of the output file.
 
@@ -97,6 +102,11 @@ class HDF5Writer:
             If specified, flush each output file after this many appended
             entries. If `None`, only flush when explicitly requested or when
             the file handle is closed.
+        format_version : int, default 1
+            Physical HDF5 layout version. Version 1 is the legacy
+            region-reference/VLEN layout. Version 2 stores event and object
+            boundaries as integer offsets and variable object attributes in
+            flat datasets.
         """
         # Build the output file name(s) from the input prefix(es) if not provided
         self.file_names = self.get_file_names(
@@ -119,6 +129,12 @@ class HDF5Writer:
         self.lite = lite
         self.keep_open = keep_open
         self.flush_frequency = flush_frequency
+        if format_version not in self.supported_format_versions:
+            raise ValueError(
+                f"Unsupported HDF5 format version {format_version}. Supported "
+                f"versions are {self.supported_format_versions}."
+            )
+        self.format_version = format_version
 
         self.keys = set(keys) if keys is not None else None
         self.skip_keys = skip_keys
@@ -276,6 +292,7 @@ class HDF5Writer:
                 self._check_handle_pid()
                 out_file = h5py.File(file_name, "a")
                 self._file_handles[file_id] = out_file
+                self._validate_append_format(out_file, file_name)
                 event_obj = out_file["events"]
                 assert isinstance(event_obj, h5py.Dataset), (
                     "Expected dataset for events to be a Dataset, but got "
@@ -285,6 +302,7 @@ class HDF5Writer:
                 out_file["info"].attrs["complete"] = False
             else:
                 with h5py.File(file_name, "a") as out_file:
+                    self._validate_append_format(out_file, file_name)
                     event_obj = out_file["events"]
                     assert isinstance(event_obj, h5py.Dataset), (
                         "Expected dataset for events to be a Dataset, but got "
@@ -304,19 +322,38 @@ class HDF5Writer:
             try:
                 out_file.create_group("info")
                 out_file["info"].attrs["version"] = __version__
+                out_file["info"].attrs["spine_version"] = __version__
+                out_file["info"].attrs["format"] = self.format_name
+                out_file["info"].attrs["format_version"] = self.format_version
                 out_file["info"].attrs["complete"] = False
                 if self._cfg is not None:
                     out_file["info"].attrs["cfg"] = yaml.dump(self._cfg)
                 assert (
                     self.type_dict is not None
                 ), "Cannot initialize an output file before data types are known."
-                self.initialize_datasets(out_file, self.type_dict)
+                if self.format_version == self.legacy_format_version:
+                    self.initialize_datasets(out_file, self.type_dict)
+                else:
+                    self.initialize_datasets_v2(out_file, self.type_dict)
             finally:
                 if not self.keep_open:
                     out_file.close()
 
         self._initialized_file_ids.add(file_id)
         self._entries_since_flush_by_file_id[file_id] = 0
+
+    def _validate_append_format(self, out_file: h5py.File, file_name: str) -> None:
+        """Ensure an existing output file uses the requested physical layout."""
+        if "info" not in out_file:
+            raise ValueError(f"Cannot append to '{file_name}': missing info group.")
+        stored_version = int(
+            out_file["info"].attrs.get("format_version", self.legacy_format_version)
+        )
+        if stored_version != self.format_version:
+            raise ValueError(
+                f"Cannot append HDF5 format version {self.format_version} to "
+                f"'{file_name}', which uses format version {stored_version}."
+            )
 
     @staticmethod
     def _ensure_parent_dir(file_name: str) -> None:
@@ -837,6 +874,117 @@ class HDF5Writer:
             "events", (0,), maxshape=(None,), dtype=self.event_dtype
         )
 
+    def initialize_datasets_v2(
+        self, out_file: h5py.File, type_dict: dict[str, DataFormat]
+    ) -> None:
+        """Create the offset-based version-2 dataset layout."""
+        self.event_dtype = np.dtype(np.int64)
+        for key, val in type_dict.items():
+            group = out_file.create_group(key)
+            group.attrs["scalar"] = val.scalar
+
+            if val.class_name is not None:
+                group.attrs["kind"] = "objects"
+                group.attrs["class_name"] = val.class_name
+                assert isinstance(val.dtype, list)
+                fixed_dtype, variable_pools = self.split_object_dtype_v2(val.dtype)
+                fixed_dtype.extend(
+                    (f"_var_offsets_{i}", np.int64, len(fields) + 1)
+                    for i, (_, _, fields) in enumerate(variable_pools)
+                )
+                group.create_dataset("fixed", (0,), maxshape=(None,), dtype=fixed_dtype)
+                group.create_dataset(
+                    "event_offsets",
+                    data=np.zeros(1, dtype=np.int64),
+                    maxshape=(None,),
+                )
+                variables = group.create_group("variables")
+                for i, (dtype, is_string, fields) in enumerate(variable_pools):
+                    pool = variables.create_group(f"pool_{i}")
+                    pool.attrs["kind"] = "string" if is_string else "array"
+                    pool.attrs["fields"] = yaml.safe_dump(fields)
+                    value_dtype = np.uint8 if is_string else dtype
+                    pool.create_dataset(
+                        "values", (0,), maxshape=(None,), dtype=value_dtype
+                    )
+
+            elif not isinstance(val.width, list):
+                dtype = np.dtype(val.dtype)
+                is_string = h5py.check_dtype(vlen=dtype) is str
+                group.attrs["kind"] = "string" if is_string else "array"
+                shape = (0, val.width) if val.width else (0,)
+                maxshape = (None, val.width) if val.width else (None,)
+                value_dtype = np.uint8 if is_string else val.dtype
+                group.create_dataset(
+                    "values", shape, maxshape=maxshape, dtype=value_dtype
+                )
+                group.create_dataset(
+                    "event_offsets",
+                    data=np.zeros(1, dtype=np.int64),
+                    maxshape=(None,),
+                )
+
+            elif val.merge:
+                group.attrs["kind"] = "list"
+                width = val.width[0]
+                shape = (0, width) if width else (0,)
+                maxshape = (None, width) if width else (None,)
+                group.create_dataset(
+                    "values", shape, maxshape=maxshape, dtype=val.dtype
+                )
+                group.create_dataset(
+                    "element_offsets",
+                    data=np.zeros(1, dtype=np.int64),
+                    maxshape=(None,),
+                )
+                group.create_dataset(
+                    "event_offsets",
+                    data=np.zeros(1, dtype=np.int64),
+                    maxshape=(None,),
+                )
+
+            else:
+                group.attrs["kind"] = "multi_list"
+                for i, width in enumerate(val.width):
+                    element = group.create_group(f"element_{i}")
+                    shape = (0, width) if width else (0,)
+                    maxshape = (None, width) if width else (None,)
+                    element.create_dataset(
+                        "values", shape, maxshape=maxshape, dtype=val.dtype
+                    )
+                    element.create_dataset(
+                        "event_offsets",
+                        data=np.zeros(1, dtype=np.int64),
+                        maxshape=(None,),
+                    )
+
+        # V2 retains an event axis for counting and future event-level metadata,
+        # but it contains no HDF5 references.
+        out_file.create_dataset(
+            "events", (0,), maxshape=(None,), dtype=self.event_dtype
+        )
+
+    @staticmethod
+    def split_object_dtype_v2(
+        obj_dtype: list[tuple[str, type]],
+    ) -> tuple[list[tuple[str, type]], list[tuple[np.dtype, bool, list[str]]]]:
+        """Separate fixed columns and pool VLEN columns by physical dtype."""
+        fixed_dtype = []
+        pool_map: dict[tuple[str, bool], tuple[np.dtype, bool, list[str]]] = {}
+        for spec in obj_dtype:
+            dtype = np.dtype(spec[1])
+            base = h5py.check_dtype(vlen=dtype)
+            if base is None:
+                fixed_dtype.append(spec)
+                continue
+            is_string = base is str
+            base_dtype = np.dtype(np.uint8 if is_string else base)
+            pool_key = (base_dtype.str, is_string)
+            if pool_key not in pool_map:
+                pool_map[pool_key] = (base_dtype, is_string, [])
+            pool_map[pool_key][2].append(spec[0])
+        return fixed_dtype, list(pool_map.values())
+
     def __call__(self, data: dict[str, Any], cfg: dict[str, Any] | None = None) -> None:
         """Append the HDF5 file with the content of a batch.
 
@@ -871,9 +1019,12 @@ class HDF5Writer:
         if not self.split or len(self.file_names) == 1:
             out_file, should_close = self._get_output_handle(0)
             try:
-                # Loop over batch IDs
-                for batch_id in range(batch_size):
-                    self.append_entry(out_file, data, batch_id)
+                batch_ids = np.arange(batch_size, dtype=np.int64)
+                if self.format_version == self.current_format_version:
+                    self.append_entries_v2(out_file, data, batch_ids)
+                else:
+                    for batch_id in batch_ids:
+                        self.append_entry(out_file, data, int(batch_id))
                 self._record_write(0, batch_size, out_file)
             finally:
                 if should_close:
@@ -887,8 +1038,11 @@ class HDF5Writer:
                 out_file, should_close = self._get_output_handle(int(file_id))
                 try:
                     batch_ids = np.where(file_ids == file_id)[0]
-                    for batch_id in batch_ids:
-                        self.append_entry(out_file, data, batch_id)
+                    if self.format_version == self.current_format_version:
+                        self.append_entries_v2(out_file, data, batch_ids)
+                    else:
+                        for batch_id in batch_ids:
+                            self.append_entry(out_file, data, int(batch_id))
                     self._record_write(int(file_id), len(batch_ids), out_file)
                 finally:
                     if should_close:
@@ -915,6 +1069,10 @@ class HDF5Writer:
         batch_id : int
             Batch ID to be stored
         """
+        if self.format_version == self.current_format_version:
+            self.append_entry_v2(out_file, data, batch_id)
+            return
+
         # Initialize a new event
         event = np.empty(1, self.event_dtype)
 
@@ -933,6 +1091,186 @@ class HDF5Writer:
         event_id = len(event_ds)
         event_ds.resize(event_id + 1, axis=0)  # pylint: disable=E1101
         event_ds[event_id] = event
+
+    def append_entry_v2(
+        self, out_file: h5py.File, data: dict[str, Any], batch_id: int
+    ) -> None:
+        """Append one entry using flat values and integer offsets."""
+        self.append_entries_v2(out_file, data, np.asarray([batch_id], dtype=np.int64))
+
+    def append_entries_v2(
+        self, out_file: h5py.File, data: dict[str, Any], batch_ids: np.ndarray
+    ) -> None:
+        """Append a batch while resizing each V2 dataset only once."""
+        assert self.keys is not None
+        for key in self.keys:
+            self.append_key_batch_v2(out_file, data, key, batch_ids)
+
+        events = out_file["events"]
+        assert isinstance(events, h5py.Dataset)
+        event_id = len(events)
+        events.resize(event_id + len(batch_ids), axis=0)
+        events[event_id:] = np.arange(
+            event_id, event_id + len(batch_ids), dtype=np.int64
+        )
+
+    def append_key_batch_v2(
+        self,
+        out_file: h5py.File,
+        data: dict[str, Any],
+        key: str,
+        batch_ids: np.ndarray,
+    ) -> None:
+        """Append multiple events for one V2 product in collective slices."""
+        assert self.type_dict is not None
+        val = self.type_dict[key]
+        group = out_file[key]
+        assert isinstance(group, h5py.Group)
+        kind = group.attrs["kind"]
+
+        if kind == "objects":
+            batches = []
+            for batch_id in batch_ids:
+                obj = data[key] if np.isscalar(data[key]) else data[key][batch_id]
+                batches.append([obj] if val.scalar else obj)
+            self.store_object_batches_v2(group, batches, self.lite)
+            return
+
+        if kind in {"array", "string"}:
+            arrays = []
+            for batch_id in batch_ids:
+                if np.isscalar(data[key]):
+                    value = data[key]
+                else:
+                    value = data[key][batch_id]
+                if kind == "string":
+                    array = np.frombuffer(str(value).encode("utf-8"), dtype=np.uint8)
+                else:
+                    array = np.asarray([value]) if val.scalar else np.asarray(value)
+                arrays.append(array)
+            self.append_array_batch_v2(group, arrays)
+            return
+
+        array_lists = [data[key][batch_id] for batch_id in batch_ids]
+        if kind == "list":
+            arrays = [array for array_list in array_lists for array in array_list]
+            self.append_values_with_offsets_v2(
+                group["values"], group["element_offsets"], arrays
+            )
+            event_offsets = group["event_offsets"]
+            counts = [len(array_list) for array_list in array_lists]
+            self.append_lengths_v2(event_offsets, counts)
+            return
+
+        assert kind == "multi_list"
+        for i, name in enumerate(
+            sorted(group.keys(), key=lambda item: int(item.split("_")[-1]))
+        ):
+            element = group[name]
+            assert isinstance(element, h5py.Group)
+            self.append_array_batch_v2(
+                element, [array_list[i] for array_list in array_lists]
+            )
+
+    @staticmethod
+    def append_lengths_v2(offsets: h5py.Dataset, lengths: Any) -> None:
+        """Append terminal offsets derived from a sequence of lengths."""
+        lengths = np.asarray(lengths, dtype=np.int64)
+        if not len(lengths):
+            return
+        first = len(offsets) - 1
+        base = int(offsets[first])
+        offsets.resize(len(offsets) + len(lengths), axis=0)
+        offsets[first + 1 :] = base + np.cumsum(lengths)
+
+    @classmethod
+    def append_values_with_offsets_v2(
+        cls,
+        values: h5py.Dataset,
+        offsets: h5py.Dataset,
+        arrays: list[np.ndarray],
+    ) -> None:
+        """Append multiple variable arrays with one values resize and one offset resize."""
+        lengths = np.asarray([len(array) for array in arrays], dtype=np.int64)
+        first = len(values)
+        combined = np.concatenate(arrays) if arrays else np.empty(0, dtype=values.dtype)
+        values.resize(first + len(combined), axis=0)
+        if len(combined):
+            values[first:] = combined
+        cls.append_lengths_v2(offsets, lengths)
+
+    @classmethod
+    def append_array_batch_v2(cls, group: h5py.Group, arrays: list[np.ndarray]) -> None:
+        """Append several event arrays while resizing values and offsets once."""
+        values = group["values"]
+        offsets = group["event_offsets"]
+        assert isinstance(values, h5py.Dataset)
+        assert isinstance(offsets, h5py.Dataset)
+        cls.append_values_with_offsets_v2(values, offsets, arrays)
+
+    @classmethod
+    def store_object_batches_v2(
+        cls, group: h5py.Group, batches: list[Any], lite: bool
+    ) -> None:
+        """Store several events of objects with collective dataset appends."""
+        fixed = group["fixed"]
+        event_offsets = group["event_offsets"]
+        variables = group["variables"]
+        assert isinstance(fixed, h5py.Dataset)
+        assert isinstance(event_offsets, h5py.Dataset)
+        assert isinstance(variables, h5py.Group)
+
+        object_dicts = [obj.as_dict(lite) for batch in batches for obj in batch]
+        rows = np.empty(len(object_dicts), dtype=fixed.dtype)
+        if object_dicts:
+            for name in fixed.dtype.names or ():
+                if not name.startswith("_var_offsets_"):
+                    rows[name] = [obj[name] for obj in object_dicts]
+
+        for pool_name, pool in variables.items():
+            assert isinstance(pool, h5py.Group)
+            values = pool["values"]
+            assert isinstance(values, h5py.Dataset)
+            is_string = pool.attrs["kind"] == "string"
+            fields = yaml.safe_load(pool.attrs["fields"])
+            chunks = []
+            offset_rows = np.empty((len(object_dicts), len(fields) + 1), dtype=np.int64)
+            cursor = len(values)
+            for i, obj in enumerate(object_dicts):
+                offset_rows[i, 0] = cursor
+                for j, name in enumerate(fields):
+                    value = obj[name]
+                    if is_string:
+                        chunk = np.frombuffer(value.encode("utf-8"), dtype=np.uint8)
+                    else:
+                        chunk = np.asarray(value)
+                        if chunk.ndim != 1:
+                            raise ValueError(
+                                f"V2 variable object field '{name}' must be "
+                                f"one-dimensional, got shape {chunk.shape}."
+                            )
+                    chunks.append(chunk)
+                    cursor += len(chunk)
+                    offset_rows[i, j + 1] = cursor
+
+            first_value = len(values)
+            combined = (
+                np.concatenate(chunks) if chunks else np.empty(0, dtype=values.dtype)
+            )
+            values.resize(first_value + len(combined), axis=0)
+            if len(combined):
+                values[first_value:] = combined
+
+            if len(object_dicts):
+                pool_index = int(pool_name.split("_")[-1])
+                rows[f"_var_offsets_{pool_index}"] = offset_rows
+
+        first_object = len(fixed)
+        fixed.resize(first_object + len(object_dicts), axis=0)
+        if len(object_dicts):
+            fixed[first_object:] = rows
+
+        cls.append_lengths_v2(event_offsets, [len(batch) for batch in batches])
 
     def append_key(
         self,

--- a/src/spine/io/write/stage_hdf5.py
+++ b/src/spine/io/write/stage_hdf5.py
@@ -133,6 +133,7 @@ class StageHDF5Writer(HDF5Writer):
         self.lite = lite
         self.keep_open = keep_open
         self.flush_frequency = flush_frequency
+        self.format_version = self.legacy_format_version
         self.source_info: dict[str, Any] | None = None
 
         self.keys = set(keys) if keys is not None else None
@@ -261,7 +262,9 @@ class StageHDF5Writer(HDF5Writer):
             if "info" not in out_file:
                 out_file.create_group("info")
             out_file["info"].attrs["version"] = __version__
+            out_file["info"].attrs["spine_version"] = __version__
             out_file["info"].attrs["format"] = self.name
+            out_file["info"].attrs["format_version"] = self.format_version
 
             if "stages" not in out_file:
                 out_file.create_group("stages")

--- a/src/spine/io/write/stage_hdf5.py
+++ b/src/spine/io/write/stage_hdf5.py
@@ -108,6 +108,14 @@ class StageHDF5Writer(HDF5Writer):
             `None`, only flush on explicit requests or close/finalize.
         overwrite : bool, default False
             If `True`, replace the entire cache file if it already exists.
+
+        Notes
+        -----
+        Stage-cache files have a different, multi-stage schema and are not the
+        flat event files targeted by HDF5 format V2. They deliberately retain
+        the legacy V1 product layout. Recording ``format_version=1`` makes that
+        choice explicit for inspection tools without implying that staged
+        caches can be switched to V2 through writer configuration.
         """
         self._handle_pid: int | None = None
         self._handles: dict[str, h5py.File] = {}
@@ -133,6 +141,9 @@ class StageHDF5Writer(HDF5Writer):
         self.lite = lite
         self.keep_open = keep_open
         self.flush_frequency = flush_frequency
+        # StageHDF5Writer reuses V1 serialization helpers but owns a distinct
+        # container schema. Pin the inherited version attribute explicitly so
+        # future changes to the flat-writer default cannot alter stage caches.
         self.format_version = self.legacy_format_version
         self.source_info: dict[str, Any] | None = None
 
@@ -225,7 +236,7 @@ class StageHDF5Writer(HDF5Writer):
             Open HDF5 handle and a flag indicating whether the caller is
             responsible for closing it immediately.
         """
-        self._ensure_file(file_path)
+        self._ensure_stage_file(file_path)
         if not self.keep_open:
             return h5py.File(file_path, "a"), True
 
@@ -237,7 +248,7 @@ class StageHDF5Writer(HDF5Writer):
 
         return handle, False
 
-    def _ensure_file(self, file_path: str) -> None:
+    def _ensure_stage_file(self, file_path: str) -> None:
         """Initialize one output cache file structure on first use.
 
         The top-level administrative groups are created lazily because staged
@@ -301,7 +312,7 @@ class StageHDF5Writer(HDF5Writer):
         for key in required:
             value = data[key]
             if np.isscalar(value):
-                values[key] = value.item() if hasattr(value, "item") else value
+                values[key] = value.item() if isinstance(value, np.generic) else value
                 continue
 
             array = np.asarray(value)
@@ -654,7 +665,10 @@ class StageHDF5Writer(HDF5Writer):
                     continue
 
                 stage_group = stages[stage]
-                stage_group["info"].attrs["complete"] = True
+                assert isinstance(stage_group, h5py.Group)
+                info = stage_group["info"]
+                assert isinstance(info, h5py.Group)
+                info.attrs["complete"] = True
                 out_file.flush()
                 self._completed_stages[file_path].add(stage)
             finally:

--- a/test/test_ana/test_base.py
+++ b/test/test_ana/test_base.py
@@ -19,6 +19,11 @@ class DummyAna(AnaBase):
         return {"updated": data["value"] + 1}
 
 
+class ColumnarDummyAna(DummyAna):
+    def process_columnar(self, data):
+        return {"updated": [value + 1 for value in data["value"]]}
+
+
 class DummyWriter:
     def __init__(self, file_name, append=False, overwrite=False, buffer_size=1):
         self.file_name = file_name
@@ -130,3 +135,39 @@ def test_ana_base_reports_missing_required_input():
 
     with pytest.raises(KeyError, match="missing an essential"):
         ana({"index": 0, "file_index": 0})
+
+
+def test_ana_base_dispatches_optional_columnar_hook():
+    ana = ColumnarDummyAna()
+    ana.update_keys({"value": True, "optional": False})
+    data = {
+        "index": [0, 1],
+        "file_index": [2, 2],
+        "value": [4, 8],
+        "unrequested": [10, 20],
+    }
+
+    assert ana.supports_columnar
+    assert ana.run_columnar(data) == {"updated": [5, 9]}
+
+
+def test_ana_base_rejects_unsupported_columnar_execution():
+    ana = DummyAna()
+
+    assert not ana.supports_columnar
+    with pytest.raises(NotImplementedError, match="does not implement"):
+        ana.run_columnar({"index": [0], "file_index": [0]})
+    with pytest.raises(NotImplementedError):
+        ana.process_columnar({})
+
+
+def test_ana_base_reports_missing_required_columnar_inputs():
+    """Columnar filtering should validate administrative and product inputs."""
+    ana = ColumnarDummyAna()
+    ana.update_keys({"value": True})
+
+    with pytest.raises(KeyError, match="`index`"):
+        ana.run_columnar({"file_index": [0], "value": [1]})
+
+    with pytest.raises(KeyError, match="`value`"):
+        ana.run_columnar({"index": [0], "file_index": [0]})

--- a/test/test_ana/test_columnar.py
+++ b/test/test_ana/test_columnar.py
@@ -1,0 +1,94 @@
+"""End-to-end tests for configurable columnar analysis execution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from spine.data import ObjectList, RecoParticle, RunInfo, TruthParticle
+from spine.driver import Driver
+from spine.io.write import HDF5Writer
+
+
+def _config(path: Path, log_dir: Path, columnar: bool) -> dict:
+    return {
+        "base": {
+            "iterations": -1,
+            "log_dir": str(log_dir),
+            "overwrite_log": True,
+            "verbosity": "critical",
+        },
+        "io": {
+            "reader": {
+                "name": "hdf5",
+                "file_keys": str(path),
+                "columnar": columnar,
+                "chunk_size": 2,
+            }
+        },
+        "ana": {
+            "overwrite": True,
+            "save": {
+                "obj_type": "particle",
+                "particle": ["id", "pid", "size"],
+                "run_mode": "both",
+                "match_mode": "reco_to_truth",
+            },
+        },
+    }
+
+
+def _run(config: dict) -> None:
+    driver = Driver(config)
+    assert driver.iterations is not None
+    for iteration in range(driver.iterations):
+        driver.process(
+            entry=iteration,
+            iteration=iteration,
+            epoch=(iteration + 1) / driver.io.iter_per_epoch,
+        )
+    driver.cleanup()
+
+
+def test_configured_event_and_columnar_save_are_identical(tmp_path):
+    """Reader policy should switch execution without changing CSV content."""
+    path = tmp_path / "objects.h5"
+    truth = TruthParticle(
+        id=0,
+        pid=2,
+        index=np.asarray([1, 2], dtype=np.int32),
+    )
+    reco = RecoParticle(
+        id=0,
+        pid=2,
+        index=np.asarray([1, 2], dtype=np.int32),
+        is_matched=True,
+        match_ids=np.asarray([0], dtype=np.int32),
+        match_overlaps=np.asarray([0.75], dtype=np.float32),
+    )
+    data = {
+        "index": np.asarray([0, 1]),
+        "run_info": [
+            RunInfo(run=1, event=10),
+            RunInfo(run=1, event=11),
+        ],
+        "reco_particles": [
+            ObjectList([reco], RecoParticle()),
+            ObjectList([], RecoParticle()),
+        ],
+        "truth_particles": [
+            ObjectList([truth], TruthParticle()),
+            ObjectList([], TruthParticle()),
+        ],
+    }
+    with HDF5Writer(str(path), overwrite=True, format_version=2) as writer:
+        writer(data, cfg={})
+
+    event_dir = tmp_path / "event"
+    columnar_dir = tmp_path / "columnar"
+    _run(_config(path, event_dir, False))
+    _run(_config(path, columnar_dir, True))
+
+    for name in ("save_reco_particles.csv", "save_truth_particles.csv"):
+        assert (event_dir / name).read_bytes() == (columnar_dir / name).read_bytes()

--- a/test/test_ana/test_manager.py
+++ b/test/test_ana/test_manager.py
@@ -20,6 +20,17 @@ class FakeAnaModule:
             return {"value": data["index"] + self.cfg["offset"]}
         return {"value": data["index"][entry] + self.cfg["offset"]}
 
+    @property
+    def supports_columnar(self):
+        return self.cfg.get("columnar", False)
+
+    def run_columnar(self, data):
+        self.calls.append((self.name, "columnar"))
+        return {"value": [value + self.cfg["offset"] for value in data["index"]]}
+
+    def columnar_requests(self):
+        return self.cfg.get("requests", {})
+
     def close_writers(self):
         self.closed = True
 
@@ -95,3 +106,89 @@ def test_ana_manager_validates_global_options():
 
     with pytest.raises(TypeError, match="buffer_size"):
         AnaManager({"buffer_size": 1.5})
+
+    with pytest.raises(TypeError, match="columnar"):
+        AnaManager({}, columnar=1)
+
+
+def test_ana_manager_runs_supported_columnar_modules(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        manager_mod,
+        "ana_script_factory",
+        lambda name, cfg, *args: FakeAnaModule(name, cfg, calls),
+    )
+    manager = AnaManager(
+        {"demo": {"offset": 10, "columnar": True}},
+        columnar=True,
+    )
+    data = {"index": [1, 2, 3]}
+
+    assert manager.supports_columnar
+    manager.process_columnar(data)
+
+    assert data["value"] == [11, 12, 13]
+    assert calls == [("demo", "columnar")]
+
+
+def test_ana_manager_preflights_unsupported_columnar_modules(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        manager_mod,
+        "ana_script_factory",
+        lambda name, cfg, *args: FakeAnaModule(name, cfg, calls),
+    )
+    with pytest.raises(ValueError, match="event_only"):
+        AnaManager(
+            {
+                "supported": {"priority": 2, "offset": 10, "columnar": True},
+                "event_only": {"priority": 1, "offset": 20},
+            },
+            columnar=True,
+        )
+    assert calls == []
+
+
+def test_ana_manager_rejects_columnar_call_in_event_mode(monkeypatch):
+    """An event-mode manager should not accept columnar execution."""
+    calls = []
+    monkeypatch.setattr(
+        manager_mod,
+        "ana_script_factory",
+        lambda name, cfg, *args: FakeAnaModule(name, cfg, calls),
+    )
+    manager = AnaManager({"demo": {"offset": 10, "columnar": True}})
+
+    with pytest.raises(RuntimeError, match="not configured"):
+        manager.process_columnar({"index": [1, 2, 3]})
+
+
+def test_ana_manager_merges_columnar_requests(monkeypatch):
+    """Repeated projections should union fields and preserve requiredness."""
+    calls = []
+    monkeypatch.setattr(
+        manager_mod,
+        "ana_script_factory",
+        lambda name, cfg, *args: FakeAnaModule(name, cfg, calls),
+    )
+    manager = AnaManager(
+        {
+            "first": {
+                "requests": {
+                    "particles": (("id",), False),
+                    "all_fields": (None, False),
+                }
+            },
+            "second": {
+                "requests": {
+                    "particles": (("pid",), True),
+                    "all_fields": (("size",), True),
+                }
+            },
+        }
+    )
+
+    assert manager.columnar_requests() == {
+        "particles": (("id", "pid"), True),
+        "all_fields": (None, True),
+    }

--- a/test/test_ana/test_save.py
+++ b/test/test_ana/test_save.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 from spine.ana.script.save import SaveAna
+from spine.data import RecoParticle
 
 
 class FakeObject:
@@ -16,6 +18,12 @@ class FakeObject:
 
 
 class FakeWriter:
+    def __init__(self):
+        self.columns = []
+
+    def append_columns(self, data):
+        self.columns.append(data)
+
     def close(self):
         pass
 
@@ -121,3 +129,73 @@ def test_save_ana_uses_default_object_for_missing_match(monkeypatch):
             {"reco_id": 1, "truth_id": -1, "match_overlap": 0.2},
         )
     ]
+
+
+def test_save_ana_columnar_joins_best_matches():
+    ana = SaveAna(
+        obj_type="particle",
+        particle=("id", "pid", "size"),
+        match_mode="reco_to_truth",
+    )
+    data = {
+        "index": np.asarray([0, 1]),
+        "file_index": np.asarray([0, 0]),
+        "file_entry_index": np.asarray([0, 1]),
+        "reco_particles": {
+            "id": np.asarray([0, 1, 0]),
+            "pid": np.asarray([2, 4, 3]),
+            "size": np.asarray([10, 20, 30]),
+            "best_match_id": np.asarray([0, -1, 0]),
+            "best_match_overlap": np.asarray([0.8, -1.0, 0.6]),
+            "event_offsets": np.asarray([0, 2, 3]),
+        },
+        "truth_particles": {
+            "id": np.asarray([0, 0]),
+            "pid": np.asarray([2, 3]),
+            "size": np.asarray([12, 28]),
+            "event_offsets": np.asarray([0, 1, 2]),
+        },
+    }
+
+    ana.process_columnar(data)
+
+    reco = ana.writers["reco_particles"].columns[0]
+    assert reco["index"].tolist() == [0, 0, 1]
+    assert reco["reco_id"].tolist() == [0, 1, 0]
+    assert reco["truth_pid"].tolist() == [2, -1, 3]
+    assert reco["truth_size"].tolist() == [12, 0, 28]
+    assert reco["match_overlap"].tolist() == [0.8, -1.0, 0.6]
+
+    truth = ana.writers["truth_particles"].columns[0]
+    assert truth["index"].tolist() == [0, 1]
+    assert truth["id"].tolist() == [0, 0]
+
+
+def test_save_ana_validates_columnar_attributes():
+    """Columnar save requires explicit, fixed-width object attributes."""
+    implicit = SaveAna(obj_type="particle", run_mode="reco", match_mode=None)
+    with pytest.raises(ValueError, match="explicit attribute"):
+        implicit.columnar_requests()
+
+    variable = SaveAna(
+        obj_type="particle",
+        particle=("index",),
+        run_mode="reco",
+        match_mode=None,
+    )
+    with pytest.raises(ValueError, match="variable fields"):
+        variable.columnar_requests()
+
+
+def test_save_ana_expands_fixed_width_columnar_attributes():
+    """Fixed vectors should expand into named scalar output columns."""
+    product = {"start_point": np.asarray([[1.0, 2.0, 3.0]], dtype=np.float32)}
+    columns = SaveAna._expand_columnar_attrs(product, ("start_point",), RecoParticle())
+    assert list(columns) == ["start_point_x", "start_point_y", "start_point_z"]
+
+    with pytest.raises(ValueError, match="scalar or fixed-width"):
+        SaveAna._expand_columnar_attrs(
+            {"start_point": np.zeros((1, 2, 3))},
+            ("start_point",),
+            RecoParticle(),
+        )

--- a/test/test_ana/test_template.py
+++ b/test/test_ana/test_template.py
@@ -36,3 +36,28 @@ def test_template_ana_process_writes_displacements(monkeypatch):
     ana.process({"prod": {"reco_particles": [FakeObject()]}})
 
     assert rows == [("template", {"disp_x": 3.0, "disp_y": 4.0, "disp_z": 5.0})]
+
+
+def test_template_ana_processes_projected_columns(monkeypatch):
+    monkeypatch.setattr(TemplateAna, "initialize_writer", lambda self, name: None)
+    ana = TemplateAna("a", "b")
+    starts = np.asarray([[1.0, 2.0, 3.0], [0.0, 1.0, 2.0]])
+    ends = np.asarray([[4.0, 6.0, 8.0], [3.0, 3.0, 3.0]])
+    offsets = np.asarray([0, 1, 2], dtype=np.int64)
+
+    result = ana.process_columnar(
+        {
+            "prod": {
+                "start_point": starts,
+                "end_point": ends,
+                "event_offsets": offsets,
+            }
+        }
+    )
+
+    assert ana.supports_columnar
+    assert np.array_equal(
+        result["displacements"]["values"],
+        np.asarray([[3.0, 4.0, 5.0], [3.0, 2.0, 1.0]]),
+    )
+    assert result["displacements"]["event_offsets"] is offsets

--- a/test/test_bin/test_larcv_utils.py
+++ b/test/test_bin/test_larcv_utils.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 
 def load_larcv_utils():
     """Import ``bin/larcv/utils.py`` as a test module."""
@@ -37,6 +39,31 @@ class FakeFile:
 
     def Get(self, name):
         return object()
+
+
+def test_resolve_sources_accepts_direct_paths_and_text_lists(tmp_path):
+    """Input paths should resolve consistently from either CLI representation."""
+    module = load_larcv_utils()
+
+    assert module.resolve_sources(("a.root", "b.root"), None) == [
+        "a.root",
+        "b.root",
+    ]
+
+    source_list = tmp_path / "files.txt"
+    source_list.write_text("c.root\nd.root\n", encoding="utf-8")
+    assert module.resolve_sources(None, str(source_list)) == [
+        "c.root",
+        "d.root",
+    ]
+
+
+def test_resolve_sources_rejects_missing_input():
+    """Direct Python calls should receive the same guard as the CLI."""
+    module = load_larcv_utils()
+
+    with pytest.raises(ValueError, match="source"):
+        module.resolve_sources(None, None)
 
 
 def test_tree_lookup_uses_larcv_tree_names_and_typed_attributes():

--- a/test/test_bin/test_output_compare.py
+++ b/test/test_bin/test_output_compare.py
@@ -1,0 +1,233 @@
+"""Tests for the SPINE HDF5 output comparison utility."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+
+def load_output_compare_module():
+    """Import ``bin/output/output_compare.py`` as a test module."""
+    script_path = (
+        Path(__file__).resolve().parents[2] / "bin" / "output" / "output_compare.py"
+    )
+    spec = importlib.util.spec_from_file_location("output_compare", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_output_file(
+    path: Path,
+    values: list[np.ndarray],
+    *,
+    labels: list[np.ndarray] | None = None,
+) -> None:
+    """Create a minimal multi-event SPINE-style HDF5 output."""
+    ref_dtype = h5py.special_dtype(ref=h5py.RegionReference)
+    event_dtype = [("values", ref_dtype)]
+    if labels is not None:
+        event_dtype.append(("labels", ref_dtype))
+
+    with h5py.File(path, "w") as out_file:
+        events = out_file.create_dataset(
+            "events", (len(values),), dtype=np.dtype(event_dtype)
+        )
+        flat_values = np.concatenate(values)
+        value_ds = out_file.create_dataset("values", data=flat_values, maxshape=(None,))
+        value_ds.attrs["scalar"] = False
+
+        labels_ds = None
+        if labels is not None:
+            flat_labels = np.concatenate(labels)
+            labels_ds = out_file.create_dataset(
+                "labels", data=flat_labels, maxshape=(None,)
+            )
+            labels_ds.attrs["scalar"] = False
+
+        value_offset = 0
+        label_offset = 0
+        for idx, event_values in enumerate(values):
+            event = np.zeros(1, dtype=np.dtype(event_dtype))
+            value_end = value_offset + len(event_values)
+            event["values"][0] = value_ds.regionref[value_offset:value_end]
+            value_offset = value_end
+            if labels is not None and labels_ds is not None:
+                label_end = label_offset + len(labels[idx])
+                event["labels"][0] = labels_ds.regionref[label_offset:label_end]
+                label_offset = label_end
+            events[idx] = event[0]
+
+
+def test_compare_files_exact_match(tmp_path):
+    """Identical semantic content should pass exact comparison."""
+    module = load_output_compare_module()
+    reference = tmp_path / "reference.h5"
+    candidate = tmp_path / "candidate.h5"
+    values = [
+        np.asarray([1.0, np.nan], dtype=np.float32),
+        np.asarray([], dtype=np.float32),
+    ]
+    make_output_file(reference, values)
+    make_output_file(candidate, values)
+
+    result = module.compare_files(reference, candidate, exact=True)
+
+    assert result.agrees
+    assert result.num_events == 2
+    assert result.num_products == 2
+    assert result.num_values == 2
+
+
+def test_compare_files_float_tolerance_and_exact(tmp_path):
+    """Tolerant comparison should accept noise that exact mode rejects."""
+    module = load_output_compare_module()
+    reference = tmp_path / "reference.h5"
+    candidate = tmp_path / "candidate.h5"
+    make_output_file(reference, [np.asarray([1.0, 0.0], dtype=np.float32)])
+    make_output_file(candidate, [np.asarray([1.0 + 5.0e-5, 5.0e-7], dtype=np.float32)])
+
+    tolerant = module.compare_files(reference, candidate, rtol=1.0e-4, atol=1.0e-6)
+    exact = module.compare_files(reference, candidate, exact=True)
+
+    assert tolerant.agrees
+    assert not exact.agrees
+    assert exact.num_mismatches == 1
+    assert "event[0].values[0]" in exact.differences[0]
+
+
+def test_compare_files_exact_non_float_and_schema(tmp_path):
+    """Non-floating data and event-product schemas must agree exactly."""
+    module = load_output_compare_module()
+    reference = tmp_path / "reference.h5"
+    candidate = tmp_path / "candidate.h5"
+    make_output_file(
+        reference,
+        [np.asarray([1.0], dtype=np.float32)],
+        labels=[np.asarray([1, 2], dtype=np.int64)],
+    )
+    make_output_file(
+        candidate,
+        [np.asarray([1.0], dtype=np.float32)],
+        labels=[np.asarray([1, 3], dtype=np.int64)],
+    )
+
+    result = module.compare_files(reference, candidate)
+
+    assert not result.agrees
+    assert result.num_mismatches == 1
+    assert "event[0].labels[1]" in result.differences[0]
+
+
+def test_compare_files_shape_and_event_count(tmp_path):
+    """Shape and event-count differences should produce clear failures."""
+    module = load_output_compare_module()
+    reference = tmp_path / "reference.h5"
+    shape_candidate = tmp_path / "shape.h5"
+    count_candidate = tmp_path / "count.h5"
+    make_output_file(reference, [np.asarray([1.0, 2.0], dtype=np.float32)])
+    make_output_file(shape_candidate, [np.asarray([1.0], dtype=np.float32)])
+    make_output_file(
+        count_candidate,
+        [
+            np.asarray([1.0, 2.0], dtype=np.float32),
+            np.asarray([3.0], dtype=np.float32),
+        ],
+    )
+
+    shape_result = module.compare_files(reference, shape_candidate)
+    count_result = module.compare_files(reference, count_candidate)
+
+    assert "shape differs" in shape_result.differences[0]
+    assert "count differs" in count_result.differences[0]
+
+
+def test_compare_files_key_selection(tmp_path):
+    """Key inclusion and exclusion should limit compared products."""
+    module = load_output_compare_module()
+    reference = tmp_path / "reference.h5"
+    candidate = tmp_path / "candidate.h5"
+    make_output_file(
+        reference,
+        [np.asarray([1.0], dtype=np.float32)],
+        labels=[np.asarray([1], dtype=np.int64)],
+    )
+    make_output_file(
+        candidate,
+        [np.asarray([2.0], dtype=np.float32)],
+        labels=[np.asarray([1], dtype=np.int64)],
+    )
+
+    included = module.compare_files(reference, candidate, keys=["labels"])
+    skipped = module.compare_files(reference, candidate, skip_keys=["values"])
+    missing = module.compare_files(reference, candidate, keys=["unknown"])
+
+    assert included.agrees
+    assert skipped.agrees
+    assert not missing.agrees
+    assert "missing products" in missing.differences[0]
+
+
+def test_compare_values_structured_and_object_fields():
+    """Structured variable-length object fields should compare recursively."""
+    module = load_output_compare_module()
+    dtype = np.dtype(
+        [("id", np.int64), ("scores", h5py.vlen_dtype(np.dtype("float32")))]
+    )
+    reference = np.empty(1, dtype=dtype)
+    candidate = np.empty(1, dtype=dtype)
+    reference["id"] = 4
+    candidate["id"] = 4
+    reference["scores"][0] = np.asarray([0.1, 0.2], dtype=np.float32)
+    candidate["scores"][0] = np.asarray([0.1, 0.3], dtype=np.float32)
+    result = module.ComparisonResult()
+
+    module.compare_values(
+        reference,
+        candidate,
+        "event[0].objects",
+        result,
+        rtol=0.0,
+        atol=0.0,
+        exact=True,
+    )
+
+    assert not result.agrees
+    assert "objects.scores[0][1]" in result.differences[0]
+
+
+def test_compare_files_rejects_invalid_options(tmp_path):
+    """Negative tolerances and report bounds should be rejected."""
+    module = load_output_compare_module()
+    path = tmp_path / "output.h5"
+    make_output_file(path, [np.asarray([1.0], dtype=np.float32)])
+
+    for kwargs in ({"rtol": -1.0}, {"atol": -1.0}, {"max_differences": -1}):
+        try:
+            module.compare_files(path, path, **kwargs)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"Expected ValueError for {kwargs}")
+
+
+def test_format_result():
+    """The text report should expose status, mode, and bounded differences."""
+    module = load_output_compare_module()
+    result = module.ComparisonResult(max_differences=1)
+    result.add_difference("event[0].x", "first")
+    result.add_difference("event[0].y", "second")
+
+    report = module.format_result(
+        result, "reference.h5", "candidate.h5", rtol=1.0e-4, atol=1.0e-6, exact=False
+    )
+
+    assert report.startswith("FAIL:")
+    assert "rtol=0.0001, atol=1e-06" in report
+    assert "1 additional mismatches not shown" in report

--- a/test/test_bin/test_output_compare.py
+++ b/test/test_bin/test_output_compare.py
@@ -9,6 +9,9 @@ from pathlib import Path
 import h5py
 import numpy as np
 
+from spine.data import ObjectList, RecoParticle
+from spine.io.write import HDF5Writer
+
 
 def load_output_compare_module():
     """Import ``bin/output/output_compare.py`` as a test module."""
@@ -65,6 +68,44 @@ def make_output_file(
             events[idx] = event[0]
 
 
+def make_versioned_output(path: Path, format_version: int) -> None:
+    """Write representative semantic content in either physical layout."""
+    particle = RecoParticle(
+        id=4,
+        index=np.asarray([1, 3, 8], dtype=np.int32),
+        match_ids=np.asarray([12], dtype=np.int32),
+        match_overlaps=np.asarray([0.5], dtype=np.float32),
+    )
+    data = {
+        "index": np.asarray([0, 1]),
+        "label": ["first", "second"],
+        "particles": [
+            ObjectList([particle], RecoParticle()),
+            ObjectList([], RecoParticle()),
+        ],
+        "tensor": [
+            np.arange(6, dtype=np.float32).reshape(3, 2),
+            np.ones((1, 2), dtype=np.float32),
+        ],
+        "clusters": [
+            [np.asarray([1, 2]), np.asarray([3])],
+            [np.asarray([], dtype=np.int64)],
+        ],
+        "features": [
+            [
+                np.ones((2, 2), dtype=np.float32),
+                np.ones((3, 3), dtype=np.float32),
+            ],
+            [
+                np.zeros((1, 2), dtype=np.float32),
+                np.zeros((2, 3), dtype=np.float32),
+            ],
+        ],
+    }
+    with HDF5Writer(str(path), overwrite=True, format_version=format_version) as writer:
+        writer(data, cfg={})
+
+
 def test_compare_files_exact_match(tmp_path):
     """Identical semantic content should pass exact comparison."""
     module = load_output_compare_module()
@@ -83,6 +124,38 @@ def test_compare_files_exact_match(tmp_path):
     assert result.num_events == 2
     assert result.num_products == 2
     assert result.num_values == 2
+
+
+def test_compare_files_v1_v2_semantic_match(tmp_path):
+    """Physical V1 and V2 layouts should compare by reconstructed content."""
+    module = load_output_compare_module()
+    reference = tmp_path / "v1.h5"
+    candidate = tmp_path / "v2.h5"
+    make_versioned_output(reference, 1)
+    make_versioned_output(candidate, 2)
+
+    result = module.compare_files(reference, candidate, exact=True)
+
+    assert result.agrees, result.differences
+    assert result.num_events == 2
+    assert result.num_products == 12
+    assert result.num_values > 0
+
+
+def test_compare_files_v2_reports_semantic_difference(tmp_path):
+    """V2 values should retain ordinary event/product mismatch paths."""
+    module = load_output_compare_module()
+    reference = tmp_path / "reference_v2.h5"
+    candidate = tmp_path / "candidate_v2.h5"
+    make_versioned_output(reference, 2)
+    make_versioned_output(candidate, 2)
+    with h5py.File(candidate, "a") as out_file:
+        out_file["tensor"]["values"][0, 0] += 1.0
+
+    result = module.compare_files(reference, candidate, exact=True)
+
+    assert not result.agrees
+    assert "event[0].tensor[0][0]" in result.differences[0]
 
 
 def test_compare_files_float_tolerance_and_exact(tmp_path):

--- a/test/test_bin/test_output_litify.py
+++ b/test/test_bin/test_output_litify.py
@@ -1,0 +1,53 @@
+"""Tests for the structural HDF5 litification CLI."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def load_output_litify_module():
+    """Import ``bin/output/output_litify.py`` as a test module."""
+    script_path = (
+        Path(__file__).resolve().parents[2] / "bin" / "output" / "output_litify.py"
+    )
+    spec = importlib.util.spec_from_file_location("output_litify", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_litify_cli_loads_simple_and_driver_configs(tmp_path):
+    """Key selection should accept both concise and existing SPINE configs."""
+    module = load_output_litify_module()
+    simple = tmp_path / "simple.yaml"
+    full = tmp_path / "full.yaml"
+    simple.write_text(yaml.safe_dump({"keys": ["meta", "particles"]}))
+    full.write_text(
+        yaml.safe_dump({"io": {"writer": {"keys": ["run_info", "interactions"]}}})
+    )
+
+    assert module.resolve_keys(None, str(simple)) == ("meta", "particles")
+    assert module.resolve_keys(None, str(full)) == (
+        "run_info",
+        "interactions",
+    )
+    assert module.resolve_keys(("particles",), None) == ("particles",)
+
+
+def test_litify_cli_rejects_ambiguous_or_invalid_selection(tmp_path):
+    """CLI and config selection should fail clearly when malformed."""
+    module = load_output_litify_module()
+    invalid = tmp_path / "invalid.yaml"
+    invalid.write_text(yaml.safe_dump({"keys": "particles"}))
+
+    with pytest.raises(ValueError, match="either"):
+        module.resolve_keys(("particles",), str(invalid))
+    with pytest.raises(ValueError, match="string list"):
+        module.load_keys(str(invalid))

--- a/test/test_data/test_base.py
+++ b/test/test_data/test_base.py
@@ -697,6 +697,59 @@ class TestDataBase:
         assert obj._value == 10  # pylint: disable=protected-access
         assert obj.energy == 20  # Computed, not loaded from dict
 
+    def test_from_dict_trusted_rebuilds_serialized_fields(self):
+        """Trusted reconstruction should preserve fields and storage casts."""
+
+        @dataclass(eq=False)
+        class TrustedData(DataBase):
+            name: str = "default"
+            flag_array: bool = False
+            flag_scalar: bool = False
+            values: np.ndarray = field(
+                default_factory=lambda: np.empty(0, dtype=np.int32),
+                metadata=FieldMetadata(dtype=np.int32),
+            )
+
+        obj = TrustedData.from_dict_trusted(
+            {
+                "name": b"loaded",
+                "flag_array": np.asarray([1], dtype=np.uint8),
+                "flag_scalar": np.uint8(1),
+                "values": np.asarray([3, 5], dtype=np.int32),
+                "derived": "ignored",
+            }
+        )
+
+        assert obj.name == "loaded"
+        assert obj.flag_array is True
+        assert obj.flag_scalar is True
+        assert np.array_equal(obj.values, [3, 5])
+        assert not hasattr(obj, "derived")
+
+    def test_from_dict_trusted_uses_isolated_defaults_and_hook(self):
+        """Trusted reconstruction should run factories and its minimal hook."""
+
+        @dataclass(eq=False)
+        class TrustedData(DataBase):
+            scalar: int = 4
+            values: np.ndarray = field(
+                default_factory=lambda: np.empty(0, dtype=np.int32),
+                metadata=FieldMetadata(dtype=np.int32),
+            )
+
+            def __post_init__(self):
+                raise AssertionError("Trusted input must bypass __post_init__")
+
+            def _post_deserialize(self):
+                object.__setattr__(self, "restored", True)
+
+        first = TrustedData.from_dict_trusted({})
+        second = TrustedData.from_dict_trusted({})
+
+        assert first.scalar == 4
+        assert first.restored
+        assert first.values is not second.values
+
     def test_cached_attrs_mechanism(self):
         """Test that attribute caching works correctly."""
 

--- a/test/test_data/test_larcv/test_meta.py
+++ b/test/test_data/test_larcv/test_meta.py
@@ -121,6 +121,20 @@ class TestMetaCreation:
         assert isinstance(meta.count, np.ndarray)
         assert meta.count.dtype == np.int64
 
+        # Trusted HDF5 reconstruction bypasses __post_init__, so the minimal
+        # deserialize hook must restore the omitted runtime cache.
+        _ = meta.index_multipliers
+        rebuilt = Meta.from_dict_trusted(
+            {
+                "lower": meta.lower,
+                "upper": meta.upper,
+                "size": meta.size,
+                "count": meta.count,
+            }
+        )
+        assert rebuilt._index_multipliers is None
+        assert np.array_equal(rebuilt.index_multipliers, [10000, 100, 1])
+
     def test_meta_edge_cases(self):
         """Test Meta edge cases and boundary conditions."""
         # Very small voxels

--- a/test/test_data/test_out/test_base.py
+++ b/test/test_data/test_out/test_base.py
@@ -179,6 +179,12 @@ class TestOutBase:
         assert len(obj.match_overlaps) == 3
         np.testing.assert_array_equal(obj.match_ids, [5, 7, 9])
         np.testing.assert_array_almost_equal(obj.match_overlaps, [0.95, 0.85, 0.75])
+        assert obj.best_match_id == 5
+        assert obj.best_match_overlap == np.float32(0.95)
+
+        obj.reset_match()
+        assert obj.best_match_id == -1
+        assert obj.best_match_overlap == -1.0
 
 
 class TestRecoBase:

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -574,7 +574,9 @@ def test_driver_constructor_initializes_optional_managers(monkeypatch):
     monkeypatch.setattr(
         driver_mod,
         "AnaManager",
-        lambda ana, log_dir, prefix: calls.append(("ana", (ana, log_dir, prefix)))
+        lambda ana, log_dir, prefix, columnar=False: calls.append(
+            ("ana", (ana, log_dir, prefix, columnar))
+        )
         or "ana",
     )
 
@@ -692,6 +694,58 @@ def test_optional_initializers_accept_absent_configs():
 
     assert drv.model is None
     assert drv.ana is None
+
+
+def test_initialize_ana_columnar_guards_and_projection(monkeypatch):
+    """Columnar analysis should validate its pipeline and configure projection."""
+    drv = bare_driver()
+    drv.io = SimpleNamespace(
+        columnar=True,
+        has_writer=False,
+        log_prefix="input",
+    )
+    drv.model = None
+    drv.builder = None
+    drv.post = None
+    drv.unwrap = True
+    drv.log_dir = "logs"
+
+    with pytest.raises(ValueError, match="at least one analysis"):
+        drv.initialize_ana(None)
+
+    drv.model = object()
+    drv.builder = object()
+    drv.post = object()
+    drv.io.has_writer = True
+    with pytest.raises(ValueError, match="model, build, post, writer"):
+        drv.initialize_ana({"save": {}})
+
+    projection = {"particles": (("id", "pid"), True)}
+    configured = []
+
+    class FakeAnaManager:
+        watch = "ana-watch"
+
+        def __init__(self, cfg, log_dir, prefix, columnar):
+            assert cfg == {"save": {}}
+            assert log_dir == "logs"
+            assert prefix == "input"
+            assert columnar is True
+
+        def columnar_requests(self):
+            return projection
+
+    monkeypatch.setattr(driver_mod, "AnaManager", FakeAnaManager)
+    drv.model = None
+    drv.builder = None
+    drv.post = None
+    drv.io.has_writer = False
+    drv.io.configure_columnar = configured.append
+
+    drv.initialize_ana({"save": {}})
+
+    assert isinstance(drv.ana, FakeAnaManager)
+    assert configured == [projection]
 
 
 def test_initialize_io_validation_branches(monkeypatch):
@@ -812,6 +866,32 @@ def test_process_runs_pipeline_in_order():
     assert ("reset", None) in drv.watch.calls
     assert ("update", None) in drv.watch.calls
     assert drv.watch.calls[-1] == ("stop", "iteration")
+
+
+def test_process_dispatches_columnar_analysis():
+    """Columnar reader policy should select the analyzer's bulk hook."""
+    drv = bare_driver()
+    calls = []
+    drv.io = SimpleNamespace(
+        columnar=True,
+        load=lambda *args: {"index": [0, 1]},
+        unwrap=lambda data: data,
+        write=lambda data, cfg: calls.append("write"),
+        watch="io-watch",
+    )
+    drv.model = None
+    drv.builder = None
+    drv.post = None
+    drv.ana = SimpleNamespace(
+        process_columnar=lambda data: calls.append("columnar"),
+        watch="ana-watch",
+    )
+    drv.cfg = {"base": {}}
+
+    data = drv.process(entry=0)
+
+    assert data == {"index": [0, 1]}
+    assert calls == ["columnar", "write"]
 
 
 def test_run_loop_resets_loader_logs_and_closes():

--- a/test/test_io/test_manager.py
+++ b/test/test_io/test_manager.py
@@ -78,6 +78,20 @@ class FakeReader:
         self.calls.append(("process_entry_list", args))
 
 
+class FakeColumnarReader(FakeReader):
+    """Reader-like object which exposes two projected chunks."""
+
+    columnar = True
+    num_chunks = 2
+
+    def configure_columnar(self, requests):
+        self.calls.append(("configure_columnar", requests))
+
+    def get_columnar(self, entry):
+        self.calls.append(("get_columnar", entry))
+        return {"index": [2 * entry, 2 * entry + 1]}
+
+
 class FakeLoader:
     """Loader-like object used by IOManager tests."""
 
@@ -221,6 +235,11 @@ def test_io_manager_validation(monkeypatch):
     with pytest.raises(RuntimeError, match="Reader configuration"):
         manager._initialize_reader(None)
 
+    manager.reader = FakeReader()
+    manager.columnar = False
+    with pytest.raises(RuntimeError, match="not configured"):
+        manager.configure_columnar({"value": (("id",), True)})
+
 
 def test_io_manager_prefix_variants(monkeypatch):
     """Prefix helper should cover single, duplicate, skipped and long names."""
@@ -323,6 +342,26 @@ def test_io_manager_resets_stale_watch_before_timed_operation(monkeypatch):
         ("start", "read"),
     ]
     assert manager.watch.calls[-1] == ("stop", "read")
+
+
+def test_io_manager_loads_and_configures_columnar_chunks(monkeypatch):
+    reader = FakeColumnarReader()
+    monkeypatch.setattr(manager_mod, "reader_factory", lambda cfg: reader)
+    manager = IOManager(reader={"name": "hdf5"}, iterations=-1)
+    requests = {"particles": (("id", "pid"), True)}
+
+    assert manager.columnar
+    assert manager.iter_per_epoch == 2
+    assert len(manager) == 2
+    manager.configure_columnar(requests)
+    assert manager.load(entry=1) == {"index": [2, 3]}
+    assert reader.calls == [
+        ("configure_columnar", requests),
+        ("get_columnar", 1),
+    ]
+
+    with pytest.raises(ValueError, match="chunk index"):
+        manager.load(run=1, subrun=2, event=3)
 
 
 def test_io_manager_iteration_unwrap_write_and_close(monkeypatch):

--- a/test/test_io/test_read/test_hdf5.py
+++ b/test/test_io/test_read/test_hdf5.py
@@ -8,9 +8,10 @@ import pytest
 from yaml.parser import ParserError
 
 import spine.data
+from spine.data import ObjectList, RecoParticle, RunInfo
 from spine.data.larcv.meta import ImageMeta2D, ImageMeta3D
 from spine.io.read import HDF5Reader, StageHDF5Reader
-from spine.io.write import StageHDF5Writer
+from spine.io.write import HDF5Writer, StageHDF5Writer
 
 
 def _read_hdf5_entry(path, queue):
@@ -257,6 +258,126 @@ def test_hdf5_reader_close_swallows_handle_close_errors():
 
     assert reader._file_handles == {}
     assert reader._handle_pid is None
+
+
+def test_hdf5_reader_v2_round_trip_and_projection(tmp_path):
+    """The public reader should auto-detect V2 and project products at I/O time."""
+    path = tmp_path / "v2.h5"
+    particle = RecoParticle(
+        id=4,
+        index=np.asarray([1, 3, 8], dtype=np.int32),
+        match_ids=np.asarray([12], dtype=np.int32),
+        match_overlaps=np.asarray([0.5], dtype=np.float32),
+    )
+    data = {
+        "index": np.asarray([0, 1]),
+        "run_info": [RunInfo(run=1, event=10), RunInfo(run=1, event=11)],
+        "particles": [
+            ObjectList([particle], RecoParticle()),
+            ObjectList([], RecoParticle()),
+        ],
+        "tensor": [
+            np.arange(6, dtype=np.float32).reshape(3, 2),
+            np.ones((1, 2), dtype=np.float32),
+        ],
+        "label": ["first", "second"],
+    }
+    with HDF5Writer(str(path), overwrite=True, format_version=2) as writer:
+        writer(data, cfg={"format": 2})
+
+    reader = HDF5Reader(str(path), create_run_map=True)
+    assert reader.file_format_versions == [2]
+    assert reader.run_map == {(1, -1, 10): 0, (1, -1, 11): 1}
+    first = reader.get(0)
+    second = reader.get(1)
+    assert first["label"] == "first"
+    assert first["particles"][0].size == 3
+    assert np.array_equal(first["particles"][0].index, [1, 3, 8])
+    assert second["particles"] == []
+    assert second["tensor"].shape == (1, 2)
+    reader.close()
+
+    projected = HDF5Reader(str(path), keys=["tensor"])
+    entry = projected.get(0)
+    assert "tensor" in entry
+    assert "particles" not in entry
+    assert "label" not in entry
+    projected.close()
+
+
+def test_hdf5_reader_v2_append_and_nested_lists(tmp_path):
+    """V2 offsets should remain valid across appends and both jagged layouts."""
+    path = tmp_path / "v2_append.h5"
+
+    def batch(base):
+        return {
+            "index": np.asarray([base, base + 1]),
+            "clusters": [
+                [np.asarray([1, 2]), np.asarray([3])],
+                [np.asarray([], dtype=np.int64)],
+            ],
+            "features": [
+                [
+                    np.ones((2, 2), dtype=np.float32),
+                    np.ones((3, 3), dtype=np.float32),
+                ],
+                [
+                    np.zeros((1, 2), dtype=np.float32),
+                    np.zeros((2, 3), dtype=np.float32),
+                ],
+            ],
+        }
+
+    with HDF5Writer(str(path), overwrite=True, format_version=2) as writer:
+        writer(batch(0), cfg={})
+    with HDF5Writer(str(path), append=True, format_version=2) as writer:
+        writer(batch(2), cfg={})
+
+    reader = HDF5Reader(str(path), build_classes=False)
+    assert len(reader) == 4
+    assert [array.tolist() for array in reader.get(0)["clusters"]] == [[1, 2], [3]]
+    assert [array.shape for array in reader.get(1)["features"]] == [(1, 2), (2, 3)]
+    assert [array.tolist() for array in reader.get(2)["clusters"]] == [[1, 2], [3]]
+    reader.close()
+
+
+def test_hdf5_reader_dispatches_mixed_v1_v2_files(tmp_path):
+    """One public reader should normalize legacy and offset files identically."""
+    paths = [tmp_path / "v1.h5", tmp_path / "v2.h5"]
+    data = {
+        "index": np.asarray([0]),
+        "value": [np.asarray([3, 4, 5], dtype=np.int32)],
+        "other": [np.asarray([9], dtype=np.int32)],
+    }
+    for version, path in enumerate(paths, start=1):
+        with HDF5Writer(str(path), overwrite=True, format_version=version) as writer:
+            writer(data, cfg={})
+    # Files predating explicit layout metadata are legacy V1 by definition.
+    with h5py.File(paths[0], "a") as legacy_file:
+        del legacy_file["info"].attrs["format_version"]
+
+    reader = HDF5Reader([str(path) for path in paths], keys=["value"])
+    assert reader.file_format_versions == [1, 2]
+    assert np.array_equal(reader.get(0)["value"], [3, 4, 5])
+    assert np.array_equal(reader.get(1)["value"], [3, 4, 5])
+    assert "other" not in reader.get(0)
+    assert "other" not in reader.get(1)
+    reader.close()
+
+
+def test_hdf5_reader_rejects_unknown_format_version(tmp_path):
+    """Unknown physical layouts should fail clearly instead of guessing."""
+    path = tmp_path / "future.h5"
+    with h5py.File(path, "w") as out_file:
+        info = out_file.create_group("info")
+        info.attrs["format_version"] = 99
+        info.attrs["version"] = "test"
+        info.attrs["cfg"] = "{}"
+        info.attrs["complete"] = True
+        out_file.create_dataset("events", data=np.empty(0, dtype=np.int64))
+
+    with pytest.raises(ValueError, match="Unsupported HDF5 format version 99"):
+        HDF5Reader(str(path))
 
 
 def test_stage_hdf5_reader_loads_one_stage(tmp_path):

--- a/test/test_io/test_read/test_hdf5.py
+++ b/test/test_io/test_read/test_hdf5.py
@@ -11,6 +11,11 @@ import spine.data
 from spine.data import ObjectList, RecoParticle, RunInfo
 from spine.data.larcv.meta import ImageMeta2D, ImageMeta3D
 from spine.io.read import HDF5Reader, StageHDF5Reader
+from spine.io.read.hdf5 import (
+    _decode_string_attribute,
+    _require_dataset,
+    _require_group,
+)
 from spine.io.write import HDF5Writer, StageHDF5Writer
 
 
@@ -295,7 +300,22 @@ def test_hdf5_reader_v2_round_trip_and_projection(tmp_path):
     assert np.array_equal(first["particles"][0].index, [1, 3, 8])
     assert second["particles"] == []
     assert second["tensor"].shape == (1, 2)
+    assert reader._v2_object_schemas
+    assert reader._v2_object_handles
+    assert reader._v2_product_handles
     reader.close()
+    assert reader._v2_object_handles == {}
+    assert reader._v2_product_handles == {}
+
+    # Closing a persistent reader invalidates cached h5py objects. A later
+    # access must transparently rebuild those process-local handle caches.
+    assert reader.get(0)["particles"][0].size == 3
+    assert reader._v2_object_handles
+    reader.close()
+
+    raw_reader = HDF5Reader(str(path), keys=["particles"], build_classes=False)
+    assert isinstance(raw_reader.get(0)["particles"][0], dict)
+    raw_reader.close()
 
     projected = HDF5Reader(str(path), keys=["tensor"])
     entry = projected.get(0)
@@ -303,6 +323,98 @@ def test_hdf5_reader_v2_round_trip_and_projection(tmp_path):
     assert "particles" not in entry
     assert "label" not in entry
     projected.close()
+
+
+def test_hdf5_reader_v2_schema_helpers_reject_wrong_types(tmp_path):
+    """V2 schema helpers should validate child and attribute types."""
+    path = tmp_path / "bad_helpers.h5"
+    with h5py.File(path, "w") as out_file:
+        out_file.create_group("group")
+        out_file.create_dataset("dataset", data=np.asarray([1]))
+
+        with pytest.raises(TypeError, match="HDF5 dataset"):
+            _require_dataset(out_file, "group")
+        with pytest.raises(TypeError, match="HDF5 group"):
+            _require_group(out_file, "dataset")
+
+    assert _decode_string_attribute(b"value", "test") == "value"
+    with pytest.raises(TypeError, match="must be a string"):
+        _decode_string_attribute(3, "test")
+
+
+def test_hdf5_reader_v2_rejects_bad_product_groups(tmp_path):
+    """V2 dispatch should reject missing and unknown product kinds."""
+    path = tmp_path / "bad_products.h5"
+    reader = HDF5Reader.__new__(HDF5Reader)
+    reader.keep_open = False
+    reader._v2_product_handles = {}
+
+    with h5py.File(path, "w") as out_file:
+        out_file.create_dataset("not_group", data=np.asarray([1]))
+        unknown = out_file.create_group("unknown")
+        unknown.attrs["kind"] = "future"
+
+        with pytest.raises(ValueError, match="not a recognized product group"):
+            reader.load_key_v2(out_file, 0, {}, "not_group")
+        with pytest.raises(ValueError, match="Unrecognized V2 product kind"):
+            reader.load_key_v2(out_file, 0, {}, "unknown")
+
+
+def test_hdf5_reader_v2_rejects_anonymous_object_group(tmp_path):
+    """Object products must have a stable path for schema caching."""
+    path = tmp_path / "anonymous.h5"
+    reader = HDF5Reader.__new__(HDF5Reader)
+
+    with h5py.File(path, "w") as out_file:
+        anonymous = out_file.create_group(None)
+        with pytest.raises(ValueError, match="must have a file path"):
+            reader.load_objects_v2(anonymous, 0, {}, "objects")
+
+
+@pytest.mark.parametrize("bad_fields", ["index", "[index, 3]"])
+def test_hdf5_reader_v2_rejects_bad_variable_pool_fields(tmp_path, bad_fields):
+    """Variable-pool field metadata must decode to string lists."""
+    path = tmp_path / "bad_fields.h5"
+    reader = HDF5Reader.__new__(HDF5Reader)
+    reader._v2_object_schemas = {}
+
+    with h5py.File(path, "w") as out_file:
+        objects = out_file.create_group("objects")
+        objects.attrs["class_name"] = "RecoParticle"
+        objects.attrs["scalar"] = False
+        objects.create_dataset(
+            "fixed",
+            (0,),
+            dtype=np.dtype([("_var_offsets_0", np.int64, (2,))]),
+        )
+        objects.create_dataset("event_offsets", data=np.asarray([0]))
+        variables = objects.create_group("variables")
+        pool = variables.create_group("pool_0")
+        pool.attrs["kind"] = "array"
+        pool.attrs["fields"] = bad_fields
+        pool.create_dataset("values", data=np.asarray([], dtype=np.int64))
+
+        with pytest.raises(TypeError, match="list of strings"):
+            reader.load_objects_v2(objects, 0, {}, "objects")
+
+
+def test_hdf5_reader_v2_rejects_non_group_variable_pool(tmp_path):
+    """Every entry below the variables group must itself be a pool group."""
+    path = tmp_path / "bad_pool.h5"
+    reader = HDF5Reader.__new__(HDF5Reader)
+    reader._v2_object_schemas = {}
+
+    with h5py.File(path, "w") as out_file:
+        objects = out_file.create_group("objects")
+        objects.attrs["class_name"] = "RecoParticle"
+        objects.attrs["scalar"] = False
+        objects.create_dataset("fixed", (0,), dtype=np.dtype([("id", np.int64)]))
+        objects.create_dataset("event_offsets", data=np.asarray([0]))
+        variables = objects.create_group("variables")
+        variables.create_dataset("pool_0", data=np.asarray([], dtype=np.int64))
+
+        with pytest.raises(TypeError, match="must be a group"):
+            reader.load_objects_v2(objects, 0, {}, "objects")
 
 
 def test_hdf5_reader_v2_append_and_nested_lists(tmp_path):

--- a/test/test_io/test_read/test_hdf5.py
+++ b/test/test_io/test_read/test_hdf5.py
@@ -277,6 +277,15 @@ def test_hdf5_reader_v2_round_trip_and_projection(tmp_path):
     data = {
         "index": np.asarray([0, 1]),
         "run_info": [RunInfo(run=1, event=10), RunInfo(run=1, event=11)],
+        "meta": [
+            ImageMeta3D(
+                lower=np.asarray([0.0, 0.0, 0.0], dtype=np.float32),
+                upper=np.asarray([4.0, 6.0, 8.0], dtype=np.float32),
+                size=np.asarray([1.0, 2.0, 2.0], dtype=np.float32),
+                count=np.asarray([4, 3, 4], dtype=np.int64),
+            ),
+            ImageMeta3D(),
+        ],
         "particles": [
             ObjectList([particle], RecoParticle()),
             ObjectList([], RecoParticle()),
@@ -298,6 +307,7 @@ def test_hdf5_reader_v2_round_trip_and_projection(tmp_path):
     assert first["label"] == "first"
     assert first["particles"][0].size == 3
     assert np.array_equal(first["particles"][0].index, [1, 3, 8])
+    assert np.array_equal(first["meta"].index_multipliers, [12, 4, 1])
     assert second["particles"] == []
     assert second["tensor"].shape == (1, 2)
     assert reader._v2_object_schemas
@@ -317,12 +327,80 @@ def test_hdf5_reader_v2_round_trip_and_projection(tmp_path):
     assert isinstance(raw_reader.get(0)["particles"][0], dict)
     raw_reader.close()
 
+    fixed_reader = HDF5Reader(
+        str(path),
+        keys=["particles"],
+        build_classes=False,
+        fixed_only=True,
+    )
+    fixed_particle = fixed_reader.get(0)["particles"][0]
+    assert fixed_particle["id"] == 4
+    assert fixed_particle["size"] == 3
+    assert "index" not in fixed_particle
+    assert "match_ids" not in fixed_particle
+    assert all(
+        not pool_values
+        for _, _, pool_values in fixed_reader._v2_object_handles.values()
+    )
+    fixed_reader.close()
+
+    fixed_class_reader = HDF5Reader(str(path), keys=["particles"], fixed_only=True)
+    fixed_class_particle = fixed_class_reader.get(0)["particles"][0]
+    assert fixed_class_particle.id == 4
+    assert len(fixed_class_particle.index) == 0
+    assert fixed_class_particle.size == 0
+    fixed_class_reader.close()
+
     projected = HDF5Reader(str(path), keys=["tensor"])
     entry = projected.get(0)
     assert "tensor" in entry
     assert "particles" not in entry
     assert "label" not in entry
     projected.close()
+
+
+def test_hdf5_reader_fixed_only_does_not_access_variable_group(tmp_path):
+    """Fixed-only object reads must not require the variable-pool hierarchy."""
+    path = tmp_path / "fixed_only.h5"
+    particle = RecoParticle(
+        id=9,
+        index=np.asarray([1, 2, 3], dtype=np.int32),
+    )
+    data = {
+        "index": np.asarray([0]),
+        "particles": [ObjectList([particle], RecoParticle())],
+    }
+    with HDF5Writer(str(path), overwrite=True, format_version=2) as writer:
+        writer(data, cfg={})
+
+    with h5py.File(path, "a") as out_file:
+        del out_file["particles"]["variables"]
+
+    reader = HDF5Reader(
+        str(path),
+        keys=["particles"],
+        build_classes=False,
+        fixed_only=True,
+    )
+    loaded = reader.get(0)["particles"][0]
+    assert loaded["id"] == 9
+    assert loaded["size"] == 3
+    assert "index" not in loaded
+    reader.close()
+
+
+def test_hdf5_reader_fixed_only_rejects_v1_and_mixed_files(tmp_path):
+    """Fixed-only loading must not silently degrade on legacy inputs."""
+    paths = [tmp_path / "v1.h5", tmp_path / "v2.h5"]
+    data = {"index": np.asarray([0]), "value": [np.asarray([1])]}
+    for version, path in enumerate(paths, start=1):
+        with HDF5Writer(str(path), overwrite=True, format_version=version) as writer:
+            writer(data, cfg={})
+
+    with pytest.raises(ValueError, match="only for HDF5 format version 2"):
+        HDF5Reader(str(paths[0]), fixed_only=True)
+    with pytest.raises(ValueError, match="only for HDF5 format version 2"):
+        HDF5Reader([str(path) for path in paths], fixed_only=True)
 
 
 def test_hdf5_reader_v2_schema_helpers_reject_wrong_types(tmp_path):
@@ -377,6 +455,7 @@ def test_hdf5_reader_v2_rejects_bad_variable_pool_fields(tmp_path, bad_fields):
     path = tmp_path / "bad_fields.h5"
     reader = HDF5Reader.__new__(HDF5Reader)
     reader._v2_object_schemas = {}
+    reader.fixed_only = False
 
     with h5py.File(path, "w") as out_file:
         objects = out_file.create_group("objects")
@@ -403,6 +482,7 @@ def test_hdf5_reader_v2_rejects_non_group_variable_pool(tmp_path):
     path = tmp_path / "bad_pool.h5"
     reader = HDF5Reader.__new__(HDF5Reader)
     reader._v2_object_schemas = {}
+    reader.fixed_only = False
 
     with h5py.File(path, "w") as out_file:
         objects = out_file.create_group("objects")

--- a/test/test_io/test_read/test_hdf5.py
+++ b/test/test_io/test_read/test_hdf5.py
@@ -336,6 +336,8 @@ def test_hdf5_reader_v2_round_trip_and_projection(tmp_path):
     fixed_particle = fixed_reader.get(0)["particles"][0]
     assert fixed_particle["id"] == 4
     assert fixed_particle["size"] == 3
+    assert fixed_particle["best_match_id"] == 12
+    assert fixed_particle["best_match_overlap"] == pytest.approx(0.5)
     assert "index" not in fixed_particle
     assert "match_ids" not in fixed_particle
     assert all(
@@ -357,6 +359,188 @@ def test_hdf5_reader_v2_round_trip_and_projection(tmp_path):
     assert "particles" not in entry
     assert "label" not in entry
     projected.close()
+
+    columnar = HDF5Reader(
+        str(path),
+        columnar=True,
+        chunk_size=2,
+    )
+    columnar.configure_columnar(
+        {
+            "particles": (
+                ("best_match_id", "best_match_overlap", "id", "size"),
+                True,
+            )
+        }
+    )
+    chunk = columnar.get_columnar(0)
+    assert chunk["index"].tolist() == [0, 1]
+    assert chunk["particles"]["event_offsets"].tolist() == [0, 1, 1]
+    assert chunk["particles"]["id"].tolist() == [4]
+    assert chunk["particles"]["best_match_id"].tolist() == [12]
+    assert chunk["particles"]["best_match_overlap"].tolist() == [0.5]
+    columnar.close()
+
+
+def test_hdf5_reader_v1_columnar_projection(tmp_path):
+    """Legacy region references should support fixed-field projection."""
+    path = tmp_path / "v1_columnar.h5"
+    particle = RecoParticle(
+        id=3,
+        pid=2,
+        index=np.asarray([1, 2], dtype=np.int32),
+        match_ids=np.asarray([0], dtype=np.int32),
+        match_overlaps=np.asarray([0.75], dtype=np.float32),
+    )
+    data = {
+        "index": np.asarray([0]),
+        "particles": [ObjectList([particle], RecoParticle())],
+    }
+    with HDF5Writer(str(path), overwrite=True, format_version=1) as writer:
+        writer(data, cfg={})
+
+    reader = HDF5Reader(str(path), columnar=True)
+    reader.configure_columnar(
+        {
+            "particles": (
+                ("best_match_id", "best_match_overlap", "id", "pid", "size"),
+                True,
+            )
+        }
+    )
+    chunk = reader.get_columnar(0)
+
+    assert chunk["particles"]["event_offsets"].tolist() == [0, 1]
+    assert chunk["particles"]["id"].tolist() == [3]
+    assert chunk["particles"]["size"].tolist() == [2]
+    assert chunk["particles"]["best_match_id"].tolist() == [0]
+    reader.close()
+
+
+@pytest.mark.parametrize("format_version", [1, 2])
+def test_hdf5_reader_columnar_offsets_only(tmp_path, format_version):
+    """Empty field projections should return boundaries without compound I/O."""
+    path = tmp_path / f"offsets_only_v{format_version}.h5"
+    data = {
+        "index": np.asarray([0, 1]),
+        "particles": [
+            ObjectList([RecoParticle(id=3)], RecoParticle()),
+            ObjectList([], RecoParticle()),
+        ],
+    }
+    with HDF5Writer(str(path), overwrite=True, format_version=format_version) as writer:
+        writer(data, cfg={})
+
+    reader = HDF5Reader(str(path), columnar=True)
+    reader.configure_columnar({"particles": ((), True)})
+    product = reader.get_columnar(0)["particles"]
+
+    assert list(product) == ["event_offsets"]
+    assert product["event_offsets"].tolist() == [0, 1, 1]
+    reader.close()
+
+
+def test_hdf5_reader_validates_columnar_state_and_bounds(tmp_path):
+    """Columnar APIs should reject invalid mode, size, state and chunk IDs."""
+    path = tmp_path / "columnar_validation.h5"
+    data = {
+        "index": np.asarray([0]),
+        "particles": [ObjectList([], RecoParticle())],
+    }
+    with HDF5Writer(str(path), overwrite=True, format_version=2) as writer:
+        writer(data, cfg={})
+
+    with pytest.raises(ValueError, match="positive integer"):
+        HDF5Reader(str(path), columnar=True, chunk_size=0)
+
+    event_reader = HDF5Reader(str(path))
+    with pytest.raises(RuntimeError, match="event mode"):
+        event_reader.configure_columnar({"particles": (("id",), True)})
+    with pytest.raises(RuntimeError, match="not enabled"):
+        event_reader.get_columnar(0)
+    event_reader.close()
+
+    reader = HDF5Reader(str(path), columnar=True)
+    with pytest.raises(IndexError, match="out of bounds"):
+        reader.get_columnar(1)
+    with pytest.raises(RuntimeError, match="not configured"):
+        reader.get_columnar(0)
+    reader.close()
+
+
+def test_hdf5_reader_columnar_missing_products_and_fields(tmp_path):
+    """Columnar projections should distinguish optional and required data."""
+    path = tmp_path / "columnar_missing.h5"
+    data = {
+        "index": np.asarray([0]),
+        "particles": [
+            ObjectList([RecoParticle(id=3)], RecoParticle()),
+        ],
+        "tensor": [np.ones((1, 2), dtype=np.float32)],
+    }
+    with HDF5Writer(str(path), overwrite=True, format_version=2) as writer:
+        writer(data, cfg={})
+
+    optional = HDF5Reader(str(path), columnar=True, keep_open=False)
+    optional.configure_columnar({"absent": (("id",), False)})
+    assert "absent" not in optional.get_columnar(0)
+    optional.close()
+
+    required = HDF5Reader(str(path), columnar=True)
+    required.configure_columnar({"absent": (("id",), True)})
+    with pytest.raises(KeyError, match="Required columnar product"):
+        required.get_columnar(0)
+    required.close()
+
+    missing_field = HDF5Reader(str(path), columnar=True)
+    missing_field.configure_columnar({"particles": (("not_a_field",), True)})
+    with pytest.raises(KeyError, match="missing fixed fields"):
+        missing_field.get_columnar(0)
+    missing_field.close()
+
+    wrong_kind = HDF5Reader(str(path), columnar=True)
+    wrong_kind.configure_columnar({"tensor": (None, True)})
+    with pytest.raises(TypeError, match="object collection"):
+        wrong_kind.get_columnar(0)
+    wrong_kind.close()
+
+
+def test_hdf5_reader_columnar_run_splitting_and_legacy_errors(tmp_path):
+    """Run splitting and malformed legacy projections should be explicit."""
+    assert HDF5Reader._contiguous_runs(np.empty(0, dtype=np.int64)) == []
+    assert HDF5Reader._contiguous_runs(np.asarray([1, 2, 4, 7, 8])) == [
+        (1, 3),
+        (4, 5),
+        (7, 9),
+    ]
+
+    path = tmp_path / "legacy_errors.h5"
+    data = {
+        "index": np.asarray([0]),
+        "particles": [
+            ObjectList([RecoParticle(id=3)], RecoParticle()),
+        ],
+    }
+    with HDF5Writer(str(path), overwrite=True, format_version=1) as writer:
+        writer(data, cfg={})
+
+    missing_field = HDF5Reader(str(path), columnar=True)
+    missing_field.configure_columnar({"particles": (("not_a_field",), True)})
+    with pytest.raises(KeyError, match="Legacy columnar product"):
+        missing_field.get_columnar(0)
+    missing_field.close()
+
+    with h5py.File(path, "a") as out_file:
+        out_file.create_dataset(
+            "orphan",
+            data=np.asarray([(4,)], dtype=[("id", np.int64)]),
+        )
+
+    missing_reference = HDF5Reader(str(path), columnar=True)
+    missing_reference.configure_columnar({"orphan": (("id",), True)})
+    with pytest.raises(KeyError, match="does not reference"):
+        missing_reference.get_columnar(0)
+    missing_reference.close()
 
 
 def test_hdf5_reader_fixed_only_does_not_access_variable_group(tmp_path):

--- a/test/test_io/test_transform/test_hdf5.py
+++ b/test/test_io/test_transform/test_hdf5.py
@@ -1,0 +1,312 @@
+"""Tests for direct V2 HDF5 transformations."""
+
+from __future__ import annotations
+
+import h5py
+import numpy as np
+import pytest
+import yaml
+
+from spine.data import ObjectList, RecoParticle
+from spine.io.read import HDF5Reader
+from spine.io.transform import litify_hdf5
+from spine.io.transform.hdf5 import _dataset_kwargs
+from spine.io.write import HDF5Writer
+
+
+def _write_source(path, format_version=2):
+    particle = RecoParticle(
+        id=3,
+        index=np.asarray([1, 4, 8], dtype=np.int32),
+        orig_index=np.asarray([2, 5, 9], dtype=np.int32),
+        match_ids=np.asarray([7], dtype=np.int32),
+        match_overlaps=np.asarray([0.75], dtype=np.float32),
+        fragment_ids=np.asarray([2, 6], dtype=np.int32),
+    )
+    data = {
+        "index": np.asarray([0, 1]),
+        "particles": [
+            ObjectList([particle], RecoParticle()),
+            ObjectList([], RecoParticle()),
+        ],
+    }
+    with HDF5Writer(
+        str(path),
+        overwrite=True,
+        format_version=format_version,
+    ) as writer:
+        writer(data, cfg={})
+
+
+def _pool_fields(group):
+    return [
+        tuple(yaml.safe_load(pool.attrs["fields"]))
+        for pool in group["variables"].values()
+    ]
+
+
+def _assert_compound_equal(left, right):
+    """Compare compound rows while treating corresponding NaNs as equal."""
+    assert left.dtype == right.dtype
+    for name in left.dtype.names:
+        left_values = left[name]
+        right_values = right[name]
+        if np.issubdtype(left_values.dtype, np.floating):
+            assert np.allclose(left_values, right_values, equal_nan=True)
+        else:
+            assert np.array_equal(left_values, right_values)
+
+
+def test_structural_lite_matches_event_writer(tmp_path):
+    """Structural lite output should match the established object policy."""
+    source = tmp_path / "source.h5"
+    structural = tmp_path / "structural.h5"
+    event_lite = tmp_path / "event_lite.h5"
+    _write_source(source)
+
+    litify_hdf5(str(source), str(structural), keys=("particles",))
+
+    reader = HDF5Reader(str(source))
+    with HDF5Writer(
+        str(event_lite),
+        overwrite=True,
+        format_version=2,
+        lite=True,
+        keys=("particles",),
+    ) as writer:
+        for entry in range(len(reader)):
+            writer(reader.get(entry), cfg={})
+    reader.close()
+
+    with h5py.File(structural, "r") as direct, h5py.File(event_lite, "r") as rebuilt:
+        direct_group = direct["particles"]
+        rebuilt_group = rebuilt["particles"]
+        assert direct_group["fixed"].dtype == rebuilt_group["fixed"].dtype
+        _assert_compound_equal(
+            direct_group["fixed"][:],
+            rebuilt_group["fixed"][:],
+        )
+        assert np.array_equal(
+            direct_group["event_offsets"][:],
+            rebuilt_group["event_offsets"][:],
+        )
+        assert _pool_fields(direct_group) == _pool_fields(rebuilt_group)
+        for direct_pool, rebuilt_pool in zip(
+            direct_group["variables"].values(),
+            rebuilt_group["variables"].values(),
+        ):
+            assert np.array_equal(
+                direct_pool["values"][:],
+                rebuilt_pool["values"][:],
+            )
+
+        fields = set().union(*_pool_fields(direct_group))
+        assert "index" not in fields
+        assert "orig_index" not in fields
+        assert {"match_ids", "fragment_ids"}.issubset(fields)
+        assert direct["info"].attrs["complete"]
+        assert direct["info"].attrs["litified"]
+
+
+def test_structural_fixed_only_removes_variable_pools(tmp_path):
+    """Fixed-only mode should preserve object rows without helper columns."""
+    source = tmp_path / "source.h5"
+    target = tmp_path / "fixed.h5"
+    _write_source(source)
+
+    litify_hdf5(
+        str(source),
+        str(target),
+        keys=("particles",),
+        mode="fixed_only",
+    )
+
+    with h5py.File(target, "r") as out_file:
+        group = out_file["particles"]
+        assert len(group["variables"]) == 0
+        assert not any(
+            name.startswith("_var_offsets_") for name in group["fixed"].dtype.names
+        )
+        assert group["event_offsets"][:].tolist() == [0, 1, 1]
+
+
+def test_structural_lite_validates_input_and_destination(tmp_path):
+    """The transformer should reject V1, missing products and unsafe paths."""
+    source = tmp_path / "source_v1.h5"
+    target = tmp_path / "target.h5"
+    _write_source(source, format_version=1)
+
+    with pytest.raises(ValueError, match="version 2"):
+        litify_hdf5(str(source), str(target), keys=("particles",))
+
+    source_v2 = tmp_path / "source_v2.h5"
+    _write_source(source_v2)
+    with pytest.raises(KeyError, match="missing"):
+        litify_hdf5(str(source_v2), str(target), keys=("absent",))
+    with pytest.raises(ValueError, match="different"):
+        litify_hdf5(str(source_v2), str(source_v2), keys=("particles",))
+
+    litify_hdf5(str(source_v2), str(target), keys=("particles",))
+    with pytest.raises(FileExistsError):
+        litify_hdf5(str(source_v2), str(target), keys=("particles",))
+    litify_hdf5(
+        str(source_v2),
+        str(target),
+        keys=("particles",),
+        overwrite=True,
+    )
+
+
+def test_structural_lite_validates_options_and_metadata(tmp_path):
+    """Public options and required V2 metadata should fail clearly."""
+    missing = tmp_path / "missing.h5"
+    target = tmp_path / "target.h5"
+    with pytest.raises(ValueError, match="mode"):
+        litify_hdf5(str(missing), str(target), mode="unknown")
+    with pytest.raises(ValueError, match="block_size"):
+        litify_hdf5(str(missing), str(target), block_size=0)
+    with pytest.raises(FileNotFoundError):
+        litify_hdf5(str(missing), str(target))
+
+    incomplete = tmp_path / "incomplete.h5"
+    with h5py.File(incomplete, "w") as out_file:
+        out_file.create_dataset("events", data=np.arange(1))
+    with pytest.raises(ValueError, match="complete SPINE"):
+        litify_hdf5(str(incomplete), str(target), keys=())
+
+
+def test_structural_lite_handles_encoded_metadata_and_source(tmp_path):
+    """Byte metadata and top-level source provenance should be preserved."""
+    source = tmp_path / "source.h5"
+    target = tmp_path / "target.h5"
+    _write_source(source)
+    with h5py.File(source, "a") as out_file:
+        group = out_file["particles"]
+        group.attrs["class_name"] = np.bytes_("RecoParticle")
+        for pool in group["variables"].values():
+            fields = pool.attrs["fields"]
+            del pool.attrs["fields"]
+            pool.attrs["fields"] = np.bytes_(fields)
+        provenance = out_file.create_group("source")
+        provenance.attrs["file_name"] = "original.root"
+
+    litify_hdf5(str(source), str(target), keys=("particles",))
+
+    with h5py.File(target, "r") as out_file:
+        assert out_file["source"].attrs["file_name"] == "original.root"
+
+
+@pytest.mark.parametrize(
+    ("field_value", "message"),
+    [
+        (4, "no string field metadata"),
+        (yaml.safe_dump({"index": 1}), "string list"),
+    ],
+)
+def test_structural_lite_rejects_invalid_pool_fields(tmp_path, field_value, message):
+    """Malformed variable-pool field metadata should be rejected."""
+    source = tmp_path / "source.h5"
+    target = tmp_path / "target.h5"
+    _write_source(source)
+    with h5py.File(source, "a") as out_file:
+        pool = next(iter(out_file["particles"]["variables"].values()))
+        del pool.attrs["fields"]
+        pool.attrs["fields"] = field_value
+
+    with pytest.raises(TypeError, match=message):
+        litify_hdf5(str(source), str(target), keys=("particles",))
+
+
+def test_structural_lite_rejects_unknown_object_class(tmp_path):
+    """Lite policy lookup requires a known stored SPINE object class."""
+    source = tmp_path / "source.h5"
+    target = tmp_path / "target.h5"
+    _write_source(source)
+    with h5py.File(source, "a") as out_file:
+        out_file["particles"].attrs["class_name"] = "UnknownObject"
+
+    with pytest.raises(ValueError, match="Cannot resolve"):
+        litify_hdf5(str(source), str(target), keys=("particles",))
+
+
+def test_dataset_creation_options_are_preserved(tmp_path):
+    """Physical filters should transfer to structurally rewritten datasets."""
+    path = tmp_path / "filters.h5"
+    with h5py.File(path, "w") as out_file:
+        filtered = out_file.create_dataset(
+            "filtered",
+            data=np.arange(10),
+            chunks=(5,),
+            compression="gzip",
+            compression_opts=2,
+            shuffle=True,
+            fletcher32=True,
+        )
+        scaled = out_file.create_dataset(
+            "scaled",
+            data=np.arange(10, dtype=np.float32),
+            chunks=(5,),
+            scaleoffset=2,
+        )
+        filtered_kwargs = _dataset_kwargs(filtered)
+        scaled_kwargs = _dataset_kwargs(scaled)
+
+    assert filtered_kwargs == {
+        "chunks": (5,),
+        "compression": "gzip",
+        "compression_opts": 2,
+        "shuffle": True,
+        "fletcher32": True,
+    }
+    assert scaled_kwargs == {"chunks": (5,), "scaleoffset": 2}
+
+
+@pytest.mark.parametrize(
+    ("corruption", "message"),
+    [
+        ("class_name", "no class name"),
+        ("fixed", "no fixed dataset"),
+        ("event_offsets", "no event offsets"),
+        ("variables", "no variable group"),
+        ("pool", "not a group"),
+        ("values", "no values"),
+        ("helper", "missing helper"),
+    ],
+)
+def test_structural_lite_rejects_corrupt_object_layout(tmp_path, corruption, message):
+    """Malformed object hierarchy components should fail before publication."""
+    source = tmp_path / f"source_{corruption}.h5"
+    target = tmp_path / f"target_{corruption}.h5"
+    _write_source(source)
+    with h5py.File(source, "a") as out_file:
+        group = out_file["particles"]
+        if corruption == "class_name":
+            del group.attrs["class_name"]
+            group.attrs["class_name"] = 4
+        elif corruption in ("fixed", "event_offsets"):
+            del group[corruption]
+            group.create_group(corruption)
+        elif corruption == "variables":
+            del group["variables"]
+            group.create_dataset("variables", data=np.arange(1))
+        elif corruption == "pool":
+            del group["variables"]["pool_0"]
+            group["variables"].create_dataset("pool_0", data=np.arange(1))
+        elif corruption == "values":
+            pool = group["variables"]["pool_0"]
+            del pool["values"]
+            pool.create_group("values")
+        else:
+            fixed = group["fixed"]
+            source_rows = fixed[:]
+            names = [name for name in fixed.dtype.names if name != "_var_offsets_0"]
+            dtype = np.dtype([(name, fixed.dtype.fields[name][0]) for name in names])
+            replacement = np.empty(len(source_rows), dtype=dtype)
+            for name in names:
+                replacement[name] = source_rows[name]
+            del group["fixed"]
+            group.create_dataset("fixed", data=replacement)
+
+    with pytest.raises((TypeError, KeyError), match=message):
+        litify_hdf5(str(source), str(target), keys=("particles",))
+    assert not target.exists()

--- a/test/test_io/test_write/test_csv.py
+++ b/test/test_io/test_write/test_csv.py
@@ -112,3 +112,43 @@ def test_csv_writer_directory_relocates_output(tmp_path):
         "a",
         "1",
     ]
+
+
+def test_csv_writer_appends_columns(tmp_path):
+    """Columnar writes should share headers and avoid row dictionaries."""
+    path = tmp_path / "columns.csv"
+    writer = CSVWriter(path)
+    writer.append_columns({"a": [1, 2], "b": [3, 4]})
+    writer.append_columns({"a": [5], "b": [6]})
+    writer.close()
+
+    assert path.read_text(encoding="utf-8").splitlines() == [
+        "a,b",
+        "1,3",
+        "2,4",
+        "5,6",
+    ]
+
+
+def test_csv_writer_reopens_for_columnar_append(tmp_path):
+    """A closed initialized writer should reopen before writing more columns."""
+    path = tmp_path / "columns.csv"
+    writer = CSVWriter(path)
+    writer.append_columns({"a": [1]})
+    writer.close()
+    writer.append_columns({"a": [2]})
+    writer.close()
+
+    assert path.read_text(encoding="utf-8").splitlines() == ["a", "1", "2"]
+
+
+def test_csv_writer_validates_columnar_shape_and_header(tmp_path):
+    path = tmp_path / "columns.csv"
+    writer = CSVWriter(path)
+    with pytest.raises(ValueError, match="same length"):
+        writer.append_columns({"a": [1], "b": [2, 3]})
+
+    writer.append_columns({"a": [1], "b": [2]})
+    with pytest.raises(AssertionError, match="match"):
+        writer.append_columns({"b": [3], "a": [4]})
+    writer.close()

--- a/test/test_io/test_write/test_hdf5.py
+++ b/test/test_io/test_write/test_hdf5.py
@@ -738,7 +738,7 @@ def test_stage_hdf5_writer_ensure_source_group_existing_matches_and_mismatches(
     """Existing source groups should validate cache-file provenance."""
     path = tmp_path / "cache.h5"
     writer = StageHDF5Writer(str(path), overwrite=True)
-    writer._ensure_file(str(path))
+    writer._ensure_stage_file(str(path))
     handle, should_close = writer._open_handle(str(path))
     try:
         batch = {
@@ -1671,3 +1671,129 @@ def test_hdf5_writer_rejects_append_format_mismatch(hdf5_output):
     with pytest.raises(ValueError, match="format version"):
         writer(data, cfg={})
     writer.close()
+
+
+def test_hdf5_writer_rejects_unknown_format_version(hdf5_output):
+    """Writers should reject physical layouts they do not implement."""
+    with pytest.raises(ValueError, match="Unsupported HDF5 format version"):
+        HDF5Writer(hdf5_output, format_version=99)
+
+
+def test_hdf5_writer_rejects_append_without_info_group(hdf5_output):
+    """Append validation should reject files without format metadata."""
+    writer = HDF5Writer(hdf5_output, append=True, format_version=2)
+    with h5py.File(hdf5_output, "w") as out_file:
+        out_file.create_dataset("events", data=np.asarray([], dtype=np.int64))
+        with pytest.raises(ValueError, match="missing info group"):
+            writer._validate_append_format(out_file, hdf5_output)
+
+
+def test_hdf5_writer_v2_split_uses_collective_append(tmp_path):
+    """Split V2 outputs should use the batch-oriented append path."""
+    path = str(tmp_path / "split.h5")
+    data = {
+        "index": np.asarray([0, 1]),
+        "file_index": np.asarray([0, 1]),
+        "value": [
+            np.asarray([1], dtype=np.int32),
+            np.asarray([2], dtype=np.int32),
+        ],
+    }
+    with HDF5Writer(
+        path,
+        prefix=["first", "second"],
+        split=True,
+        overwrite=True,
+        format_version=2,
+    ) as writer:
+        writer(data, cfg={})
+
+    for file_id in range(2):
+        with h5py.File(tmp_path / f"split_{file_id}.h5", "r") as out_file:
+            assert len(out_file["events"]) == 1
+
+
+def test_hdf5_writer_v2_single_entry_wrapper_and_scalar(hdf5_output):
+    """The single-entry compatibility wrapper should accept scalar products."""
+    data = {"index": np.asarray([0]), "scalar": 5}
+    writer = HDF5Writer(
+        hdf5_output,
+        overwrite=True,
+        keep_open=False,
+        format_version=2,
+    )
+    writer.create(data, cfg={})
+    writer._ensure_file(0)
+
+    with h5py.File(hdf5_output, "a") as out_file:
+        writer.append_entry(out_file, data, 0)
+
+    with h5py.File(hdf5_output, "r") as out_file:
+        assert out_file["scalar"]["values"][:].tolist() == [5]
+        assert len(out_file["events"]) == 1
+
+
+def _make_v2_variable_object_group(out_file, fields):
+    """Create the minimal V2 object group needed by pool validation tests."""
+    objects = out_file.create_group("objects")
+    objects.create_dataset(
+        "fixed",
+        (0,),
+        maxshape=(None,),
+        dtype=np.dtype([("_var_offsets_0", np.int64, (2,))]),
+    )
+    objects.create_dataset(
+        "event_offsets",
+        data=np.asarray([0], dtype=np.int64),
+        maxshape=(None,),
+    )
+    pool = objects.create_group("variables").create_group("pool_0")
+    pool.attrs["kind"] = "array"
+    pool.attrs["fields"] = fields
+    pool.create_dataset(
+        "values",
+        (0,),
+        maxshape=(None,),
+        dtype=np.float32,
+    )
+    return objects
+
+
+def test_hdf5_writer_v2_decodes_byte_pool_fields_and_empty_lengths(
+    hdf5_output,
+):
+    """Byte-valued field metadata and empty appends should be harmless."""
+    with h5py.File(hdf5_output, "w") as out_file:
+        objects = _make_v2_variable_object_group(out_file, np.bytes_(b"- field\n"))
+        HDF5Writer.store_object_batches_v2(objects, [], lite=False)
+        assert objects["event_offsets"][:].tolist() == [0]
+
+
+@pytest.mark.parametrize(
+    ("fields", "message"),
+    [
+        (np.void(b"- field\n"), "must be a string"),
+        ("field", "list of strings"),
+    ],
+)
+def test_hdf5_writer_v2_rejects_bad_pool_field_metadata(hdf5_output, fields, message):
+    """Object pool field metadata must be a serialized string list."""
+    with h5py.File(hdf5_output, "w") as out_file:
+        objects = _make_v2_variable_object_group(out_file, fields)
+        with pytest.raises(TypeError, match=message):
+            HDF5Writer.store_object_batches_v2(objects, [], lite=False)
+
+
+def test_hdf5_writer_v2_rejects_multidimensional_variable_fields(
+    hdf5_output,
+):
+    """Variable object fields must remain one-dimensional."""
+
+    class BadObject:
+        def as_dict(self, lite):
+            return {"field": np.ones((2, 2), dtype=np.float32)}
+
+    with h5py.File(hdf5_output, "w") as out_file:
+        objects = _make_v2_variable_object_group(out_file, yaml.safe_dump(["field"]))
+        with pytest.raises(ValueError, match="must be one-dimensional"):
+            HDF5Writer.store_object_batches_v2(objects, [[BadObject()]], lite=False)

--- a/test/test_io/test_write/test_hdf5.py
+++ b/test/test_io/test_write/test_hdf5.py
@@ -5,6 +5,7 @@ import os
 import h5py
 import numpy as np
 import pytest
+import yaml
 
 from spine.data import (
     CRTHit,
@@ -1603,3 +1604,70 @@ def generate_object_list(cls, sizes):
         List of typed lists of objects
     """
     return [ObjectList([cls() for _ in range(s)], cls()) for s in sizes]
+
+
+def test_hdf5_writer_v2_uses_offsets_and_preserves_derived_fields(hdf5_output):
+    """V2 should flatten variable fields while retaining advertised summaries."""
+    particle = RecoParticle(
+        id=7,
+        index=np.asarray([2, 5, 9], dtype=np.int32),
+        match_ids=np.asarray([11], dtype=np.int32),
+        match_overlaps=np.asarray([0.75], dtype=np.float32),
+    )
+    data = {
+        "index": np.asarray([0]),
+        "particles": [ObjectList([particle], RecoParticle())],
+        "tensor": [np.arange(6, dtype=np.float32).reshape(3, 2)],
+        "label": ["event-zero"],
+    }
+
+    with HDF5Writer(hdf5_output, overwrite=True, format_version=2) as writer:
+        writer(data, cfg={"test": True})
+
+    with h5py.File(hdf5_output, "r") as out_file:
+        info = out_file["info"].attrs
+        assert info["format"] == "spine_hdf5"
+        assert info["format_version"] == 2
+        assert "spine_version" in info
+
+        particles = out_file["particles"]
+        assert particles.attrs["kind"] == "objects"
+        assert particles["event_offsets"][:].tolist() == [0, 1]
+        index_pool = next(
+            pool
+            for pool in particles["variables"].values()
+            if "index" in yaml.safe_load(pool.attrs["fields"])
+        )
+        fields = yaml.safe_load(index_pool.attrs["fields"])
+        index_column = fields.index("index")
+        pool_index = int(index_pool.name.split("_")[-1])
+        bounds = particles["fixed"][f"_var_offsets_{pool_index}"][
+            0, index_column : index_column + 2
+        ]
+        assert index_pool["values"][bounds[0] : bounds[1]].tolist() == [2, 5, 9]
+
+        # Derived properties remain directly available without SPINE classes.
+        assert particles["fixed"]["size"].tolist() == [3]
+        assert "num_fragments" in particles["fixed"].dtype.names
+
+        # No dataset in the V2 product tree uses an HDF5 VLEN dtype.
+        def assert_no_vlen(_, obj):
+            if isinstance(obj, h5py.Dataset):
+                if obj.dtype.names:
+                    for name in obj.dtype.names:
+                        assert h5py.check_dtype(vlen=obj.dtype[name]) is None
+                else:
+                    assert h5py.check_dtype(vlen=obj.dtype) is None
+
+        out_file.visititems(assert_no_vlen)
+
+
+def test_hdf5_writer_rejects_append_format_mismatch(hdf5_output):
+    """Appending must never silently mix physical HDF5 layouts."""
+    data = {"index": np.asarray([0]), "value": [np.asarray([1], dtype=np.int32)]}
+    HDF5Writer(hdf5_output, overwrite=True, format_version=1)(data, cfg={})
+
+    writer = HDF5Writer(hdf5_output, append=True, format_version=2)
+    with pytest.raises(ValueError, match="format version"):
+        writer(data, cfg={})
+    writer.close()

--- a/test/test_io/test_write/test_hdf5.py
+++ b/test/test_io/test_write/test_hdf5.py
@@ -1648,6 +1648,8 @@ def test_hdf5_writer_v2_uses_offsets_and_preserves_derived_fields(hdf5_output):
 
         # Derived properties remain directly available without SPINE classes.
         assert particles["fixed"]["size"].tolist() == [3]
+        assert particles["fixed"]["best_match_id"].tolist() == [11]
+        assert particles["fixed"]["best_match_overlap"].tolist() == [0.75]
         assert "num_fragments" in particles["fixed"].dtype.names
 
         # No dataset in the V2 product tree uses an HDF5 VLEN dtype.


### PR DESCRIPTION
## Summary

Introduces an opt-in version 2 SPINE HDF5 layout designed to reduce region-reference and variable-length-field overhead.

The legacy format remains the default during production validation.

## Key changes

- Adds explicit format versioning:
  - `format_version: 1`: legacy region-reference/VLEN layout
  - `format_version: 2`: offset-based layout
- Stores event and object boundaries as integer offsets.
- Stores variable-length object attributes in flat, dtype-specific pools.
- Retains derived and fixed-width properties in each product’s `fixed` dataset.
- Keeps `events` as the authoritative event axis, without product references in V2.
- Adds reader-level product projection.
- Adds semantic V1/V2 output comparison tooling.

## V2 object layout

Each object product contains:

- `fixed`: scalar, enum, fixed-width, and derived properties
- `event_offsets`: maps events to object rows
- `variables`: flat pools for variable-length arrays and strings

Variable fields are grouped by physical dtype. Offset rows stored in `fixed` locate each object attribute within its pool.

This avoids HDF5 VLEN fields and per-object region references while keeping derived properties directly accessible to external consumers such as CAF makers.

## Backward compatibility

- Files without `format_version` are treated as V1.
- `HDF5Reader` automatically reads both layouts.
- A single reader may consume mixed V1 and V2 files.
- Software and layout versions are recorded separately:
  - `spine_version`
  - `format = spine_hdf5`
  - `format_version`
- Appending with a different format version is rejected.
- Stage HDF5 files remain pinned to their existing legacy layout.

## Usage

V1 remains the default. Enable V2 explicitly:

```yaml
io:
  writer:
    name: hdf5
    format_version: 2
```

No reader configuration change is required.

## Output validation

The semantic comparator supports:

- V1 ↔ V1
- V2 ↔ V2
- V1 ↔ V2

It normalizes references, offsets, variable-field pools, and dataset ordering before comparing event content.

```bash
python3 bin/output/output_compare.py reference.h5 candidate.h5
```

For deterministic comparisons:

```bash
python3 bin/output/output_compare.py reference.h5 candidate.h5 --exact
```

Products can be selected or omitted with `--keys` and `--skip-keys`.

## Validation performed

- 133 HDF5 reader, writer, and comparator tests pass.
- Coverage includes:
  - V1/V2 round trips
  - Direct V1-to-V2 semantic equivalence
  - Scalars, strings, tensors, objects, and empty collections
  - Same-width and mixed-width nested lists
  - Variable object attributes
  - Derived-property availability without SPINE reconstruction
  - Appending and format mismatch rejection
  - Reader product projection
  - Run/event mapping
  - Unknown format-version rejection

## Rollout

This PR does not change the default writer format. V2 remains opt-in pending representative production validation of:

- Semantic equivalence
- Read/write throughput
- File size
- External CAF/ROOT consumer compatibility

Changing the default to V2 can follow in a minor release after validation.