### PR TITLE
Persist container repair cache in GHCR

### DIFF
--- a/.github/workflows/docker-repair.yml
+++ b/.github/workflows/docker-repair.yml
@@ -24,6 +24,7 @@ env:
   IMAGE_REPOSITORY: ghcr.io/deeplearnphysics/spine
   PACKAGE_NAME: spine
   CACHE_IMAGE: ghcr.io/deeplearnphysics/spine-buildcache:buildcache
+  REPAIR_CACHE_IMAGE: ghcr.io/deeplearnphysics/spine-buildcache:repair
 
 concurrency:
   group: docker-repair
@@ -177,8 +178,8 @@ jobs:
           pull: true
           cache-from: |
             type=registry,ref=${{ env.CACHE_IMAGE }}
-            type=gha,scope=spine-repair
-          cache-to: type=gha,scope=spine-repair,mode=max
+            type=registry,ref=${{ env.REPAIR_CACHE_IMAGE }}
+          cache-to: type=registry,ref=${{ env.REPAIR_CACHE_IMAGE }},mode=max
 
       - name: Verify repaired image
         if: steps.preflight.outputs.needs_repair == 'true' && inputs.publish_rebuilds


### PR DESCRIPTION
## What changed

- add a dedicated `ghcr.io/deeplearnphysics/spine-buildcache:repair` cache
- import both the normal release cache and the dedicated repair cache
- export historical rebuild cache only to the dedicated repair tag

## Root cause

The recovery workflow exported rebuilt historical layers only to GitHub Actions
cache. The repository was using roughly 12.8 GB of Actions caches, above the
BuildKit backend's documented 10 GB shared limit, and an adjacent release with
an identical Dockerfile rebuilt MinkowskiEngine instead of finding the layer.

The normal publishing workflow does not exhibit this behavior because it also
uses a registry-backed cache.

## Impact

Historical rebuilds retain durable cross-job cache layers in GHCR without
overwriting the production `spine-buildcache:buildcache` tag. Sequential repair
execution remains in place.

## Validation

- `actionlint`
- `git diff --check`
- repository pre-commit hooks
