### PR TITLE
Normalize container repository name

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: deeplearnphysics/spine
   CACHE_IMAGE: ghcr.io/deeplearnphysics/spine-buildcache:buildcache
 
 jobs:

--- a/.github/workflows/docker-repair.yml
+++ b/.github/workflows/docker-repair.yml
@@ -21,8 +21,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  IMAGE_REPOSITORY: ghcr.io/${{ github.repository }}
+  IMAGE_REPOSITORY: ghcr.io/deeplearnphysics/spine
   PACKAGE_NAME: spine
   CACHE_IMAGE: ghcr.io/deeplearnphysics/spine-buildcache:buildcache
 


### PR DESCRIPTION
## Summary

Use the canonical lowercase GHCR repository name in the publishing and recovery workflows.

## Root cause

`github.repository` evaluates to `DeepLearnPhysics/spine`. Docker metadata-action normalized that value during normal publishing, but direct `docker buildx imagetools` calls rejected it because Docker repository names must be lowercase. The first recovery run therefore stopped before restoring or rebuilding anything.

## Validation

- actionlint passes
- repository pre-commit hooks pass
- live recursive verification of `ghcr.io/deeplearnphysics/spine:0.16.3` passes
