### PR TITLE
Fix container publishing retention and recovery

### DIFF
--- a/.github/scripts/verify-container-image.sh
+++ b/.github/scripts/verify-container-image.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if (( $# < 2 )); then
+  echo "Usage: $0 REPOSITORY REFERENCE [REFERENCE ...]" >&2
+  exit 2
+fi
+
+repository="${1%/}"
+shift
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required" >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 2
+fi
+
+visited_references=()
+
+verify_reference() {
+  local reference="$1"
+  local raw
+  local digest
+  local child
+  local visited
+
+  for visited in "${visited_references[@]-}"; do
+    if [[ "${visited}" == "${reference}" ]]; then
+      return
+    fi
+  done
+  visited_references[${#visited_references[@]}]="${reference}"
+
+  echo "Verifying ${reference}"
+  raw="$(docker buildx imagetools inspect "${reference}" --raw)"
+  jq -e '.schemaVersion == 2' <<< "${raw}" >/dev/null
+
+  while IFS= read -r digest; do
+    [[ -n "${digest}" ]] || continue
+    child="${repository}@${digest}"
+    verify_reference "${child}"
+  done < <(jq -r '.manifests[]?.digest // empty' <<< "${raw}")
+}
+
+for reference in "$@"; do
+  [[ -n "${reference}" ]] || continue
+  if [[ "${reference}" == *"/"* && \
+        ( "${reference}" == *":"* || "${reference}" == *"@"* ) ]]; then
+    verify_reference "${reference}"
+  else
+    verify_reference "${repository}:${reference}"
+  fi
+done
+
+echo "All referenced manifests are available."

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,7 +4,12 @@ on:
   push:
     tags:
       - 'v*.*.*'
-  workflow_dispatch:
+
+concurrency:
+  # Publishing updates the shared BuildKit cache and mutable semver aliases.
+  # Serialize releases so two tag pushes cannot race those updates.
+  group: docker-publish
+  cancel-in-progress: false
 
 env:
   REGISTRY: ghcr.io
@@ -14,6 +19,7 @@ env:
 jobs:
   build-spine:
     runs-on: ubuntu-latest
+    timeout-minutes: 360
     permissions:
       contents: read
       packages: write
@@ -44,35 +50,34 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push spine image
-        uses: docker/build-push-action@v5
+        id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/spine/Dockerfile
           platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
           pull: true
           cache-from: |
             type=registry,ref=${{ env.CACHE_IMAGE }}
-            type=gha,scope=spine-${{ github.ref_name }}
-            type=gha,scope=spine-main
+            type=gha,scope=spine-release
           cache-to: |
             type=registry,ref=${{ env.CACHE_IMAGE }},mode=max
-            type=gha,scope=spine-${{ github.ref_name }},mode=max
+            type=gha,scope=spine-release,mode=max
 
-  cleanup-old-images:
-    runs-on: ubuntu-latest
-    needs: [build-spine]
-    if: github.event_name != 'pull_request'
-    permissions:
-      packages: write
+      - name: Verify every published manifest reference
+        env:
+          PUBLISHED_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          mapfile -t tags <<< "${PUBLISHED_TAGS}"
+          .github/scripts/verify-container-image.sh \
+            "${REGISTRY}/${IMAGE_NAME}" "${tags[@]}"
 
-    steps:
-      - name: Delete old untagged spine images
-        uses: actions/delete-package-versions@v5
-        with:
-          package-name: 'spine'
-          package-type: 'container'
-          min-versions-to-keep: 5
-          delete-only-untagged-versions: 'true'
+      # Release images are immutable reproducibility artifacts. Do not run an
+      # "untagged package" cleanup against this package: GHCR represents the
+      # platform images and attestations referenced by a tagged OCI index as
+      # untagged package versions. The disposable BuildKit cache lives in the
+      # separate spine-buildcache package.

--- a/.github/workflows/docker-repair.yml
+++ b/.github/workflows/docker-repair.yml
@@ -1,0 +1,244 @@
+name: Repair Published Docker Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      versions:
+        description: JSON array of release versions to inspect and repair
+        required: true
+        type: string
+        default: '["0.10.8","0.10.9","0.10.10","0.10.11","0.10.12","0.10.13","0.11.0","0.11.1","0.12.0","0.12.1","0.12.2","0.12.3","0.12.4","0.13.0","0.13.1","0.13.2","0.13.3","0.14.0","0.14.1","0.14.2","0.15.0","0.15.1","0.15.2","0.15.3","0.15.4","0.15.5","0.16.0","0.16.1","0.16.2","0.16.3"]'
+      restore_deleted:
+        description: Restore matching GHCR package versions still in the 30-day recovery window
+        required: true
+        type: boolean
+        default: true
+      publish_rebuilds:
+        description: Rebuild and overwrite tags that remain broken after restoration
+        required: true
+        type: boolean
+        default: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}
+  PACKAGE_NAME: spine
+  CACHE_IMAGE: ghcr.io/deeplearnphysics/spine-buildcache:buildcache
+
+concurrency:
+  group: docker-repair
+  cancel-in-progress: false
+
+jobs:
+  restore-deleted-manifests:
+    if: inputs.restore_deleted
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out repair tooling
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Find missing child manifests
+        env:
+          VERSIONS: ${{ inputs.versions }}
+        run: |
+          : > missing-manifests.txt
+          jq -er 'type == "array" and all(.[]; type == "string" and test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' \
+            <<< "${VERSIONS}" >/dev/null
+
+          while IFS= read -r version; do
+            raw="$(docker buildx imagetools inspect \
+              "${IMAGE_REPOSITORY}:${version}" --raw)"
+            while IFS= read -r digest; do
+              if ! docker buildx imagetools inspect \
+                "${IMAGE_REPOSITORY}@${digest}" --raw >/dev/null 2>&1; then
+                echo "${digest}" | tee -a missing-manifests.txt
+              fi
+            done < <(jq -r '.manifests[]?.digest // empty' <<< "${raw}")
+          done < <(jq -r '.[]' <<< "${VERSIONS}")
+
+          sort -u -o missing-manifests.txt missing-manifests.txt
+
+      - name: Restore recoverable package versions
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ ! -s missing-manifests.txt ]]; then
+            echo "No missing child manifests were found."
+            exit 0
+          fi
+
+          gh api --paginate \
+            "/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/${PACKAGE_NAME}/versions?state=deleted&per_page=100" \
+            --jq '.[] | [.id, .name] | @tsv' |
+          while IFS=$'\t' read -r id name; do
+            if grep -Fxq "${name}" missing-manifests.txt; then
+              echo "Restoring ${name} (package version ${id})"
+              gh api --method POST \
+                "/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/${PACKAGE_NAME}/versions/${id}/restore"
+            fi
+          done
+
+  rebuild-missing-images:
+    needs: restore-deleted-manifests
+    if: ${{ always() && (needs.restore-deleted-manifests.result == 'success' || needs.restore-deleted-manifests.result == 'skipped') }}
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        version: ${{ fromJSON(inputs.versions) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out repair tooling
+        uses: actions/checkout@v6
+        with:
+          path: tooling
+
+      - name: Validate version
+        env:
+          VERSION: ${{ matrix.version }}
+        run: |
+          [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+
+      - name: Check out release source
+        uses: actions/checkout@v6
+        with:
+          ref: v${{ matrix.version }}
+          path: source
+
+      - name: Confirm release tag
+        id: source-revision
+        env:
+          VERSION: ${{ matrix.version }}
+        run: |
+          test "$(git -C source describe --tags --exact-match)" = "v${VERSION}"
+          echo "commit=$(git -C source rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Check whether the image is already healthy
+        id: preflight
+        env:
+          VERSION: ${{ matrix.version }}
+        run: |
+          if tooling/.github/scripts/verify-container-image.sh \
+            "${IMAGE_REPOSITORY}" "${VERSION}"; then
+            echo "needs_repair=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "needs_repair=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Generate repair metadata
+        if: steps.preflight.outputs.needs_repair == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_REPOSITORY }}
+          tags: type=raw,value=${{ matrix.version }}
+          labels: |
+            org.opencontainers.image.version=${{ matrix.version }}
+            org.opencontainers.image.revision=${{ steps.source-revision.outputs.commit }}
+
+      - name: Rebuild release image
+        if: steps.preflight.outputs.needs_repair == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: source
+          file: source/docker/spine/Dockerfile
+          platforms: linux/amd64
+          push: ${{ inputs.publish_rebuilds }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          pull: true
+          cache-from: |
+            type=registry,ref=${{ env.CACHE_IMAGE }}
+            type=gha,scope=spine-repair-${{ matrix.version }}
+          cache-to: type=gha,scope=spine-repair-${{ matrix.version }},mode=max
+
+      - name: Verify repaired image
+        if: steps.preflight.outputs.needs_repair == 'true' && inputs.publish_rebuilds
+        env:
+          VERSION: ${{ matrix.version }}
+        run: |
+          tooling/.github/scripts/verify-container-image.sh \
+            "${IMAGE_REPOSITORY}" "${VERSION}"
+
+  repair-moving-aliases:
+    needs: rebuild-missing-images
+    if: ${{ always() && inputs.publish_rebuilds && needs.rebuild-missing-images.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out repair tooling
+        uses: actions/checkout@v6
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Repair broken minor and latest aliases
+        env:
+          VERSIONS: ${{ inputs.versions }}
+        run: |
+          mapfile -t versions < <(jq -r '.[]' <<< "${VERSIONS}" | sort -V)
+          mapfile -t minors < <(printf '%s\n' "${versions[@]}" | sed 's/\.[^.]*$//' | sort -Vu)
+
+          for minor in "${minors[@]}"; do
+            if .github/scripts/verify-container-image.sh \
+              "${IMAGE_REPOSITORY}" "${minor}"; then
+              continue
+            fi
+            target="$(printf '%s\n' "${versions[@]}" | \
+              awk -v prefix="${minor}." 'index($0, prefix) == 1' | tail -n 1)"
+            .github/scripts/verify-container-image.sh \
+              "${IMAGE_REPOSITORY}" "${target}"
+            docker buildx imagetools create \
+              --tag "${IMAGE_REPOSITORY}:${minor}" \
+              "${IMAGE_REPOSITORY}:${target}"
+            .github/scripts/verify-container-image.sh \
+              "${IMAGE_REPOSITORY}" "${minor}"
+          done
+
+          if ! .github/scripts/verify-container-image.sh \
+            "${IMAGE_REPOSITORY}" latest; then
+            target="${versions[${#versions[@]}-1]}"
+            .github/scripts/verify-container-image.sh \
+              "${IMAGE_REPOSITORY}" "${target}"
+            docker buildx imagetools create \
+              --tag "${IMAGE_REPOSITORY}:latest" \
+              "${IMAGE_REPOSITORY}:${target}"
+            .github/scripts/verify-container-image.sh \
+              "${IMAGE_REPOSITORY}" latest
+          fi


### PR DESCRIPTION
## Summary

- stop deleting untagged versions from the release package, because GHCR exposes OCI index children as untagged package versions
- serialize releases and use a stable shared BuildKit cache scope
- verify every manifest referenced by each published tag before declaring a release successful
- add a manually dispatched recovery workflow that restores exact deleted package versions when possible, rebuilds only releases that remain broken, and repairs broken semver aliases

## Root cause

`actions/delete-package-versions` deleted the untagged platform and provenance manifests referenced by tagged OCI indexes. The parent indexes and tags remained visible, but fresh pulls failed with `manifest unknown`.

## Validation

- `actionlint` passes for all workflows
- ShellCheck passes for the new verifier
- repository pre-commit hooks pass
- the verifier accepts healthy `0.16.3`
- the verifier rejects broken `0.15.5` at its missing amd64 child digest

## Recovery

After merge, run **Repair Published Docker Images** with restoration enabled. Exact deleted manifests still inside GitHub's 30-day recovery window are restored first. Set `publish_rebuilds` to true to rebuild only releases whose manifests are no longer recoverable.
