### PR TITLE
Share cache across container repairs

### DIFF
--- a/.github/workflows/docker-repair.yml
+++ b/.github/workflows/docker-repair.yml
@@ -91,7 +91,11 @@ jobs:
     if: ${{ always() && (needs.restore-deleted-manifests.result == 'success' || needs.restore-deleted-manifests.result == 'skipped') }}
     strategy:
       fail-fast: false
-      max-parallel: 2
+      # Rebuilds are deliberately serialized so each historical release can
+      # consume the cache exported by the preceding release. In particular,
+      # compiling MinkowskiEngine takes tens of minutes and many adjacent
+      # releases use the same Dockerfile.
+      max-parallel: 1
       matrix:
         version: ${{ fromJSON(inputs.versions) }}
     runs-on: ubuntu-latest
@@ -173,8 +177,8 @@ jobs:
           pull: true
           cache-from: |
             type=registry,ref=${{ env.CACHE_IMAGE }}
-            type=gha,scope=spine-repair-${{ matrix.version }}
-          cache-to: type=gha,scope=spine-repair-${{ matrix.version }},mode=max
+            type=gha,scope=spine-repair
+          cache-to: type=gha,scope=spine-repair,mode=max
 
       - name: Verify repaired image
         if: steps.preflight.outputs.needs_repair == 'true' && inputs.publish_rebuilds


### PR DESCRIPTION
## What changed

- serialize historical container rebuilds with `max-parallel: 1`
- use a shared `spine-repair` GitHub Actions cache scope across matrix jobs
- keep the production registry/release cache isolated from historical recovery

## Root cause

The repair workflow used a version-specific cache scope. Every repaired release
therefore recompiled MinkowskiEngine and uploaded a cache that no later release
could consume. Adjacent releases often have byte-identical Dockerfiles, so those
roughly 50-minute rebuilds were unnecessary.

## Impact

A repaired release now seeds the next historical release. Already-healthy tags
are still detected and skipped, while production release caching is unchanged.

## Validation

- `actionlint`
- `git diff --check`
- repository pre-commit hooks
