### PR TITLE
Extend training checkpoints and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,12 @@ train:
   optimizer:
     name: Adam
     lr: 0.001
+  lr_scheduler:
+    name: ReduceLROnPlateau
+    interval: checkpoint
+    monitor: loss
+    mode: min
+    patience: 2
 
 validation:
   file_keys: /path/to/validation/*.root
@@ -300,6 +306,10 @@ validation:
     monitor: loss
     mode: min
     patience: 5
+    min_delta: 0.0
+  best_checkpoint:
+    monitor: loss
+    mode: min
     min_delta: 0.0
 ```
 
@@ -319,7 +329,88 @@ validation:
 Use source names `larcv` and `hdf5` instead for a mixed dataset. Joint
 validation retains the overlay distribution but uses repeatable sequential
 primary/secondary pairing. Validation scalar outputs are logged with a
-`val_` prefix and stored in the checkpoint with early-stopping state.
+`val_` prefix and stored in the checkpoint with early-stopping and
+best-checkpoint state. When `best_checkpoint` is enabled, an improving
+snapshot is atomically copied to `<weight_prefix>-best.ckpt` with its own
+checksum. Set `best_checkpoint.path` to choose another stable destination.
+
+Learning-rate schedulers default to `interval: step`, preserving the
+historical update after every optimizer step. `interval: checkpoint` advances
+the scheduler after each checkpoint-bound validation and before serializing
+its state. An optional `monitor` passes the named validation scalar to metric-
+aware schedulers such as `ReduceLROnPlateau`; monitored schedulers therefore
+require a validation block.
+
+During distributed training, scalar model/loss outputs are averaged across
+ranks before CSV and stdout logging. Rank-specific timings and memory metrics
+remain local, while TensorBoard events are emitted by rank zero only.
+
+SPINE checkpoints use a versioned, backward-compatible format. In addition to
+model weights and progress, new checkpoints record optimizer and optional
+learning-rate-scheduler state, per-rank RNG and loader continuation state, the
+complete normalized configuration, resolved training/validation dataset
+sources, and a runtime manifest containing the SPINE/Python/PyTorch versions,
+creation time, distributed world size and source revision when discoverable.
+Every checkpoint is written atomically with an adjacent SHA-256 checksum:
+
+```text
+snapshot-1000.ckpt
+snapshot-1000.ckpt.sha256
+```
+
+When training is configured with one top-level `model.weight_path`, SPINE
+automatically restores all available training state. Use `resume: true` to
+make complete restoration strict: a checkpoint without optimizer state is
+then rejected. The historical `restore_optimizer: true` option remains
+supported and has the same strict behavior:
+
+```yaml
+model:
+  weight_path: weights/snapshot-1000.ckpt
+
+train:
+  resume: true
+  optimizer:
+    name: Adam
+    lr: 0.001
+```
+
+Set `resume: false` explicitly to use `weight_path` only as parameter
+initialization and start a new training process at iteration zero. The same
+choices are available as `--resume` and `--no-resume` command-line overrides.
+Training accepts exactly one checkpoint; `weight_list` remains an
+inference-only facility. During automatic resume, a legacy checkpoint without
+optimizer state retains its saved progress, restarts the optimizer and emits
+a warning.
+
+Epoch progress is restored independently from the global iteration number.
+Changing the batch size while resuming therefore continues from the saved
+epoch and recomputes the remaining epoch-based run length using the new
+number of batches per epoch. The global step remains monotonic. A batch-size
+change preserves the saved sample order when sampler state is available, but
+necessarily changes subsequent batch boundaries and emits a warning.
+
+Legacy checkpoints without scheduler, RNG or loader state still load. SPINE
+warns when a requested resume must restart missing state. Exact stochastic
+continuation requires the same distributed world size. DataLoader worker RNG
+and prefetch queues cannot be serialized, so configurations with worker-side
+stochastic transforms may reproduce the same sample order without being
+bit-for-bit identical. Exact mid-epoch sample order also requires a
+checkpointable SPINE sampler; generic third-party samplers are replayed to the
+saved cursor on a best-effort basis. Numba and external-library RNG state is
+not generally introspectable and is not included.
+
+Checkpoint provenance can be queried without constructing the model:
+
+```python
+from spine.model import inspect_checkpoint, verify_checkpoint
+
+assert verify_checkpoint("snapshot-1000.ckpt")
+info = inspect_checkpoint("snapshot-1000.ckpt", verify=True)
+print(info["manifest"])
+print(info["config"])
+print(info["datasets"])
+```
 
 ### Running A Configuration File
 

--- a/src/spine/bin/cli.py
+++ b/src/spine/bin/cli.py
@@ -42,6 +42,7 @@ def main(
     weight_path: str | None,
     weight_list: str | None,
     config_overrides: list[str] | None,
+    resume: bool | None = None,
 ) -> None:
     """Main driver for training/validation/inference/analysis.
 
@@ -83,6 +84,9 @@ def main(
         the model weights
     config_overrides : list[str], optional
         List of config overrides in the form "key.path=value"
+    resume : bool, optional
+        Command-line override for complete training-state restoration. ``None``
+        leaves resume selection to the configuration and automatic defaults.
     """
     # Print the banner before configuration loading starts, since loading may
     # trigger download/cache messages and warnings.
@@ -162,6 +166,13 @@ def main(
         cfg["model"]["weight_path"] = weight_path
     if weight_list is not None:
         cfg["model"]["weight_list"] = weight_list
+
+    # Apply an explicit resume override to either supported train location.
+    if resume is not None:
+        train_cfg = cfg.get("train", cfg["base"].get("train"))
+        if train_cfg is None:
+            raise KeyError("--resume/--no-resume requires a `train` block.")
+        train_cfg["resume"] = resume
 
     # Apply any generic config overrides from --set arguments
     if config_overrides:
@@ -293,6 +304,14 @@ For ML training/inference functionality, ensure PyTorch is installed:
         help="Path to a text file containing a list of weight file paths",
     )
 
+    parser.add_argument(
+        "--resume",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Resume all available training state from the configured checkpoint; "
+        "use --no-resume for weights-only initialization",
+    )
+
     # Add option to dynamically override any config parameter using dot notation
     # (e.g., --set io.loader.batch_size=8)
     parser.add_argument(
@@ -337,6 +356,7 @@ For ML training/inference functionality, ensure PyTorch is installed:
         weight_path=args.weight_path,
         weight_list=args.weight_list,
         config_overrides=args.config_overrides,
+        resume=args.resume,
     )
 
 

--- a/src/spine/driver.py
+++ b/src/spine/driver.py
@@ -15,9 +15,11 @@ import os
 import random
 import subprocess as sc
 import time
+import warnings
 from collections.abc import Mapping
 from copy import deepcopy
 from datetime import datetime
+from numbers import Real
 from typing import Any
 
 import numpy as np
@@ -31,7 +33,7 @@ from .io import IOManager
 from .math import seed as numba_seed
 from .model import ModelManager, ValidationManager
 from .post import PostManager
-from .utils.conditional import TORCH_AVAILABLE
+from .utils.conditional import TORCH_AVAILABLE, torch
 from .utils.log import LogManager
 from .utils.logger import configure_rank_logging, logger
 from .utils.stopwatch import StopwatchManager
@@ -144,6 +146,10 @@ class Driver:
 
         # Initialize the analysis scripts
         self.initialize_ana(ana)
+
+        # Restore stochastic and loader state after every configured module is
+        # constructed, so initialization cannot advance the resumed streams.
+        self.restore_training_runtime()
 
         # Place-holder for the structured log manager, initialized in run()
         self.log_manager = None
@@ -446,6 +452,7 @@ class Driver:
         self.parent_path = parent_path
         self.iterations = iterations
         self.epochs = epochs
+        self.epoch_based = epochs is not None
         self.unwrap = unwrap
         self.seed = seed
         self.log_step = log_step
@@ -539,6 +546,61 @@ class Driver:
             iter_per_epoch=self.io.iter_per_epoch,
         )
 
+    def restore_training_runtime(self) -> None:
+        """Restore this rank's RNG and loader state from a resume checkpoint.
+
+        A runtime snapshot is meaningful only for the same distributed world
+        size that produced it. Model, optimizer and scheduler state remain
+        usable when the world changes, but rank-local stochastic streams and
+        data shards cannot be mapped exactly and are intentionally skipped.
+        """
+        if self.model is None or not getattr(self.model, "resume_training", False):
+            return
+        state = getattr(self.model, "checkpoint_runtime_state", None)
+        if state is None:
+            return
+
+        world_size = max(1, self.world_size)
+        checkpoint_world_size = int(state.get("world_size", 1))
+        if checkpoint_world_size != world_size:
+            warnings.warn(
+                "Checkpoint runtime state was recorded with world size "
+                f"{checkpoint_world_size}, but this run uses {world_size}; RNG "
+                "and loader state will not be restored exactly.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return
+
+        rank = 0 if self.rank is None else self.rank
+        rank_states = state.get("ranks", [])
+        local_state = next(
+            (item for item in rank_states if int(item.get("rank", -1)) == rank),
+            None,
+        )
+        if local_state is None:
+            warnings.warn(
+                f"Checkpoint has no runtime state for rank {rank}; continuation "
+                "will not be bit-for-bit exact.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return
+
+        io_state = local_state.get("io")
+        if io_state is not None:
+            next_iteration = int(io_state.get("next_iteration", -1))
+            if next_iteration != self.model.start_iteration:
+                raise ValueError(
+                    "Checkpoint loader cursor does not match its global step: "
+                    f"expected iteration {self.model.start_iteration}, got "
+                    f"{next_iteration}."
+                )
+
+        runtime.restore_rng_state(local_state["rng"])
+        if io_state is not None:
+            self.io.restore_checkpoint_state(io_state)
+
     def initialize_validation(
         self,
         validation: Mapping[str, Any] | None,
@@ -566,6 +628,13 @@ class Driver:
         """
         self.validation = None
         if validation is None:
+            if (
+                self.model is not None
+                and getattr(self.model, "lr_scheduler_monitor", None) is not None
+            ):
+                raise ValueError(
+                    "A monitored checkpoint scheduler requires a `validation` block."
+                )
             return
         if self.model is None or not self.model.train:
             raise ValueError("On-the-fly validation requires a training model.")
@@ -738,7 +807,9 @@ class Driver:
             log_path,
             overwrite=self.overwrite_log,
             buffer_size=self.csv_buffer_size,
-            tensorboard=self.tensorboard_cfg,
+            tensorboard=(
+                self.tensorboard_cfg if getattr(self, "main_process", True) else None
+            ),
             tensorboard_dir=tb_dir,
         )
 
@@ -799,21 +870,45 @@ class Driver:
         try:
             # Get the iteration start (if model exists)
             start_iteration = 0
+            start_epoch = 0.0
             if self.model is not None and self.model.train:
                 start_iteration = self.model.start_iteration
+                start_epoch = getattr(self.model, "start_epoch", None)
+
+            # Anchor loader epochs to checkpoint progress rather than the old
+            # global iteration-to-batch-size relationship.
+            if start_epoch is not None and hasattr(self.io, "set_resume_progress"):
+                self.io.set_resume_progress(start_iteration, start_epoch)
+
+            # Epoch limits describe total training progress. Re-express the
+            # remaining epochs using the current loader's batch size.
+            stop_iteration = self.iterations
+            epochs = getattr(self, "epochs", None)
+            if epochs is not None and start_epoch is not None:
+                remaining_epochs = max(0.0, epochs - start_epoch)
+                stop_iteration = start_iteration + int(
+                    remaining_epochs * self.io.iter_per_epoch
+                )
 
             # Loop and process each iteration
-            for iteration in range(start_iteration, self.iterations):
+            for iteration in range(start_iteration, stop_iteration):
                 # Let I/O prepare loader state, if using a loader.
                 self.io.prepare_iteration(iteration)
 
                 # Update the epoch counter, record the execution date/time
-                epoch = (iteration + 1) / self.io.iter_per_epoch
+                if start_epoch is None:
+                    epoch = (iteration + 1) / self.io.iter_per_epoch
+                else:
+                    relative_iteration = iteration - start_iteration + 1
+                    epoch = start_epoch + relative_iteration / self.io.iter_per_epoch
                 tstamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
                 # Process one batch/entry of data
                 entry = None if self.io.has_loader else iteration
                 data = self.process(entry=entry, iteration=iteration, epoch=epoch)
+
+                # Report globally representative training scalars under DDP.
+                self.reduce_training_metrics(data)
 
                 # Checkpoint boundaries are driver-owned so all ranks can
                 # validate before rank zero serializes the live weights.
@@ -824,18 +919,66 @@ class Driver:
                     and self.model.should_save(iteration)
                 ):
                     validation_state = None
+                    validation_metrics = None
+                    promote_best = False
                     if self.validation is not None:
-                        metrics = self.validation.run(iteration)
+                        validation_metrics = self.validation.run(iteration)
                         data.update(
-                            {f"val_{key}": value for key, value in metrics.items()}
+                            {
+                                f"val_{key}": value
+                                for key, value in validation_metrics.items()
+                            }
                         )
-                        stop_training = self.validation.update_early_stopping(metrics)
-                        validation_state = self.validation.checkpoint_state(metrics)
+                        promote_best = self.validation.update_best_checkpoint(
+                            validation_metrics
+                        )
+                        stop_training = self.validation.update_early_stopping(
+                            validation_metrics
+                        )
+                        validation_state = self.validation.checkpoint_state(
+                            validation_metrics
+                        )
+
+                    # Checkpoint-bound schedulers advance before their state is saved.
+                    self.model.step_checkpoint_scheduler(validation_metrics)
+
+                    # Every rank contributes its stochastic and loader cursor
+                    # state before rank zero writes the shared checkpoint.
+                    local_runtime_state = {
+                        "rank": 0 if self.rank is None else self.rank,
+                        "rng": runtime.capture_rng_state(),
+                        "io": self.io.checkpoint_state(iteration + 1),
+                    }
+                    rank_states = runtime.distributed_all_gather_object(
+                        local_runtime_state
+                    )
+                    checkpoint_runtime = {
+                        "world_size": max(1, self.world_size),
+                        "ranks": rank_states,
+                    }
 
                     if self.main_process:
                         # Retain model-owned save timing around serialization
                         self.model.watch.start("save")
-                        self.model.save_state(iteration, epoch, validation_state)
+                        datasets = {"train": self.io.dataset_provenance()}
+                        if self.validation is not None:
+                            datasets["validation"] = (
+                                self.validation.io.dataset_provenance()
+                            )
+                        checkpoint_path = self.model.save_state(
+                            iteration,
+                            epoch,
+                            validation_state,
+                            config=self.cfg,
+                            datasets=datasets,
+                            runtime_state=checkpoint_runtime,
+                            world_size=max(1, self.world_size),
+                        )
+                        if promote_best:
+                            assert self.validation is not None
+                            assert self.validation.best_checkpoint is not None
+                            best_path = self.validation.best_checkpoint.path
+                            self.model.save_best_state(checkpoint_path, best_path)
                         self.model.watch.stop("save")
                         self.watch.update(self.model.watch, "model")
 
@@ -860,10 +1003,55 @@ class Driver:
             self.ana.close()
         if self.log_manager is not None:
             self.log_manager.close()
-        if getattr(self, "validation", None) is not None:
-            self.validation.close()
+        validation = getattr(self, "validation", None)
+        if validation is not None:
+            validation.close()
         if hasattr(self, "io"):
             self.io.close()
+
+    def reduce_training_metrics(self, data: dict[str, Any]) -> None:
+        """Average scalar training outputs across distributed ranks in place.
+
+        Structured outputs, timings and memory statistics remain rank-local.
+        Validation scalars are reduced by :class:`ValidationManager` and are
+        appended only after this method runs.
+
+        Parameters
+        ----------
+        data : dict
+            Current processed batch containing model and loss outputs.
+        """
+        if (
+            not TORCH_AVAILABLE
+            or not getattr(self, "distributed", False)
+            or self.model is None
+            or not self.model.train
+            or not torch.distributed.is_initialized()
+        ):
+            return
+
+        scalar_keys = []
+        scalar_values = []
+        for key, value in data.items():
+            if isinstance(value, Real) and not isinstance(value, bool):
+                scalar_keys.append(key)
+                scalar_values.append(float(value))
+            elif torch.is_tensor(value) and value.dim() == 0:
+                scalar_keys.append(key)
+                scalar_values.append(float(value.item()))
+
+        if not scalar_keys:
+            return
+
+        reduced = torch.tensor(
+            scalar_values,
+            dtype=torch.float64,
+            device=self.model.device,
+        )
+        torch.distributed.all_reduce(reduced)
+        reduced /= torch.distributed.get_world_size()
+        for key, value in zip(scalar_keys, reduced.tolist()):
+            data[key] = value
 
     def process(
         self,

--- a/src/spine/io/manager.py
+++ b/src/spine/io/manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from collections.abc import Mapping
 from typing import Any
 
@@ -139,6 +140,10 @@ class IOManager:
         self.reader = None
         self.writer = None
         self.columnar = False
+        self._resume_skip_batches = 0
+        self._iteration_origin = 0
+        self._epoch_origin = 0
+        self._epoch_batch_offset = 0
         self.iterations = iterations
         self.epochs = epochs
         self.distributed = distributed
@@ -521,6 +526,149 @@ class IOManager:
         if self.loader is not None:
             self.loader_iter = iter(self.loader)
 
+            # Generic samplers cannot expose their generated epoch order. In
+            # that case, replay batches up to the checkpoint cursor.
+            for _ in range(self._resume_skip_batches):
+                next(self.loader_iter)
+            self._resume_skip_batches = 0
+
+    def checkpoint_state(self, next_iteration: int) -> dict[str, Any] | None:
+        """Return loader state needed to continue at ``next_iteration``.
+
+        Parameters
+        ----------
+        next_iteration : int
+            First global iteration which will run after the checkpoint.
+
+        Returns
+        -------
+        dict or None
+            Loader cursor and optional checkpointable sampler state. Reader
+            mode has no training iterator and returns ``None``.
+        """
+        if self.loader is None:
+            return None
+
+        batch_offset = next_iteration % self.iter_per_epoch
+        sampler = self.loader.sampler
+        sampler_state = None
+        if hasattr(sampler, "state_dict"):
+            sample_offset = batch_offset * int(self.loader.batch_size)
+            try:
+                sampler_state = sampler.state_dict(offset=sample_offset)
+            except TypeError:
+                sampler_state = sampler.state_dict()
+
+        return {
+            "next_iteration": int(next_iteration),
+            "batch_offset": int(batch_offset),
+            "batch_size": int(self.loader.batch_size),
+            "sampler": sampler_state,
+            "num_workers": int(self.loader.num_workers),
+        }
+
+    def restore_checkpoint_state(self, state: Mapping[str, Any]) -> None:
+        """Restore a loader cursor and checkpointable sampler state.
+
+        Parameters
+        ----------
+        state : mapping
+            Loader state produced by :meth:`checkpoint_state`.
+
+        Notes
+        -----
+        Worker-process RNG and prefetch queues cannot be serialized by a
+        PyTorch DataLoader. Runs with workers replay the same sample indexes,
+        but stochastic worker-side augmentation may not be bit-for-bit exact.
+        """
+        if self.loader is None:
+            raise ValueError("Cannot restore loader state without a loader.")
+
+        checkpoint_batch_size = int(state.get("batch_size", self.loader.batch_size))
+        if checkpoint_batch_size != int(self.loader.batch_size):
+            warnings.warn(
+                "Training batch size changed from "
+                f"{checkpoint_batch_size} to {self.loader.batch_size}; sample "
+                "order is retained, but resumed batch boundaries will differ.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+        # Interpret the saved cursor using the batch size that produced it.
+        batch_offset = int(state.get("batch_offset", 0))
+        sampler_state = state.get("sampler")
+        sampler = self.loader.sampler
+        if sampler_state is not None and hasattr(sampler, "load_state_dict"):
+            sample_offset = batch_offset * checkpoint_batch_size
+            sampler.load_state_dict(sampler_state, offset=sample_offset)
+        elif batch_offset:
+            self._resume_skip_batches = batch_offset
+            warnings.warn(
+                "The checkpoint loader used a sampler without resumable state; "
+                "replaying batches to the saved cursor.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+        if int(state.get("num_workers", 0)) > 0:
+            warnings.warn(
+                "DataLoader worker RNG and prefetch queues cannot be restored; "
+                "sample order is preserved but stochastic worker transforms may "
+                "not resume bit-for-bit.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+        self.loader_iter = None
+
+    def set_resume_progress(self, iteration: int, epoch: float) -> None:
+        """Anchor loader epoch boundaries to restored checkpoint progress.
+
+        Parameters
+        ----------
+        iteration : int
+            First global iteration to execute in the resumed process.
+        epoch : float
+            Completed epoch progress stored in the checkpoint.
+        """
+        self._iteration_origin = int(iteration)
+        self._epoch_origin = int(epoch)
+
+        # Preserve a fractional checkpoint position in the new loader cadence.
+        fraction = epoch - self._epoch_origin
+        self._epoch_batch_offset = int(round(fraction * self.iter_per_epoch))
+
+    def dataset_provenance(self) -> dict[str, Any] | None:
+        """Describe resolved dataset sources owned by this manager."""
+        if self.loader is None:
+            if self.reader is None:
+                return None
+            return {
+                "type": type(self.reader).__name__,
+                "files": list(self.reader.file_paths),
+            }
+        return self._dataset_provenance(self.loader.dataset)
+
+    @classmethod
+    def _dataset_provenance(cls, dataset: Any) -> dict[str, Any]:
+        """Recursively describe ordinary, joint and mixed dataset sources."""
+        result: dict[str, Any] = {
+            "type": getattr(dataset, "name", type(dataset).__name__),
+            "entries": len(dataset),
+        }
+        if getattr(dataset, "joint", False):
+            result["sources"] = {
+                "primary": cls._dataset_provenance(dataset.primary),
+                "secondary": cls._dataset_provenance(dataset.secondary),
+            }
+        elif hasattr(dataset, "primary") and hasattr(dataset, "cache"):
+            result["sources"] = {
+                "larcv": cls._dataset_provenance(dataset.primary),
+                "hdf5": cls._dataset_provenance(dataset.cache),
+            }
+        elif getattr(dataset, "reader", None) is not None:
+            result["files"] = list(dataset.reader.file_paths)
+        return result
+
     def prepare_iteration(self, iteration: int) -> None:
         """Prepare loader state for a driver iteration.
 
@@ -534,9 +682,12 @@ class IOManager:
         if self.loader is None:
             return
 
-        if self.loader_iter is None or iteration % self.iter_per_epoch == 0:
+        # Work in checkpoint-relative coordinates when batch size has changed.
+        relative_iteration = iteration - self._iteration_origin
+        epoch_iteration = self._epoch_batch_offset + relative_iteration
+        if self.loader_iter is None or epoch_iteration % self.iter_per_epoch == 0:
             if self.distributed:
-                epoch_cnt = iteration // self.iter_per_epoch
+                epoch_cnt = self._epoch_origin + epoch_iteration // self.iter_per_epoch
                 self.loader.sampler.set_epoch(epoch_cnt)
             self.reset_loader()
 

--- a/src/spine/io/sample.py
+++ b/src/spine/io/sample.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 import time
-from collections.abc import Iterator, Sized
+from collections.abc import Iterator, Mapping, Sized
 from typing import Any
 
 import numpy as np
@@ -39,6 +39,38 @@ __all__ = [
     "JointRandomSequenceBatchSampler",
     "JointBootstrapBatchSampler",
 ]
+
+
+def _serialize_random_state(state: tuple) -> dict[str, Any]:
+    """Convert a NumPy ``RandomState`` tuple to checkpoint-safe values."""
+    name, keys, position, has_gaussian, cached_gaussian = state
+    return {
+        "name": name,
+        "keys": keys.tolist(),
+        "position": int(position),
+        "has_gaussian": int(has_gaussian),
+        "cached_gaussian": float(cached_gaussian),
+    }
+
+
+def _deserialize_random_state(state: Mapping[str, Any]) -> tuple:
+    """Reconstruct a NumPy ``RandomState`` tuple from checkpoint values."""
+    return (
+        state["name"],
+        np.asarray(state["keys"], dtype=np.uint32),
+        int(state["position"]),
+        int(state["has_gaussian"]),
+        float(state["cached_gaussian"]),
+    )
+
+
+def _normalize_index(index: Any) -> Any:
+    """Cast NumPy scalar indexes recursively to Python primitives."""
+    if isinstance(index, np.generic):
+        return index.item()
+    if isinstance(index, tuple):
+        return tuple(_normalize_index(value) for value in index)
+    return index
 
 
 class AbstractBatchSampler(Sampler):
@@ -88,6 +120,8 @@ class AbstractBatchSampler(Sampler):
             ), f"The sampler seed must be an integer, got: {seed}."
 
         self._random = np.random.RandomState(seed=seed)  # pylint: disable=E1101
+        self._last_indices: list[Any] | None = None
+        self._resume_indices: list[Any] | None = None
 
         # Check that the batch_size is a sensible value
         self.batch_size = batch_size
@@ -126,6 +160,61 @@ class AbstractBatchSampler(Sampler):
         """Placeholder to be overridden by children classes."""
         raise NotImplementedError
 
+    def _resume(self) -> Iterator[Any] | None:
+        """Return and consume a restored partial-epoch index stream."""
+        if self._resume_indices is None:
+            return None
+        indices = self._resume_indices
+        self._resume_indices = None
+        return iter(indices)
+
+    def _record(self, indices: Any) -> Iterator[Any]:
+        """Cache one generated epoch order and return its iterator."""
+        self._last_indices = [_normalize_index(index) for index in indices]
+        return iter(self._last_indices)
+
+    def state_dict(self, offset: int | None = None) -> dict[str, Any]:
+        """Return sampler RNG and optional remaining epoch order.
+
+        ``offset=None`` retains the full cached order for direct callers.
+        Checkpoint code supplies an integer cursor, allowing epoch-boundary
+        checkpoints to omit indexes and mid-epoch checkpoints to store only
+        the unconsumed suffix.
+        """
+        indices = self._last_indices
+        partial_epoch = offset is not None and offset > 0
+        if offset is not None:
+            indices = None if offset == 0 or indices is None else indices[offset:]
+        return {
+            "random": _serialize_random_state(self._random.get_state()),
+            "indices": indices,
+            "partial_epoch": partial_epoch,
+        }
+
+    def load_state_dict(
+        self,
+        state: Mapping[str, Any],
+        offset: int = 0,
+    ) -> None:
+        """Restore sampler state and resume a cached epoch from ``offset``.
+
+        Parameters
+        ----------
+        state : mapping
+            State produced by :meth:`state_dict`.
+        offset : int, default 0
+            Number of process-local samples already consumed in the cached
+            epoch. Zero starts a new epoch from the restored RNG state.
+        """
+        self._random.set_state(_deserialize_random_state(state["random"]))
+        indices = state.get("indices")
+        self._last_indices = None if indices is None else list(indices)
+        self._resume_indices = None
+        if state.get("partial_epoch") and self._last_indices is not None:
+            self._resume_indices = self._last_indices
+        elif offset and self._last_indices is not None:
+            self._resume_indices = self._last_indices[offset:]
+
 
 class SequentialBatchSampler(AbstractBatchSampler):
     """Samples batches sequentially within the dataset."""
@@ -134,8 +223,11 @@ class SequentialBatchSampler(AbstractBatchSampler):
 
     def __iter__(self) -> Iterator[int]:
         """Iterates over sequential batches of data."""
+        resumed = self._resume()
+        if resumed is not None:
+            return resumed
         order = np.arange(self.num_samples, dtype=int)
-        return iter(order)
+        return self._record(order)
 
 
 class RandomSequenceBatchSampler(AbstractBatchSampler):
@@ -147,6 +239,10 @@ class RandomSequenceBatchSampler(AbstractBatchSampler):
         """Iterates over sequential batches of data randomly located
         in the dataset.
         """
+        resumed = self._resume()
+        if resumed is not None:
+            return resumed
+
         # Pick a general offset and produce sequence starts with respect to it.
         # Introducing this random offset ensures that the data is not
         # systematically batched in the same way
@@ -167,7 +263,7 @@ class RandomSequenceBatchSampler(AbstractBatchSampler):
         # Wrap indexes around if the offset is non-zero
         indices = indices % self.num_samples
 
-        return iter(indices)
+        return self._record(indices)
 
 
 class BootstrapBatchSampler(AbstractBatchSampler):
@@ -183,9 +279,13 @@ class BootstrapBatchSampler(AbstractBatchSampler):
         """Iterates over bootstrapped batches of data randomly picked
         from the dataset.
         """
+        resumed = self._resume()
+        if resumed is not None:
+            return resumed
+
         max_id = self.num_samples + 1 - self.batch_size
         starts = np.arange(0, max_id, self.batch_size, dtype=int)
-        bootstrap_indices = np.random.choice(
+        bootstrap_indices = self._random.choice(
             np.arange(self.num_samples), self.num_samples
         )
         batches = [
@@ -193,7 +293,7 @@ class BootstrapBatchSampler(AbstractBatchSampler):
             for start in starts
         ]
 
-        return iter(np.concatenate(batches))
+        return self._record(np.concatenate(batches))
 
 
 class _Sized:
@@ -269,6 +369,8 @@ class AbstractJointBatchSampler(Sampler):
         rng_seed = int(time.time()) if seed is None else seed + 2
         self._random_seed = rng_seed
         self._random = np.random.RandomState(seed=rng_seed)  # pylint: disable=E1101
+        self._last_indices: list[tuple[int, int | None]] | None = None
+        self._resume_indices: list[tuple[int, int | None]] | None = None
 
     def __len__(self) -> int:
         """Return the number of primary samples produced per epoch."""
@@ -283,6 +385,11 @@ class AbstractJointBatchSampler(Sampler):
             Primary indexes and independently sampled optional secondary
             indexes.
         """
+        if self._resume_indices is not None:
+            indices = self._resume_indices
+            self._resume_indices = None
+            return iter(indices)
+
         primary_indices = list(self.primary_sampler)
         pair_mask = self._random.random_sample(len(primary_indices))
         pair_mask = pair_mask < self.pair_probability
@@ -300,7 +407,41 @@ class AbstractJointBatchSampler(Sampler):
             else:
                 secondary_indices.append(None)
 
-        return iter(zip(primary_indices, secondary_indices))
+        self._last_indices = [
+            _normalize_index(index) for index in zip(primary_indices, secondary_indices)
+        ]
+        return iter(self._last_indices)
+
+    def state_dict(self, offset: int | None = None) -> dict[str, Any]:
+        """Return paired sampler RNG and optional remaining epoch order."""
+        indices = self._last_indices
+        partial_epoch = offset is not None and offset > 0
+        if offset is not None:
+            indices = None if offset == 0 or indices is None else indices[offset:]
+        return {
+            "random": _serialize_random_state(self._random.get_state()),
+            "primary": self.primary_sampler.state_dict(offset=0),
+            "secondary": self.secondary_sampler.state_dict(offset=0),
+            "indices": indices,
+            "partial_epoch": partial_epoch,
+        }
+
+    def load_state_dict(
+        self,
+        state: Mapping[str, Any],
+        offset: int = 0,
+    ) -> None:
+        """Restore paired sampler state and an optional partial epoch."""
+        self._random.set_state(_deserialize_random_state(state["random"]))
+        self.primary_sampler.load_state_dict(state["primary"])
+        self.secondary_sampler.load_state_dict(state["secondary"])
+        indices = state.get("indices")
+        self._last_indices = None if indices is None else list(indices)
+        self._resume_indices = None
+        if state.get("partial_epoch") and self._last_indices is not None:
+            self._resume_indices = self._last_indices
+        elif offset and self._last_indices is not None:
+            self._resume_indices = self._last_indices[offset:]
 
 
 class JointSequentialBatchSampler(AbstractJointBatchSampler):
@@ -322,6 +463,11 @@ class JointSequentialBatchSampler(AbstractJointBatchSampler):
         iterator of tuple[int, int or None]
             Repeatable primary and optional secondary index pairs.
         """
+        if self._resume_indices is not None:
+            indices = self._resume_indices
+            self._resume_indices = None
+            return iter(indices)
+
         state = self._random.get_state()
         self._random.seed(self._random_seed)
         try:
@@ -390,11 +536,18 @@ class DistributedProxySampler(DistributedSampler):
         # Store the underlying sampler and its parameters
         self.sampler = sampler
         self.batch_size = sampler.batch_size
+        self._last_indices: list[Any] | None = None
+        self._resume_indices: list[Any] | None = None
 
     def __iter__(self) -> Iterator[int]:
         """Overrides the basic iterator with one that takes into account
         the number of replicas and the rank of the sampler.
         """
+        if self._resume_indices is not None:
+            indices = self._resume_indices
+            self._resume_indices = None
+            return iter(indices)
+
         # Fetch the list of non-distributed indices
         indices = list(self.sampler)
 
@@ -419,4 +572,34 @@ class DistributedProxySampler(DistributedSampler):
         indices = [indices[i] for i in np.where(ranks == self.rank)[0]]
         assert len(indices) == self.num_samples
 
-        return iter(indices)
+        self._last_indices = list(indices)
+        return iter(self._last_indices)
+
+    def state_dict(self, offset: int | None = None) -> dict[str, Any]:
+        """Return distributed and underlying sampler state."""
+        indices = self._last_indices
+        partial_epoch = offset is not None and offset > 0
+        if offset is not None:
+            indices = None if offset == 0 or indices is None else indices[offset:]
+        return {
+            "epoch": int(self.epoch),
+            "sampler": self.sampler.state_dict(offset=0),
+            "indices": indices,
+            "partial_epoch": partial_epoch,
+        }
+
+    def load_state_dict(
+        self,
+        state: Mapping[str, Any],
+        offset: int = 0,
+    ) -> None:
+        """Restore distributed sampler state and an optional partial epoch."""
+        self.epoch = int(state.get("epoch", 0))
+        self.sampler.load_state_dict(state["sampler"])
+        indices = state.get("indices")
+        self._last_indices = None if indices is None else list(indices)
+        self._resume_indices = None
+        if state.get("partial_epoch") and self._last_indices is not None:
+            self._resume_indices = self._last_indices
+        elif offset and self._last_indices is not None:
+            self._resume_indices = self._last_indices[offset:]

--- a/src/spine/model/__init__.py
+++ b/src/spine/model/__init__.py
@@ -22,7 +22,7 @@ Key features:
 - Modular configuration-driven model assembly.
 - Support for sparse and dense convolutions.
 - Graph neural network components.
-- Mixed precision and distributed training support.
+- Distributed training support.
 
 Example
 -------
@@ -38,7 +38,24 @@ The module integrates with the broader SPINE ecosystem for data I/O,
 visualization, and post-processing workflows.
 """
 
+from .checkpoint import (
+    CHECKPOINT_FORMAT_VERSION,
+    CheckpointManifest,
+    checkpoint_sha256,
+    inspect_checkpoint,
+    promote_checkpoint,
+    verify_checkpoint,
+)
 from .manager import ModelManager
 from .validation import ValidationManager
 
-__all__ = ["ModelManager", "ValidationManager"]
+__all__ = [
+    "CHECKPOINT_FORMAT_VERSION",
+    "CheckpointManifest",
+    "ModelManager",
+    "ValidationManager",
+    "checkpoint_sha256",
+    "inspect_checkpoint",
+    "promote_checkpoint",
+    "verify_checkpoint",
+]

--- a/src/spine/model/checkpoint.py
+++ b/src/spine/model/checkpoint.py
@@ -1,0 +1,382 @@
+"""Versioned model-checkpoint metadata and artifact utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import shutil
+import socket
+import subprocess as sp
+import tempfile
+from dataclasses import asdict, dataclass, fields
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from spine.utils.conditional import TORCH_AVAILABLE, torch
+from spine.version import __version__
+
+__all__ = [
+    "CHECKPOINT_FORMAT_VERSION",
+    "CheckpointManifest",
+    "checkpoint_sha256",
+    "inspect_checkpoint",
+    "promote_checkpoint",
+    "save_checkpoint",
+    "verify_checkpoint",
+]
+
+CHECKPOINT_FORMAT_VERSION = 2
+
+
+@dataclass(frozen=True)
+class CheckpointManifest:
+    """Portable provenance recorded with every SPINE checkpoint.
+
+    The dataclass is converted to a plain dictionary before serialization so
+    checkpoints remain compatible with PyTorch's restricted ``weights_only``
+    loader and do not require this class to be importable when inspected.
+
+    Attributes
+    ----------
+    created_at : str
+        UTC creation timestamp in ISO-8601 form.
+    spine_version : str
+        SPINE package version which produced the checkpoint.
+    python_version : str
+        Python runtime version.
+    torch_version : str or None
+        PyTorch version, when PyTorch is available.
+    cuda_version : str or None
+        CUDA build version reported by PyTorch, when available.
+    hostname : str
+        Host on which rank zero serialized the artifact.
+    world_size : int
+        Number of participating training processes.
+    git_revision : str or None
+        Source revision, when discoverable from the environment or checkout.
+    git_dirty : bool or None
+        Whether tracked files differed from the discovered revision.
+    contents : tuple[str, ...]
+        Top-level checkpoint components present in the artifact.
+    """
+
+    created_at: str
+    spine_version: str
+    python_version: str
+    torch_version: str | None
+    cuda_version: str | None
+    hostname: str
+    world_size: int
+    git_revision: str | None = None
+    git_dirty: bool | None = None
+    contents: tuple[str, ...] = ()
+
+    @classmethod
+    def create(
+        cls,
+        world_size: int = 1,
+        contents: tuple[str, ...] = (),
+    ) -> "CheckpointManifest":
+        """Collect checkpoint provenance from the current runtime.
+
+        Parameters
+        ----------
+        world_size : int, default 1
+            Number of processes participating in training.
+        contents : tuple[str, ...], optional
+            Top-level checkpoint components present in the artifact.
+
+        Returns
+        -------
+        CheckpointManifest
+            Newly collected, serialization-ready provenance.
+        """
+        revision, dirty = _discover_git_state()
+        torch_version = str(torch.__version__) if TORCH_AVAILABLE else None
+        cuda_version = None
+        if TORCH_AVAILABLE:
+            cuda_version = getattr(getattr(torch, "version", None), "cuda", None)
+
+        return cls(
+            created_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            spine_version=__version__,
+            python_version=platform.python_version(),
+            torch_version=torch_version,
+            cuda_version=cuda_version,
+            hostname=socket.gethostname(),
+            world_size=int(world_size),
+            git_revision=revision,
+            git_dirty=dirty,
+            contents=tuple(contents),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the manifest as a plain serialization-safe dictionary."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "CheckpointManifest":
+        """Reconstruct a manifest from checkpoint data.
+
+        Parameters
+        ----------
+        value : mapping
+            Serialized manifest mapping.
+        """
+        field_names = {field.name for field in fields(cls)}
+        return cls(**{key: item for key, item in value.items() if key in field_names})
+
+
+def _discover_git_state() -> tuple[str | None, bool | None]:
+    """Return an optional source revision and tracked-file dirty flag."""
+    for key in ("SPINE_GIT_REVISION", "GIT_COMMIT", "CI_COMMIT_SHA"):
+        revision = os.environ.get(key)
+        if revision:
+            return revision, None
+
+    repository = Path(__file__).resolve().parents[3]
+    if not (repository / ".git").exists():
+        return None, None
+
+    try:
+        revision = sp.run(
+            ["git", "-C", str(repository), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        ).stdout.strip()
+        status = sp.run(
+            [
+                "git",
+                "-C",
+                str(repository),
+                "status",
+                "--porcelain",
+                "--untracked-files=no",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        ).stdout
+        return revision or None, bool(status.strip())
+    except (OSError, sp.SubprocessError):
+        return None, None
+
+
+def checkpoint_sha256(path: str | os.PathLike[str]) -> str:
+    """Compute the SHA-256 digest of a checkpoint artifact.
+
+    Parameters
+    ----------
+    path : path-like
+        Checkpoint file to hash.
+    """
+    digest = hashlib.sha256()
+    with open(path, "rb") as checkpoint_file:
+        for chunk in iter(lambda: checkpoint_file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def save_checkpoint(checkpoint: Mapping[str, Any], path: str | os.PathLike[str]) -> str:
+    """Atomically serialize a checkpoint and write its SHA-256 sidecar.
+
+    The checkpoint is first written in the destination directory and then
+    atomically moved into place. The checksum follows the conventional
+    ``<digest>  <filename>`` format in ``<path>.sha256``.
+
+    Parameters
+    ----------
+    checkpoint : mapping
+        Complete checkpoint payload.
+    path : path-like
+        Destination checkpoint path.
+
+    Returns
+    -------
+    str
+        SHA-256 digest of the final checkpoint bytes.
+    """
+    if not TORCH_AVAILABLE:
+        raise ImportError("PyTorch is required to save a model checkpoint.")
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Publish the artifact only after serialization completes successfully.
+    temporary_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary_path = temporary.name
+        torch.save(dict(checkpoint), temporary_path)
+        os.replace(temporary_path, path)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            try:
+                os.unlink(temporary_path)
+            except FileNotFoundError:  # pragma: no cover - external cleanup race
+                pass
+
+    # Hash the published bytes, then atomically publish the matching sidecar.
+    digest = checkpoint_sha256(path)
+    _write_checksum_sidecar(path, digest)
+
+    return digest
+
+
+def promote_checkpoint(
+    source: str | os.PathLike[str],
+    destination: str | os.PathLike[str],
+) -> str:
+    """Atomically copy a checkpoint into a stable best-checkpoint path.
+
+    Parameters
+    ----------
+    source : path-like
+        Existing checkpoint artifact to promote.
+    destination : path-like
+        Stable destination path, typically ending in ``-best.ckpt``.
+
+    Returns
+    -------
+    str
+        SHA-256 digest shared by the source and promoted artifact.
+    """
+    source = Path(source)
+    destination = Path(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    # Copy beside the destination so publication remains an atomic rename.
+    temporary_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary_path = temporary.name
+        shutil.copyfile(source, temporary_path)
+        os.replace(temporary_path, destination)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            try:
+                os.unlink(temporary_path)
+            except FileNotFoundError:  # pragma: no cover - external cleanup race
+                pass
+
+    digest = checkpoint_sha256(destination)
+    _write_checksum_sidecar(destination, digest)
+    return digest
+
+
+def _write_checksum_sidecar(path: Path, digest: str) -> None:
+    """Atomically publish a checksum sidecar for ``path``."""
+    sidecar = Path(f"{path}.sha256")
+    sidecar_temporary: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=sidecar.parent,
+            prefix=f".{sidecar.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            sidecar_temporary = temporary.name
+            temporary.write(f"{digest}  {path.name}\n")
+        os.replace(sidecar_temporary, sidecar)
+        sidecar_temporary = None
+    finally:
+        if sidecar_temporary is not None:
+            try:
+                os.unlink(sidecar_temporary)
+            except FileNotFoundError:  # pragma: no cover - external cleanup race
+                pass
+
+
+def verify_checkpoint(path: str | os.PathLike[str]) -> bool:
+    """Verify a checkpoint against its adjacent SHA-256 sidecar.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the checkpoint or sidecar does not exist.
+    ValueError
+        If the sidecar is malformed or names another artifact.
+    """
+    path = Path(path)
+    sidecar = Path(f"{path}.sha256")
+    sidecar_fields = sidecar.read_text(encoding="utf-8").strip().split(maxsplit=1)
+    if len(sidecar_fields) != 2:
+        raise ValueError(f"Malformed checkpoint checksum sidecar: {sidecar}")
+    expected, filename = sidecar_fields
+    filename = filename.lstrip(" *")
+    if filename != path.name:
+        raise ValueError(
+            f"Checksum sidecar names `{filename}`, expected `{path.name}`."
+        )
+    return checkpoint_sha256(path) == expected
+
+
+def inspect_checkpoint(
+    path: str | os.PathLike[str],
+    *,
+    verify: bool = False,
+) -> dict[str, Any]:
+    """Read checkpoint metadata without constructing a model.
+
+    Model and optimizer tensors are omitted from the returned mapping. Legacy
+    checkpoints are accepted and reported with format version 1.
+
+    Parameters
+    ----------
+    path : path-like
+        Checkpoint artifact to inspect.
+    verify : bool, default False
+        Whether to require and verify the SHA-256 sidecar first.
+    """
+    if verify and not verify_checkpoint(path):
+        raise ValueError(f"Checkpoint checksum does not match: {path}")
+    if not TORCH_AVAILABLE:
+        raise ImportError("PyTorch is required to inspect a model checkpoint.")
+
+    # Prefer restricted loading while retaining support for older Torch APIs.
+    try:
+        checkpoint = torch.load(path, map_location="cpu", weights_only=True)
+    except TypeError as err:
+        if "weights_only" not in str(err):
+            raise
+        checkpoint = torch.load(path, map_location="cpu")
+
+    # Expose provenance and availability without returning heavyweight state.
+    keys = (
+        "manifest",
+        "config",
+        "datasets",
+        "global_step",
+        "global_epoch",
+        "validation",
+    )
+    result = {
+        "format_version": int(checkpoint.get("format_version", 1)),
+        **{key: checkpoint[key] for key in keys if key in checkpoint},
+    }
+    result["has_optimizer"] = "optimizer" in checkpoint
+    result["has_lr_scheduler"] = "lr_scheduler" in checkpoint
+    result["has_runtime_state"] = "runtime_state" in checkpoint
+    result["path"] = os.fspath(path)
+    if verify:
+        result["sha256"] = checkpoint_sha256(path)
+    return result

--- a/src/spine/model/manager.py
+++ b/src/spine/model/manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import glob
 import os
+import warnings
 from collections.abc import Mapping
 from copy import deepcopy
 from typing import Any
@@ -22,6 +23,12 @@ from spine.utils.logger import logger
 from spine.utils.stopwatch import StopwatchManager
 from spine.utils.torch.training import lr_sched_factory, optim_factory
 
+from .checkpoint import (
+    CHECKPOINT_FORMAT_VERSION,
+    CheckpointManifest,
+    promote_checkpoint,
+    save_checkpoint,
+)
 from .factories import model_factory
 
 
@@ -103,6 +110,8 @@ class ModelManager:
             )
         if train is not None and not loss_input:
             raise ValueError("Training requires a non-empty `loss_input` mapping.")
+        if train is not None and weight_list is not None:
+            raise ValueError("`weight_list` is only supported for inference.")
 
         # Save parameters
         self.train: bool = train is not None
@@ -116,6 +125,15 @@ class ModelManager:
         self.rank = rank  # Global rank (process ID in distributed group)
         self.main_process = rank is None or rank == 0
         self.checkpoint_validation: dict[str, Any] | None = None
+        self.checkpoint_manifest: dict[str, Any] | None = None
+        self.checkpoint_config: dict[str, Any] | None = None
+        self.checkpoint_datasets: dict[str, Any] | None = None
+        self.checkpoint_runtime_state: dict[str, Any] | None = None
+        self.resume_training = False
+        self.strict_resume = False
+        self.load_training_progress = True
+        self.configured_weight_path = weight_path
+        self.start_epoch: float | None = 0.0
 
         # Determine device: use current_device() which setup_ddp() already configured
         if self.rank is None:
@@ -214,6 +232,7 @@ class ModelManager:
         optimizer: Mapping[str, Any],
         weight_prefix: str = "snapshot",
         restore_optimizer: bool = False,
+        resume: bool | None = None,
         save_step: int | None = None,
         save_epoch: float | None = None,
         lr_scheduler: Mapping[str, Any] | None = None,
@@ -232,9 +251,18 @@ class ModelManager:
         save_epoch : float, optional
             Fraction of epoch to train on before recording the model weights
         restore_optimizer : bool, default False
-            Whether to load the  opimizer state from the torch checkpoint
+            Whether to resume the complete available training state from a
+            checkpoint. Retained as a backward-compatible spelling of
+            ``resume=True``.
+        resume : bool, optional
+            Whether to restore optimizer, scheduler, RNG, loader and progress
+            state. Explicit ``False`` loads parameters only and starts a new
+            training process. When omitted, a configured global weight path
+            enables automatic resume.
         lr_scheduler : dict, optional
-            Configuration of the learning rate scheduler
+            Learning-rate scheduler configuration. Manager-owned ``interval``
+            and optional ``monitor`` keys select step- or checkpoint-bound
+            updates.
         iter_per_epoch : int, optional
             Number of iterations per epoch (relevant for training)
         """
@@ -244,7 +272,30 @@ class ModelManager:
 
         # Store parameters
         self.weight_prefix = weight_prefix
-        self.restore_optimizer = restore_optimizer
+        if resume is not None and not isinstance(resume, bool):
+            raise TypeError("Training `resume` must be a boolean.")
+        if resume is False and restore_optimizer:
+            raise ValueError("Cannot combine `resume: false` with `restore_optimizer`.")
+
+        # Omitted resume policy continues a configured global checkpoint.
+        auto_resume = (
+            resume is None and getattr(self, "configured_weight_path", None) is not None
+        )
+        if resume is None:
+            self.resume_training = restore_optimizer or auto_resume
+        else:
+            self.resume_training = resume
+
+        # Explicit resume remains strict; automatic legacy recovery may degrade.
+        self.strict_resume = restore_optimizer or resume is True
+        if (
+            self.strict_resume
+            and hasattr(self, "configured_weight_path")
+            and self.configured_weight_path is None
+        ):
+            raise ValueError("Explicit resume requires a global `weight_path`.")
+        self.restore_optimizer = self.resume_training
+        self.load_training_progress = resume is not False
 
         # Store the saving parameters
         if save_step is not None and save_epoch is not None:
@@ -265,10 +316,30 @@ class ModelManager:
         # Initiliaze the optimizer
         self.optimizer = optim_factory(optimizer, self.net.parameters())
 
-        # Initialize the learning rate scheduler
+        # Initialize the learning-rate scheduler and its trigger policy.
         self.lr_scheduler = None
+        self.lr_scheduler_interval = "step"
+        self.lr_scheduler_monitor = None
         if lr_scheduler is not None:
-            self.lr_scheduler = lr_sched_factory(lr_scheduler, self.optimizer)
+            if not isinstance(lr_scheduler, Mapping):
+                raise TypeError("`lr_scheduler` must be a mapping.")
+            scheduler_cfg = deepcopy(dict(lr_scheduler))
+            self.lr_scheduler_interval = scheduler_cfg.pop("interval", "step")
+            self.lr_scheduler_monitor = scheduler_cfg.pop("monitor", None)
+            if self.lr_scheduler_interval not in {"step", "checkpoint"}:
+                raise ValueError(
+                    "Learning-rate scheduler `interval` must be 'step' or "
+                    "'checkpoint'."
+                )
+            if (
+                self.lr_scheduler_monitor is not None
+                and self.lr_scheduler_interval != "checkpoint"
+            ):
+                raise ValueError(
+                    "A monitored learning-rate scheduler requires "
+                    "`interval: checkpoint`."
+                )
+            self.lr_scheduler = lr_sched_factory(scheduler_cfg, self.optimizer)
 
     def __call__(
         self,
@@ -383,14 +454,20 @@ class ModelManager:
         Parameters
         ----------
         iteration : int
-            Zero-based training iteration.
+            Global zero-based training iteration.
 
         Returns
         -------
         bool
-            Whether the iteration completes one configured save period.
+            Whether the iteration completes one configured save period since
+            the current training segment began.
         """
-        return self.save_step is not None and ((iteration + 1) % self.save_step) == 0
+        start_iteration = getattr(self, "start_iteration", 0)
+        relative_iteration = iteration - start_iteration
+        return (
+            self.save_step is not None
+            and ((relative_iteration + 1) % self.save_step) == 0
+        )
 
     @classmethod
     def clean_config(cls, config: Any) -> Any:
@@ -535,6 +612,12 @@ class ModelManager:
 
         # If no pre-trained weights are requested, nothing to do here
         self.start_iteration = 0
+        self.start_epoch = 0.0
+        self.checkpoint_manifest = None
+        self.checkpoint_config = None
+        self.checkpoint_datasets = None
+        self.checkpoint_runtime_state = None
+        self.checkpoint_validation = None
         if not weight_paths:
             return
 
@@ -612,14 +695,84 @@ class ModelManager:
 
                 # Load the optimizer state from the main weight file only
                 if self.train and module == self.model_name and self.restore_optimizer:
-                    self.optimizer.load_state_dict(checkpoint["optimizer"])
+                    if "optimizer" not in checkpoint:
+                        strict_resume = getattr(
+                            self, "strict_resume", self.restore_optimizer
+                        )
+                        if strict_resume:
+                            raise KeyError(
+                                "Cannot resume training: checkpoint has no "
+                                "optimizer state."
+                            )
+                        warnings.warn(
+                            "Checkpoint has no optimizer state; automatic resume "
+                            "will retain saved progress but restart the optimizer.",
+                            RuntimeWarning,
+                            stacklevel=2,
+                        )
+                    else:
+                        self.optimizer.load_state_dict(checkpoint["optimizer"])
 
-                # Get the latest iteration from the main weight file only
+                        lr_scheduler = getattr(self, "lr_scheduler", None)
+                        if lr_scheduler is not None:
+                            scheduler = checkpoint.get("lr_scheduler")
+                            if scheduler is None:
+                                warnings.warn(
+                                    "Checkpoint has no learning-rate-scheduler "
+                                    "state; the configured scheduler will restart.",
+                                    RuntimeWarning,
+                                    stacklevel=2,
+                                )
+                            else:
+                                lr_scheduler.load_state_dict(scheduler)
+
+                # Restore progress and provenance from the main checkpoint only.
                 if module == self.model_name:
-                    self.start_iteration = checkpoint["global_step"] + 1
-                    validation = checkpoint.get("validation")
-                    if validation is not None:
-                        self.checkpoint_validation = deepcopy(validation)
+                    load_progress = not self.train or getattr(
+                        self, "load_training_progress", True
+                    )
+                    if load_progress:
+                        self.start_iteration = checkpoint["global_step"] + 1
+                        global_epoch = checkpoint.get("global_epoch")
+                        self.start_epoch = (
+                            None if global_epoch is None else float(global_epoch)
+                        )
+                        if self.train and self.start_epoch is None:
+                            warnings.warn(
+                                "Checkpoint has no global epoch; resumed epoch "
+                                "progress must be inferred from the current batch "
+                                "size.",
+                                RuntimeWarning,
+                                stacklevel=2,
+                            )
+                    manifest = checkpoint.get("manifest")
+                    if manifest is not None:
+                        self.checkpoint_manifest = deepcopy(manifest)
+                    config = checkpoint.get("config")
+                    if config is not None:
+                        self.checkpoint_config = deepcopy(config)
+                    datasets = checkpoint.get("datasets")
+                    if datasets is not None:
+                        self.checkpoint_datasets = deepcopy(datasets)
+                    if load_progress:
+                        validation = checkpoint.get("validation")
+                        if validation is not None:
+                            self.checkpoint_validation = deepcopy(validation)
+                    if getattr(
+                        self,
+                        "resume_training",
+                        getattr(self, "restore_optimizer", False),
+                    ):
+                        runtime_state = checkpoint.get("runtime_state")
+                        if runtime_state is None:
+                            warnings.warn(
+                                "Checkpoint has no RNG or loader runtime state; "
+                                "continuation will not be bit-for-bit exact.",
+                                RuntimeWarning,
+                                stacklevel=2,
+                            )
+                        else:
+                            self.checkpoint_runtime_state = deepcopy(runtime_state)
 
             logger.info("Done.")
 
@@ -743,8 +896,11 @@ class ModelManager:
         # Step the optimizer
         self.optimizer.step()
 
-        # Step the learning rate scheduler
-        if self.lr_scheduler is not None:
+        # Step iteration-bound schedulers after the optimizer update.
+        if (
+            self.lr_scheduler is not None
+            and getattr(self, "lr_scheduler_interval", "step") == "step"
+        ):
             self.lr_scheduler.step()
 
         # If the model has a buffer that needs to be updated, do it after
@@ -801,12 +957,44 @@ class ModelManager:
                 dtype = type(value)
                 raise ValueError(f"Cannot cast output {key} of type {dtype} to numpy.")
 
+    def step_checkpoint_scheduler(
+        self,
+        metrics: Mapping[str, float] | None = None,
+    ) -> None:
+        """Step a checkpoint-bound learning-rate scheduler.
+
+        Parameters
+        ----------
+        metrics : mapping[str, float], optional
+            Validation scalars associated with the checkpoint. Required when
+            the scheduler configuration specifies ``monitor``.
+        """
+        if self.lr_scheduler is None or self.lr_scheduler_interval != "checkpoint":
+            return
+
+        if self.lr_scheduler_monitor is None:
+            self.lr_scheduler.step()
+            return
+        if metrics is None or self.lr_scheduler_monitor not in metrics:
+            available = "" if metrics is None else ", ".join(sorted(metrics))
+            raise KeyError(
+                "Learning-rate scheduler metric "
+                f"`{self.lr_scheduler_monitor}` was not produced. Available "
+                f"scalar metrics: {available or 'none'}."
+            )
+        self.lr_scheduler.step(float(metrics[self.lr_scheduler_monitor]))
+
     def save_state(
         self,
         iteration: int,
         epoch: float | None,
         validation: Mapping[str, Any] | None = None,
-    ) -> None:
+        *,
+        config: Mapping[str, Any] | None = None,
+        datasets: Mapping[str, Any] | None = None,
+        runtime_state: Mapping[str, Any] | None = None,
+        world_size: int = 1,
+    ) -> str:
         """Save the model state.
 
         Save the training state associated with this checkpoint:
@@ -814,6 +1002,9 @@ class ModelManager:
         - global_epoch (epoch progress)
         - state_dict (model parameter values)
         - optimizer (optimizer parameter values)
+        - lr_scheduler (optional scheduler parameter values)
+        - runtime_state (per-rank RNG and loader continuation state)
+        - manifest/config/datasets (artifact provenance)
         - validation (optional metrics and early-stopping progress)
 
         Parameters
@@ -825,6 +1016,19 @@ class ModelManager:
         validation : mapping, optional
             Validation metrics and early-stopping state associated with these
             exact weights.
+        config : mapping, optional
+            Complete normalized driver configuration.
+        datasets : mapping, optional
+            Resolved training and validation dataset provenance.
+        runtime_state : mapping, optional
+            Per-rank RNG and loader continuation state.
+        world_size : int, default 1
+            Number of training processes represented by the checkpoint.
+
+        Returns
+        -------
+        str
+            Path to the serialized checkpoint artifact.
         """
         # Make sure that the weight prefix is valid
         if not self.weight_prefix:
@@ -833,12 +1037,50 @@ class ModelManager:
         filename = f"{self.weight_prefix}-{iteration:d}.ckpt"
         model = self.net if not self.distributed else self.net.module
         checkpoint = {
+            "format_version": CHECKPOINT_FORMAT_VERSION,
+            "config": deepcopy(dict(config or {})),
+            "datasets": deepcopy(dict(datasets or {})),
             "global_step": iteration,
             "global_epoch": epoch,
             "state_dict": model.state_dict(),
             "optimizer": self.optimizer.state_dict(),
         }
+        scheduler = getattr(self, "lr_scheduler", None)
+        if scheduler is not None:
+            checkpoint["lr_scheduler"] = scheduler.state_dict()
+        if runtime_state is not None:
+            checkpoint["runtime_state"] = deepcopy(dict(runtime_state))
         if validation is not None:
             checkpoint["validation"] = dict(validation)
 
-        torch.save(checkpoint, filename)
+        checkpoint["manifest"] = CheckpointManifest.create(
+            world_size,
+            contents=tuple(sorted(checkpoint)),
+        ).to_dict()
+
+        save_checkpoint(checkpoint, filename)
+        return filename
+
+    def save_best_state(
+        self,
+        checkpoint_path: str,
+        path: str | None = None,
+    ) -> str:
+        """Promote an existing snapshot to the stable best-checkpoint path.
+
+        Parameters
+        ----------
+        checkpoint_path : str
+            Snapshot produced for the current validation boundary.
+        path : str, optional
+            Explicit best-checkpoint destination. Defaults to
+            ``<weight_prefix>-best.ckpt``.
+
+        Returns
+        -------
+        str
+            Path to the promoted checkpoint artifact.
+        """
+        best_path = path or f"{self.weight_prefix}-best.ckpt"
+        promote_checkpoint(checkpoint_path, best_path)
+        return best_path

--- a/src/spine/model/validation.py
+++ b/src/spine/model/validation.py
@@ -12,10 +12,25 @@ import numpy as np
 
 from spine.io import IOManager
 from spine.utils.conditional import torch
+from spine.utils.torch import runtime
 
 from .manager import ModelManager
 
 __all__ = ["ValidationManager"]
+
+
+def _metric_improved(
+    value: float,
+    best: float | None,
+    mode: str,
+    min_delta: float,
+) -> bool:
+    """Return whether ``value`` improves on a monitored best value."""
+    if best is None:
+        return True
+    if mode == "min":
+        return value < best - min_delta
+    return value > best + min_delta
 
 
 class EarlyStopping:
@@ -134,11 +149,7 @@ class EarlyStopping:
             )
 
         value = float(metrics[self.monitor])
-        improved = self.best is None
-        if self.best is not None and self.mode == "min":
-            improved = value < self.best - self.min_delta
-        elif self.best is not None:
-            improved = value > self.best + self.min_delta
+        improved = _metric_improved(value, self.best, self.mode, self.min_delta)
 
         if improved:
             self.best = value
@@ -166,6 +177,138 @@ class EarlyStopping:
         }
 
 
+class BestCheckpoint:
+    """Track which checkpoint produced the best validation metric.
+
+    Parameters
+    ----------
+    monitor : str
+        Validation scalar used to select the best checkpoint.
+    mode : {'min', 'max'}
+        Direction in which the monitored metric improves.
+    min_delta : float
+        Minimum absolute change required to replace the best checkpoint.
+    path : str or None
+        Optional stable checkpoint destination. When omitted, the model weight
+        prefix is suffixed with ``-best.ckpt``.
+    best : float or None
+        Best monitored value observed so far.
+    """
+
+    def __init__(
+        self,
+        monitor: str = "loss",
+        mode: str = "min",
+        min_delta: float = 0.0,
+        path: str | None = None,
+        state: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Initialize the best-checkpoint selection policy.
+
+        Parameters
+        ----------
+        monitor : str, default 'loss'
+            Validation scalar used to select the best checkpoint.
+        mode : {'min', 'max'}, default 'min'
+            Direction in which the monitored metric improves.
+        min_delta : float, default 0.0
+            Minimum absolute change required to replace the best checkpoint.
+        path : str, optional
+            Stable destination for the promoted checkpoint.
+        state : mapping, optional
+            Previously checkpointed best-metric progress.
+
+        Raises
+        ------
+        ValueError
+            If the mode or minimum delta is invalid.
+        TypeError
+            If the destination path is not a string.
+        """
+        if mode not in {"min", "max"}:
+            raise ValueError("Best-checkpoint `mode` must be 'min' or 'max'.")
+        if min_delta < 0.0:
+            raise ValueError("Best-checkpoint `min_delta` must be non-negative.")
+        if path is not None and not isinstance(path, str):
+            raise TypeError("Best-checkpoint `path` must be a string.")
+
+        self.monitor = monitor
+        self.mode = mode
+        self.min_delta = float(min_delta)
+        self.path = path
+        self.best: float | None = None
+
+        if state is not None:
+            self.restore(state)
+
+    def restore(self, state: Mapping[str, Any]) -> None:
+        """Restore compatible best-metric progress from a checkpoint.
+
+        Parameters
+        ----------
+        state : mapping
+            Serialized best-checkpoint state.
+
+        Raises
+        ------
+        ValueError
+            If the checkpoint monitors a different metric or direction.
+        """
+        if state.get("monitor") != self.monitor or state.get("mode") != self.mode:
+            raise ValueError(
+                "Checkpoint best-checkpoint policy does not match the current "
+                "`monitor` and `mode`."
+            )
+        best = state.get("best")
+        self.best = None if best is None else float(best)
+
+    def update(self, metrics: Mapping[str, float]) -> bool:
+        """Update the best metric and select checkpoint promotion.
+
+        Parameters
+        ----------
+        metrics : mapping[str, float]
+            Globally reduced validation metrics.
+
+        Returns
+        -------
+        bool
+            Whether the current checkpoint should replace the saved best.
+
+        Raises
+        ------
+        KeyError
+            If the monitored metric is absent.
+        """
+        if self.monitor not in metrics:
+            available = ", ".join(sorted(metrics))
+            raise KeyError(
+                f"Best-checkpoint metric `{self.monitor}` was not produced. "
+                f"Available scalar metrics: {available}."
+            )
+
+        value = float(metrics[self.monitor])
+        improved = _metric_improved(value, self.best, self.mode, self.min_delta)
+        if improved:
+            self.best = value
+        return improved
+
+    def state_dict(self) -> dict[str, Any]:
+        """Return serializable best-checkpoint progress.
+
+        Returns
+        -------
+        dict
+            Policy parameters and best monitored value.
+        """
+        return {
+            "monitor": self.monitor,
+            "mode": self.mode,
+            "min_delta": self.min_delta,
+            "best": self.best,
+        }
+
+
 class ValidationManager:
     """Run deterministic validation against the live training model.
 
@@ -186,6 +329,8 @@ class ValidationManager:
         Number of validation batches processed per checkpoint.
     early_stopping : EarlyStopping or None
         Optional early-stopping policy.
+    best_checkpoint : BestCheckpoint or None
+        Optional best-checkpoint selection policy.
     """
 
     SOURCE_KEYS = frozenset({"file_keys", "file_list"})
@@ -212,11 +357,12 @@ class ValidationManager:
         distributed: bool,
         seed: int,
     ) -> None:
-        """Build a validation loader and optional early-stopping policy.
+        """Build a validation loader and optional validation policies.
 
         ``cfg`` only describes validation sources, the fraction of the loader
-        to visit, and early stopping. The training loader supplies the dataset
-        schema, batching, collation and worker configuration.
+        to visit, early stopping and best-checkpoint selection. The training
+        loader supplies the dataset schema, batching, collation and worker
+        configuration.
 
         Parameters
         ----------
@@ -242,13 +388,17 @@ class ValidationManager:
         ValueError
             If ``fraction`` is outside ``(0, 1]``.
         TypeError
-            If the early-stopping configuration is not a mapping.
+            If a validation policy has an invalid configuration type.
         """
         # Parse validation-owned scheduling options
         cfg = deepcopy(dict(cfg))
         fraction = cfg.pop("fraction", 1.0)
         early_cfg = cfg.pop("early_stopping", None)
-        if not isinstance(fraction, Real) or not 0.0 < fraction <= 1.0:
+        best_cfg = cfg.pop("best_checkpoint", None)
+        if not isinstance(fraction, Real):
+            raise TypeError("Validation `fraction` must be a real number.")
+        fraction = float(fraction)
+        if not 0.0 < fraction <= 1.0:
             raise ValueError("Validation `fraction` must be in the interval (0, 1].")
 
         # Derive and initialize the validation input pipeline
@@ -262,16 +412,28 @@ class ValidationManager:
         )
         self.model = model
         self.distributed = distributed
-        self.num_iterations = max(1, math.ceil(float(fraction) * len(self.io.loader)))
+        assert self.io.loader is not None
+        self.num_iterations = max(1, math.ceil(fraction * len(self.io.loader)))
 
-        # Restore optional early-stopping progress from the loaded checkpoint
+        # Restore optional validation policies from the loaded checkpoint.
+        restored = model.checkpoint_validation or {}
         self.early_stopping = None
         if early_cfg is not None:
             if not isinstance(early_cfg, Mapping):
                 raise TypeError("`validation.early_stopping` must be a mapping.")
-            restored = model.checkpoint_validation or {}
             state = restored.get("early_stopping")
             self.early_stopping = EarlyStopping(**early_cfg, state=state)
+
+        self.best_checkpoint = None
+        if best_cfg is not None and best_cfg is not False:
+            if best_cfg is True:
+                best_cfg = {}
+            elif not isinstance(best_cfg, Mapping):
+                raise TypeError(
+                    "`validation.best_checkpoint` must be a boolean or mapping."
+                )
+            state = restored.get("best_checkpoint")
+            self.best_checkpoint = BestCheckpoint(**best_cfg, state=state)
 
     @classmethod
     def build_loader_config(
@@ -537,6 +699,7 @@ class ValidationManager:
             If the model does not produce any scalar validation outputs.
         """
         # Reset deterministic sampler and loader state for this pass
+        assert self.io.loader is not None
         sampler = self.io.loader.sampler
         if self.distributed and hasattr(sampler, "set_epoch"):
             sampler.set_epoch(0)
@@ -567,7 +730,7 @@ class ValidationManager:
                 torch.distributed.all_reduce(reduced)
                 totals[key], counts[key] = reduced.tolist()
 
-        return {key: totals[key] / counts[key] for key in totals}
+        return {key: total / counts[key] for key, total in totals.items()}
 
     def update_early_stopping(self, metrics: Mapping[str, float]) -> bool:
         """Update early stopping after a validation pass.
@@ -587,6 +750,23 @@ class ValidationManager:
             return False
         return self.early_stopping.update(metrics)
 
+    def update_best_checkpoint(self, metrics: Mapping[str, float]) -> bool:
+        """Update and select the best checkpoint observed so far.
+
+        Parameters
+        ----------
+        metrics : mapping[str, float]
+            Globally reduced validation metrics.
+
+        Returns
+        -------
+        bool
+            Whether the current checkpoint should replace the saved best.
+        """
+        if self.best_checkpoint is None:
+            return False
+        return self.best_checkpoint.update(metrics)
+
     def checkpoint_state(self, metrics: Mapping[str, float]) -> dict[str, Any]:
         """Build validation state to store alongside checkpoint weights.
 
@@ -603,6 +783,8 @@ class ValidationManager:
         state: dict[str, Any] = {"metrics": dict(metrics)}
         if self.early_stopping is not None:
             state["early_stopping"] = self.early_stopping.state_dict()
+        if self.best_checkpoint is not None:
+            state["best_checkpoint"] = self.best_checkpoint.state_dict()
         return state
 
     @staticmethod
@@ -623,7 +805,7 @@ class ValidationManager:
             return float(value)
         if isinstance(value, np.ndarray) and value.size == 1:
             return float(value.item())
-        if isinstance(value, torch.Tensor) and value.numel() == 1:
+        if runtime.is_tensor(value) and value.numel() == 1:
             return float(value.detach().item())
         return None
 

--- a/src/spine/utils/torch/runtime.py
+++ b/src/spine/utils/torch/runtime.py
@@ -4,7 +4,13 @@ This module provides conditional PyTorch utilities that gracefully handle
 PyTorch unavailability with sensible fallbacks or clear error messages.
 """
 
+from __future__ import annotations
+
+import random
 from importlib import import_module
+from typing import Any, Protocol, TypeGuard
+
+import numpy as np
 
 from ..conditional import TORCH_AVAILABLE, torch
 
@@ -16,9 +22,90 @@ __all__ = [
     "is_tensor",
     "distributed_barrier",
     "distributed_all_gather_object",
+    "capture_rng_state",
+    "restore_rng_state",
     "require_torch",
     "create_summary_writer",
 ]
+
+
+class _TensorLike(Protocol):
+    """Tensor interface required by scalar-output conversion."""
+
+    def numel(self) -> int:
+        """Return the number of tensor elements."""
+        ...
+
+    def detach(self) -> _TensorLike:
+        """Return a tensor detached from its computation graph."""
+        ...
+
+    def item(self) -> Any:
+        """Return the contained Python scalar."""
+        ...
+
+
+def _serialize_numpy_state(state):
+    """Convert a NumPy RNG tuple to restricted-loader-safe primitives."""
+    name, keys, position, has_gaussian, cached_gaussian = state
+    return {
+        "name": name,
+        "keys": keys.tolist(),
+        "position": int(position),
+        "has_gaussian": int(has_gaussian),
+        "cached_gaussian": float(cached_gaussian),
+    }
+
+
+def _deserialize_numpy_state(state):
+    """Reconstruct a NumPy RNG tuple from serialized primitives."""
+    return (
+        state["name"],
+        np.asarray(state["keys"], dtype=np.uint32),
+        int(state["position"]),
+        int(state["has_gaussian"]),
+        float(state["cached_gaussian"]),
+    )
+
+
+def capture_rng_state():
+    """Capture process-local Python, NumPy, Torch and CUDA RNG state.
+
+    Returns
+    -------
+    dict
+        State composed only of primitives and tensors accepted by PyTorch's
+        restricted ``weights_only`` checkpoint loader.
+    """
+    state = {
+        "python": random.getstate(),
+        "numpy": _serialize_numpy_state(np.random.get_state()),
+    }
+
+    # Torch stores RNG state as restricted-loader-safe byte tensors.
+    if TORCH_AVAILABLE:
+        state["torch"] = torch.get_rng_state()
+        if torch.cuda.is_available():
+            state["cuda"] = torch.cuda.get_rng_state()
+    return state
+
+
+def restore_rng_state(state):
+    """Restore process-local RNG state captured by :func:`capture_rng_state`.
+
+    Parameters
+    ----------
+    state : mapping
+        Serialized RNG state for the current process/rank.
+    """
+    random.setstate(tuple(state["python"]))
+    np.random.set_state(_deserialize_numpy_state(state["numpy"]))
+
+    # CUDA state is process-local, hence each distributed rank restores its own.
+    if TORCH_AVAILABLE and "torch" in state:
+        torch.set_rng_state(state["torch"])
+    if TORCH_AVAILABLE and "cuda" in state and torch.cuda.is_available():
+        torch.cuda.set_rng_state(state["cuda"])
 
 
 def manual_seed(seed):
@@ -59,8 +146,19 @@ def cuda_max_memory_allocated():
     return 0
 
 
-def is_tensor(obj):
-    """Check if object is a torch tensor."""
+def is_tensor(obj: Any) -> TypeGuard[_TensorLike]:
+    """Check whether an object is a tensor and narrow its static type.
+
+    Parameters
+    ----------
+    obj : object
+        Candidate tensor object.
+
+    Returns
+    -------
+    bool
+        Whether PyTorch is available and the object is a tensor.
+    """
     return TORCH_AVAILABLE and torch.is_tensor(obj)
 
 

--- a/test/test_bin/test_cli.py
+++ b/test/test_bin/test_cli.py
@@ -122,6 +122,81 @@ def test_main_updates_loader_dataset(monkeypatch, tmp_path):
     assert captured["cfg"]["io"]["loader"]["dataset"]["file_list"] == "sources.txt"
 
 
+@pytest.mark.parametrize("resume", [True, False])
+def test_main_applies_resume_override(monkeypatch, tmp_path, resume):
+    """Dedicated resume flags should override the training configuration."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("io: {}\n", encoding="utf-8")
+    captured = {}
+
+    monkeypatch.setattr(cli_module, "resolve_config_path", lambda cfg, current_dir: cfg)
+    monkeypatch.setattr(
+        cli_module,
+        "load_config_file",
+        lambda _path: {
+            "base": {},
+            "io": {"reader": {}},
+            "model": {},
+            "train": {"resume": not resume},
+        },
+    )
+    monkeypatch.setattr("spine.main.run", lambda cfg: captured.setdefault("cfg", cfg))
+
+    cli_module.main(
+        config=str(config_path),
+        source=None,
+        source_list=None,
+        output=None,
+        output_dir=None,
+        output_suffix=None,
+        n=None,
+        nskip=None,
+        entry_list=None,
+        skip_entry_list=None,
+        log_dir=None,
+        weight_prefix=None,
+        weight_path=None,
+        weight_list=None,
+        config_overrides=None,
+        resume=resume,
+    )
+
+    assert captured["cfg"]["train"]["resume"] is resume
+
+
+def test_main_rejects_resume_without_training(monkeypatch, tmp_path):
+    """Resume CLI flags require a training configuration."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("io: {}\n", encoding="utf-8")
+
+    monkeypatch.setattr(cli_module, "resolve_config_path", lambda cfg, current_dir: cfg)
+    monkeypatch.setattr(
+        cli_module,
+        "load_config_file",
+        lambda _path: {"io": {"reader": {}}, "model": {}},
+    )
+
+    with pytest.raises(KeyError, match="requires a `train` block"):
+        cli_module.main(
+            config=str(config_path),
+            source=None,
+            source_list=None,
+            output=None,
+            output_dir=None,
+            output_suffix=None,
+            n=None,
+            nskip=None,
+            entry_list=None,
+            skip_entry_list=None,
+            log_dir=None,
+            weight_prefix=None,
+            weight_path=None,
+            weight_list=None,
+            config_overrides=None,
+            resume=True,
+        )
+
+
 def test_main_warns_when_output_options_have_no_writer(monkeypatch, tmp_path):
     """Output options should warn and be ignored when no writer is configured."""
     config_path = tmp_path / "config.yaml"
@@ -316,6 +391,7 @@ def test_cli_entry_point_paths(monkeypatch):
                 weight_path="weights.ckpt",
                 weight_list="weights.txt",
                 config_overrides=["a=1"],
+                resume=None,
             )
 
         def add_argument(self, *args, **kwargs):

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -528,6 +528,10 @@ def test_initialize_tensorboard_logger(monkeypatch, tmp_path):
         os.path.join(drv.log_dir, "tensorboard"),
     )
 
+    drv.main_process = False
+    drv.initialize_log()
+    assert created[-1][1] is None
+
 
 def test_driver_constructor_initializes_optional_managers(monkeypatch):
     """__init__ should connect optional geometry/model/build/post/ana managers."""
@@ -800,6 +804,10 @@ def test_initialize_validation_requires_training_checkpoint_loader(monkeypatch):
     with pytest.raises(ValueError, match="training model"):
         drv.initialize_validation({"file_keys": "val.root"}, {"loader": {}})
 
+    drv.model = SimpleNamespace(lr_scheduler_monitor="loss")
+    with pytest.raises(ValueError, match="requires a `validation` block"):
+        drv.initialize_validation(None, {"loader": {}})
+
     drv.model = SimpleNamespace(train=True, save_step=None)
     with pytest.raises(ValueError, match="save_step"):
         drv.initialize_validation({"file_keys": "val.root"}, {"loader": {}})
@@ -831,6 +839,95 @@ def test_initialize_validation_requires_training_checkpoint_loader(monkeypatch):
         "distributed": True,
         "seed": 7,
     }
+
+
+def test_restore_training_runtime_selects_process_rank(monkeypatch):
+    """Resume should restore only the current rank's RNG and loader cursor."""
+    drv = bare_driver()
+    drv.rank = 1
+    drv.world_size = 2
+    drv.model = SimpleNamespace(
+        resume_training=True,
+        start_iteration=4,
+        checkpoint_runtime_state={
+            "world_size": 2,
+            "ranks": [
+                {"rank": 0, "rng": {"rank": 0}, "io": {"cursor": 0}},
+                {
+                    "rank": 1,
+                    "rng": {"rank": 1},
+                    "io": {"next_iteration": 4, "cursor": 3},
+                },
+            ],
+        },
+    )
+    restored = []
+    drv.io = SimpleNamespace(
+        restore_checkpoint_state=lambda state: restored.append(("io", state))
+    )
+    monkeypatch.setattr(
+        driver_mod.runtime,
+        "restore_rng_state",
+        lambda state: restored.append(("rng", state)),
+    )
+
+    drv.restore_training_runtime()
+
+    assert restored == [
+        ("rng", {"rank": 1}),
+        ("io", {"next_iteration": 4, "cursor": 3}),
+    ]
+
+
+def test_restore_training_runtime_rejects_changed_world_size(monkeypatch):
+    """Rank-local state should not be applied to a different process world."""
+    drv = bare_driver()
+    drv.rank = 0
+    drv.world_size = 4
+    drv.model = SimpleNamespace(
+        resume_training=True,
+        checkpoint_runtime_state={"world_size": 2, "ranks": []},
+    )
+    drv.io = SimpleNamespace()
+    monkeypatch.setattr(
+        driver_mod.runtime,
+        "restore_rng_state",
+        lambda _state: pytest.fail("RNG state should not be restored"),
+    )
+
+    with pytest.warns(RuntimeWarning, match="world size"):
+        drv.restore_training_runtime()
+
+
+def test_restore_training_runtime_handles_missing_or_inconsistent_rank_state():
+    """Resume should expose absent rank state and reject mismatched cursors."""
+    drv = bare_driver()
+    drv.rank = 0
+    drv.world_size = 1
+    drv.io = SimpleNamespace()
+    drv.model = SimpleNamespace(
+        resume_training=True,
+        start_iteration=3,
+        checkpoint_runtime_state=None,
+    )
+    drv.restore_training_runtime()
+
+    drv.model.checkpoint_runtime_state = {"world_size": 1, "ranks": []}
+    with pytest.warns(RuntimeWarning, match="rank 0"):
+        drv.restore_training_runtime()
+
+    drv.model.checkpoint_runtime_state = {
+        "world_size": 1,
+        "ranks": [
+            {
+                "rank": 0,
+                "rng": {},
+                "io": {"next_iteration": 2},
+            }
+        ],
+    }
+    with pytest.raises(ValueError, match="global step"):
+        drv.restore_training_runtime()
 
 
 def test_initialize_ana_columnar_guards_and_projection(monkeypatch):
@@ -1079,6 +1176,44 @@ def test_run_loop_resets_loader_logs_and_closes():
         drv.run()
 
 
+def test_run_resumes_epoch_progress_across_batch_size_change():
+    """Saved epochs should not be reinterpreted through the new loader length."""
+    drv = bare_driver()
+    calls: list[object] = []
+    epochs: list[float] = []
+    drv.iterations = 220
+    drv.epochs = 22.0
+    drv.epoch_based = True
+    drv.model = SimpleNamespace(
+        train=True,
+        start_iteration=200,
+        start_epoch=20.0,
+        should_save=lambda iteration: False,
+    )
+    drv.validation = None
+    drv.ana = None
+    drv.log_manager = SimpleNamespace(close=lambda: calls.append("log_close"))
+    drv.io = SimpleNamespace(
+        has_loader=True,
+        iter_per_epoch=10,
+        set_resume_progress=lambda iteration, epoch: calls.append(
+            ("resume", iteration, epoch)
+        ),
+        prepare_iteration=lambda iteration: None,
+        close=lambda: calls.append("io_close"),
+    )
+    drv.initialize_log = lambda: None
+    drv.process = lambda **kwargs: epochs.append(kwargs["epoch"]) or {}
+    drv.log = lambda *_args: None
+
+    drv.run()
+
+    assert calls[0] == ("resume", 200, 20.0)
+    assert len(epochs) == 20
+    assert epochs[0] == pytest.approx(20.1)
+    assert epochs[-1] == pytest.approx(22.0)
+
+
 def test_run_loop_cleans_up_on_processing_failure():
     """run should close resources even if processing raises."""
     drv = bare_driver()
@@ -1122,6 +1257,7 @@ def test_run_validates_before_checkpoint_and_stops_early():
     class FakeModel:
         train = True
         start_iteration = 0
+        device = "cpu"
         watch = FakeWatchManager()
 
         @staticmethod
@@ -1129,10 +1265,22 @@ def test_run_validates_before_checkpoint_and_stops_early():
             return True
 
         @staticmethod
-        def save_state(iteration, epoch, validation):
-            calls.append(("save", iteration, epoch, validation))
+        def save_state(iteration, epoch, validation, **kwargs):
+            calls.append(("save", iteration, epoch, validation, kwargs))
+            return "snapshot-0.ckpt"
+
+        @staticmethod
+        def save_best_state(checkpoint_path, path):
+            calls.append(("best", checkpoint_path, path))
+
+        @staticmethod
+        def step_checkpoint_scheduler(metrics):
+            calls.append(("scheduler", metrics))
 
     class FakeValidation:
+        io = SimpleNamespace(dataset_provenance=lambda: {"files": ["validation.root"]})
+        best_checkpoint = SimpleNamespace(path="best.ckpt")
+
         @staticmethod
         def run(iteration):
             calls.append(("validate", iteration))
@@ -1141,6 +1289,11 @@ def test_run_validates_before_checkpoint_and_stops_early():
         @staticmethod
         def update_early_stopping(metrics):
             calls.append(("stop", metrics))
+            return True
+
+        @staticmethod
+        def update_best_checkpoint(metrics):
+            calls.append(("select_best", metrics))
             return True
 
         @staticmethod
@@ -1157,12 +1310,17 @@ def test_run_validates_before_checkpoint_and_stops_early():
     drv.validation = FakeValidation()
     drv.main_process = True
     drv.distributed = False
+    drv.rank = None
+    drv.world_size = 0
+    drv.cfg = {"base": {}, "train": {}}
     drv.ana = None
     drv.log_manager = SimpleNamespace(close=lambda: calls.append("log_close"))
     drv.io = SimpleNamespace(
         has_loader=True,
         iter_per_epoch=1,
         prepare_iteration=lambda iteration: None,
+        checkpoint_state=lambda next_iteration: {"next_iteration": next_iteration},
+        dataset_provenance=lambda: {"files": ["train.root"]},
         close=lambda: calls.append("io_close"),
     )
     drv.initialize_log = lambda: None
@@ -1172,9 +1330,14 @@ def test_run_validates_before_checkpoint_and_stops_early():
     drv.run()
 
     assert calls[0] == ("validate", 0)
-    assert calls[2][0] == "save"
-    assert calls[2][3]["metrics"] == {"loss": 2.0}
-    assert calls[3] == ("log", {"loss": 1.0, "val_loss": 2.0})
+    assert calls[1] == ("select_best", {"loss": 2.0})
+    assert calls[3] == ("scheduler", {"loss": 2.0})
+    assert calls[4][0] == "save"
+    assert calls[4][3]["metrics"] == {"loss": 2.0}
+    assert calls[4][4]["config"] == drv.cfg
+    assert calls[4][4]["runtime_state"]["ranks"][0]["rank"] == 0
+    assert calls[5] == ("best", "snapshot-0.ckpt", "best.ckpt")
+    assert calls[6] == ("log", {"loss": 1.0, "val_loss": 2.0})
     assert calls[-3:] == ["log_close", "validation_close", "io_close"]
     assert ("start", "save") in FakeModel.watch.calls
     assert ("stop", "save") in FakeModel.watch.calls
@@ -1244,6 +1407,41 @@ def test_log_collects_scalars_memory_and_stdout(monkeypatch):
     drv.model = None
     drv.log({"index": 9}, "2026-01-01 00:00:01", iteration=1, epoch=1.0)
     assert rows[-1]["gpu_mem"] == 2.0
+
+
+@pytest.mark.skipif(not driver_mod.TORCH_AVAILABLE, reason="PyTorch is required.")
+def test_reduce_training_metrics_averages_distributed_scalars(monkeypatch):
+    """DDP logs should contain global means while structured data stays local."""
+    drv = bare_driver()
+    drv.distributed = True
+    drv.model = SimpleNamespace(train=True, device="cpu")
+    data = {
+        "loss": driver_mod.torch.tensor(2.0),
+        "accuracy": 0.5,
+        "prediction": [1, 2],
+        "converged": True,
+    }
+
+    monkeypatch.setattr(driver_mod.torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(driver_mod.torch.distributed, "get_world_size", lambda: 2)
+    monkeypatch.setattr(
+        driver_mod.torch.distributed,
+        "all_reduce",
+        lambda values: values.add_(
+            driver_mod.torch.tensor([4.0, 1.5], dtype=values.dtype)
+        ),
+    )
+
+    drv.reduce_training_metrics(data)
+
+    assert data["loss"] == pytest.approx(3.0)
+    assert data["accuracy"] == pytest.approx(1.0)
+    assert data["prediction"] == [1, 2]
+    assert data["converged"] is True
+
+    structured = {"prediction": [1, 2]}
+    drv.reduce_training_metrics(structured)
+    assert structured == {"prediction": [1, 2]}
 
 
 def test_log_requires_initialized_log_manager():

--- a/test/test_io/test_manager.py
+++ b/test/test_io/test_manager.py
@@ -98,6 +98,8 @@ class FakeLoader:
     def __init__(self) -> None:
         self.dataset = SimpleNamespace(reader=FakeReader())
         self.batches = iter([{"index": [0, 1]}, {"index": [2, 3]}])
+        self.batch_size = 2
+        self.num_workers = 0
         self.sampler = SimpleNamespace(epochs=[])
         self.sampler.set_epoch = lambda epoch: self.sampler.epochs.append(epoch)
 
@@ -406,6 +408,13 @@ def test_io_manager_iteration_unwrap_write_and_close(monkeypatch):
     manager.prepare_iteration(2)
     assert manager.loader.sampler.epochs == [0, 1]
 
+    manager.loader.sampler.epochs.clear()
+    manager.loader_iter = None
+    manager.set_resume_progress(iteration=5, epoch=2.5)
+    manager.prepare_iteration(5)
+    manager.prepare_iteration(6)
+    assert manager.loader.sampler.epochs == [2, 3]
+
     assert manager.unwrap({"index": [0]}) == {"index": [[0]]}
     assert ("start", "unwrap") in manager.watch.calls
     assert ("stop", "unwrap") in manager.watch.calls
@@ -450,3 +459,185 @@ def test_io_manager_apply_filter(monkeypatch):
     manager.reader = None
     with pytest.raises(RuntimeError, match="reader"):
         manager.apply_filter()
+
+
+def test_io_manager_checkpoints_and_restores_sampler_cursor():
+    """Loader state should preserve the next batch and sampler epoch order."""
+
+    class Sampler:
+        def __init__(self):
+            self.loaded = None
+
+        @staticmethod
+        def state_dict():
+            return {"indices": [4, 5, 0, 1, 2, 3]}
+
+        def load_state_dict(self, state, offset=0):
+            self.loaded = (state, offset)
+
+    manager = object.__new__(IOManager)
+    manager.loader = SimpleNamespace(
+        sampler=Sampler(),
+        batch_size=2,
+        num_workers=0,
+    )
+    manager.loader_iter = object()
+    manager.iter_per_epoch = 3
+    manager._resume_skip_batches = 0
+
+    state = manager.checkpoint_state(next_iteration=5)
+    manager.restore_checkpoint_state(state)
+
+    assert state["batch_offset"] == 2
+    assert manager.loader.sampler.loaded == (state["sampler"], 4)
+    assert manager.loader_iter is None
+
+    manager.loader = None
+    assert manager.checkpoint_state(6) is None
+    with pytest.raises(ValueError, match="without a loader"):
+        manager.restore_checkpoint_state(state)
+
+
+def test_io_manager_checkpoint_supports_parameterless_sampler_state():
+    """Third-party sampler state methods need not accept SPINE's cursor."""
+
+    class Sampler:
+        @staticmethod
+        def state_dict():
+            return {"third_party": True}
+
+    manager = object.__new__(IOManager)
+    manager.loader = SimpleNamespace(
+        sampler=Sampler(),
+        batch_size=2,
+        num_workers=0,
+    )
+    manager.iter_per_epoch = 3
+
+    assert manager.checkpoint_state(1)["sampler"] == {"third_party": True}
+
+
+def test_io_manager_replays_generic_sampler_cursor():
+    """A generic loader should consume restored batches before yielding."""
+
+    class Loader:
+        def __iter__(self):
+            return iter([0, 1, 2])
+
+    manager = object.__new__(IOManager)
+    manager.loader = Loader()
+    manager.loader_iter = None
+    manager._resume_skip_batches = 2
+
+    manager.reset_loader()
+
+    assert next(manager.loader_iter) == 2
+    assert manager._resume_skip_batches == 0
+
+
+def test_io_manager_warns_when_resume_must_replay_or_restart_workers():
+    """Generic samplers and worker RNG should expose exact-resume limits."""
+    manager = object.__new__(IOManager)
+    manager.loader = SimpleNamespace(
+        sampler=object(),
+        batch_size=2,
+        num_workers=2,
+    )
+    manager.loader_iter = None
+    manager._resume_skip_batches = 0
+
+    with pytest.warns(RuntimeWarning) as records:
+        manager.restore_checkpoint_state(
+            {"batch_offset": 2, "sampler": None, "num_workers": 2}
+        )
+
+    assert len(records) == 2
+    assert manager._resume_skip_batches == 2
+
+
+def test_io_manager_warns_when_resume_changes_batch_size():
+    """Restored sample order cannot preserve old batch boundaries after resizing."""
+
+    class Sampler:
+        def __init__(self):
+            self.offset = None
+
+        def load_state_dict(self, _state, offset=0):
+            self.offset = offset
+
+    sampler = Sampler()
+    manager = object.__new__(IOManager)
+    manager.loader = SimpleNamespace(
+        sampler=sampler,
+        batch_size=4,
+        num_workers=0,
+    )
+    manager.loader_iter = object()
+    manager._resume_skip_batches = 0
+
+    with pytest.warns(RuntimeWarning, match="batch size changed"):
+        manager.restore_checkpoint_state(
+            {
+                "batch_offset": 1,
+                "batch_size": 2,
+                "sampler": {"indices": [4, 5]},
+                "num_workers": 0,
+            }
+        )
+
+    assert sampler.offset == 2
+
+
+def test_io_manager_reports_composite_dataset_provenance():
+    """Resolved provenance should preserve joint and mixed source topology."""
+
+    class Dataset:
+        name = "larcv"
+
+        def __init__(self, files):
+            self.reader = SimpleNamespace(file_paths=files)
+
+        def __len__(self):
+            return 2
+
+    class Joint:
+        name = "joint"
+        joint = True
+
+        def __init__(self):
+            self.primary = Dataset(["primary.root"])
+            self.secondary = Dataset(["secondary.root"])
+
+        def __len__(self):
+            return 2
+
+    joint = Joint()
+    manager = object.__new__(IOManager)
+    manager.loader = SimpleNamespace(dataset=joint)
+    manager.reader = joint.primary.reader
+
+    provenance = manager.dataset_provenance()
+
+    assert provenance["type"] == "joint"
+    assert provenance["sources"]["primary"]["files"] == ["primary.root"]
+    assert provenance["sources"]["secondary"]["files"] == ["secondary.root"]
+
+    class Mixed:
+        name = "mixed"
+
+        def __init__(self):
+            self.primary = Dataset(["primary.root"])
+            self.cache = Dataset(["cache.h5"])
+
+        def __len__(self):
+            return 2
+
+    mixed = IOManager._dataset_provenance(Mixed())
+    assert mixed["sources"]["larcv"]["files"] == ["primary.root"]
+    assert mixed["sources"]["hdf5"]["files"] == ["cache.h5"]
+
+    manager.loader = None
+    manager.reader = FakeReader()
+    assert manager.dataset_provenance()["files"] == FakeReader.file_paths
+    manager.reader = None
+    assert manager.dataset_provenance() is None

--- a/test/test_io/test_sample.py
+++ b/test/test_io/test_sample.py
@@ -302,3 +302,102 @@ def test_distributed_proxy_sampler_pads_with_prefix_copy():
     dist_sampler = DistributedProxySampler(sampler, num_replicas=4, rank=0)
 
     assert list(dist_sampler) == [0, 4]
+
+
+def test_random_sampler_state_resumes_cached_epoch_and_rng():
+    """Sampler state should resume the remaining indexes and following epoch."""
+    sampler = RandomSequenceBatchSampler(DummyDataset(12), batch_size=4, seed=8)
+    epoch = list(sampler)
+    state = sampler.state_dict()
+    following_epoch = list(sampler)
+
+    restored = RandomSequenceBatchSampler(DummyDataset(12), batch_size=4, seed=99)
+    restored.load_state_dict(state, offset=4)
+
+    assert list(restored) == epoch[4:]
+    assert list(restored) == following_epoch
+
+    partial_state = sampler.state_dict(offset=4)
+    partial = RandomSequenceBatchSampler(DummyDataset(12), batch_size=4, seed=1)
+    partial.load_state_dict(partial_state, offset=4)
+    assert list(partial) == sampler._last_indices[4:]
+
+    boundary_state = sampler.state_dict(offset=0)
+    boundary = RandomSequenceBatchSampler(DummyDataset(12), batch_size=4, seed=1)
+    boundary.load_state_dict(boundary_state)
+    assert boundary._resume_indices is None
+
+
+def test_joint_sampler_state_resumes_pair_stream():
+    """Joint sampler state should retain the exact remaining overlay pairs."""
+    dataset = DummyJointDataset(size=12, secondary_size=3)
+    sampler = JointRandomSequenceBatchSampler(
+        dataset,
+        batch_size=4,
+        seed=5,
+        pair_probability=0.5,
+    )
+    epoch = list(sampler)
+    state = sampler.state_dict()
+
+    restored = JointRandomSequenceBatchSampler(
+        dataset,
+        batch_size=4,
+        seed=99,
+        pair_probability=0.5,
+    )
+    restored.load_state_dict(state, offset=8)
+
+    assert list(restored) == epoch[8:]
+
+    partial_state = sampler.state_dict(offset=8)
+    partial = JointRandomSequenceBatchSampler(
+        dataset,
+        batch_size=4,
+        seed=1,
+        pair_probability=0.5,
+    )
+    partial.load_state_dict(partial_state, offset=8)
+    assert list(partial) == epoch[8:]
+
+
+def test_distributed_sampler_state_resumes_rank_local_stream():
+    """Distributed sampler state should cache the process-local index order."""
+    base = RandomSequenceBatchSampler(DummyDataset(12), batch_size=4, seed=6)
+    sampler = DistributedProxySampler(base, num_replicas=2, rank=1)
+    epoch = list(sampler)
+    state = sampler.state_dict()
+
+    restored_base = RandomSequenceBatchSampler(DummyDataset(12), batch_size=4, seed=99)
+    restored = DistributedProxySampler(restored_base, num_replicas=2, rank=1)
+    restored.load_state_dict(state, offset=2)
+
+    assert list(restored) == epoch[2:]
+
+    partial_state = sampler.state_dict(offset=2)
+    partial_base = RandomSequenceBatchSampler(DummyDataset(12), batch_size=4, seed=1)
+    partial = DistributedProxySampler(partial_base, num_replicas=2, rank=1)
+    partial.load_state_dict(partial_state, offset=2)
+    assert list(partial) == epoch[2:]
+
+
+def test_sequential_bootstrap_and_joint_sequential_resume_branches():
+    """Every SPINE sampler family should consume restored partial indexes."""
+    sequential = SequentialBatchSampler(DummyDataset(4), batch_size=2, seed=1)
+    list(sequential)
+    sequential.load_state_dict(sequential.state_dict(offset=2))
+    assert list(sequential) == [2, 3]
+
+    bootstrap = BootstrapBatchSampler(DummyDataset(6), batch_size=2, seed=1)
+    epoch = list(bootstrap)
+    bootstrap.load_state_dict(bootstrap.state_dict(offset=2))
+    assert list(bootstrap) == epoch[2:]
+
+    joint = JointSequentialBatchSampler(
+        DummyJointDataset(size=4, secondary_size=2),
+        batch_size=2,
+        seed=1,
+    )
+    epoch = list(joint)
+    joint.load_state_dict(joint.state_dict(offset=2))
+    assert list(joint) == epoch[2:]

--- a/test/test_model/test_checkpoint.py
+++ b/test/test_model/test_checkpoint.py
@@ -1,0 +1,311 @@
+"""Tests for versioned checkpoint artifacts and inspection helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import spine.model.checkpoint as checkpoint_mod
+from spine.model import CheckpointManifest, inspect_checkpoint, verify_checkpoint
+from spine.utils.conditional import TORCH_AVAILABLE, torch
+from spine.utils.torch import runtime
+
+
+def test_checkpoint_manifest_is_plain_serializable_provenance(monkeypatch):
+    """Manifest construction should record versions and optional source state."""
+    monkeypatch.setattr(
+        checkpoint_mod,
+        "_discover_git_state",
+        lambda: ("abc123", True),
+    )
+
+    manifest = CheckpointManifest.create(
+        world_size=4,
+        contents=("state_dict", "optimizer"),
+    ).to_dict()
+
+    assert manifest["spine_version"]
+    assert manifest["created_at"].endswith("Z")
+    assert manifest["world_size"] == 4
+    assert manifest["git_revision"] == "abc123"
+    assert manifest["git_dirty"] is True
+    assert manifest["contents"] == ("state_dict", "optimizer")
+    assert (
+        CheckpointManifest.from_dict({**manifest, "future": True}).to_dict() == manifest
+    )
+
+
+def test_checkpoint_git_state_prefers_environment(monkeypatch):
+    """Build-provided revisions should not require a source checkout."""
+    monkeypatch.setenv("SPINE_GIT_REVISION", "build-sha")
+
+    assert checkpoint_mod._discover_git_state() == ("build-sha", None)
+
+
+def test_checkpoint_git_state_discovers_checkout_and_handles_failure(monkeypatch):
+    """Checkout discovery should report tracked dirt and degrade safely."""
+    for key in ("SPINE_GIT_REVISION", "GIT_COMMIT", "CI_COMMIT_SHA"):
+        monkeypatch.delenv(key, raising=False)
+
+    class GitMarker:
+        @staticmethod
+        def exists():
+            return True
+
+    class Repository:
+        def __truediv__(self, _name):
+            return GitMarker()
+
+        def __str__(self):
+            return "/repository"
+
+    class ResolvedPath:
+        parents = [None, None, None, Repository()]
+
+    class Path:
+        def __init__(self, _value):
+            pass
+
+        @staticmethod
+        def resolve():
+            return ResolvedPath()
+
+    monkeypatch.setattr(checkpoint_mod, "Path", Path)
+    results = iter(
+        [SimpleNamespace(stdout="revision\n"), SimpleNamespace(stdout=" M file\n")]
+    )
+    monkeypatch.setattr(
+        checkpoint_mod.sp, "run", lambda *_args, **_kwargs: next(results)
+    )
+
+    assert checkpoint_mod._discover_git_state() == ("revision", True)
+
+    monkeypatch.setattr(
+        checkpoint_mod.sp,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("git missing")),
+    )
+    assert checkpoint_mod._discover_git_state() == (None, None)
+
+
+def test_checkpoint_git_state_allows_installed_package_without_checkout(monkeypatch):
+    """Installed wheels should simply omit unavailable source-control state."""
+    for key in ("SPINE_GIT_REVISION", "GIT_COMMIT", "CI_COMMIT_SHA"):
+        monkeypatch.delenv(key, raising=False)
+
+    class MissingRepository:
+        def __truediv__(self, _name):
+            return self
+
+        @staticmethod
+        def exists():
+            return False
+
+    class ResolvedPath:
+        parents = [None, None, None, MissingRepository()]
+
+    class Path:
+        def __init__(self, _value):
+            pass
+
+        @staticmethod
+        def resolve():
+            return ResolvedPath()
+
+    monkeypatch.setattr(checkpoint_mod, "Path", Path)
+    assert checkpoint_mod._discover_git_state() == (None, None)
+
+
+@pytest.mark.model
+@pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch is required.")
+def test_checkpoint_atomic_save_checksum_and_inspection(tmp_path, monkeypatch):
+    """Saved artifacts should be verifiable and inspectable without a model."""
+    monkeypatch.setattr(
+        checkpoint_mod,
+        "_discover_git_state",
+        lambda: (None, None),
+    )
+    path = tmp_path / "snapshot-3.ckpt"
+    checkpoint = {
+        "format_version": 2,
+        "manifest": CheckpointManifest.create().to_dict(),
+        "config": {"model": {"name": "test"}},
+        "datasets": {"train": {"files": ["train.root"]}},
+        "global_step": 3,
+        "global_epoch": 1.5,
+        "state_dict": {"weight": torch.ones(1)},
+        "optimizer": {"state": {}},
+        "lr_scheduler": {"last_epoch": 3},
+        "runtime_state": {
+            "world_size": 1,
+            "ranks": [{"rank": 0, "rng": runtime.capture_rng_state(), "io": None}],
+        },
+    }
+
+    digest = checkpoint_mod.save_checkpoint(checkpoint, path)
+    info = inspect_checkpoint(path, verify=True)
+
+    assert verify_checkpoint(path)
+    assert (tmp_path / "snapshot-3.ckpt.sha256").exists()
+    assert info["sha256"] == digest
+    assert info["format_version"] == 2
+    assert info["config"] == checkpoint["config"]
+    assert info["datasets"] == checkpoint["datasets"]
+    assert info["has_optimizer"]
+    assert info["has_lr_scheduler"]
+    assert info["has_runtime_state"]
+    assert "state_dict" not in info
+
+
+@pytest.mark.model
+@pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch is required.")
+def test_checkpoint_inspection_accepts_legacy_payload(tmp_path):
+    """Metadata inspection should tolerate checkpoints predating manifests."""
+    path = tmp_path / "legacy.ckpt"
+    torch.save(
+        {
+            "state_dict": {"weight": torch.ones(1)},
+            "optimizer": {},
+            "global_step": 2,
+            "global_epoch": 0.5,
+        },
+        path,
+    )
+
+    info = inspect_checkpoint(path)
+
+    assert info["format_version"] == 1
+    assert info["global_step"] == 2
+    assert "manifest" not in info
+    assert not info["has_runtime_state"]
+
+
+@pytest.mark.model
+@pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch is required.")
+def test_checkpoint_verification_detects_modified_artifact(tmp_path):
+    """Checksum verification should reject bytes changed after serialization."""
+    path = tmp_path / "snapshot.ckpt"
+    checkpoint_mod.save_checkpoint({"state_dict": {}}, path)
+    with open(path, "ab") as checkpoint_file:
+        checkpoint_file.write(b"changed")
+
+    assert not verify_checkpoint(path)
+    with pytest.raises(ValueError, match="checksum"):
+        inspect_checkpoint(path, verify=True)
+
+
+@pytest.mark.model
+@pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch is required.")
+def test_checkpoint_promotion_copies_artifact_and_checksum(tmp_path):
+    """Best-checkpoint promotion should publish a loadable stable artifact."""
+    source = tmp_path / "snapshot-4.ckpt"
+    destination = tmp_path / "snapshot-best.ckpt"
+    checkpoint_mod.save_checkpoint({"state_dict": {"x": torch.ones(1)}}, source)
+
+    digest = checkpoint_mod.promote_checkpoint(source, destination)
+
+    assert destination.read_bytes() == source.read_bytes()
+    assert checkpoint_mod.checkpoint_sha256(destination) == digest
+    assert verify_checkpoint(destination)
+
+
+def test_checkpoint_promotion_cleans_temporary_copy_on_failure(tmp_path, monkeypatch):
+    """Failed best-checkpoint copies should not leave temporary artifacts."""
+    source = tmp_path / "snapshot-4.ckpt"
+    source.write_bytes(b"checkpoint")
+    monkeypatch.setattr(
+        checkpoint_mod.shutil,
+        "copyfile",
+        lambda *_args: (_ for _ in ()).throw(OSError("copy failed")),
+    )
+
+    with pytest.raises(OSError, match="copy failed"):
+        checkpoint_mod.promote_checkpoint(source, tmp_path / "snapshot-best.ckpt")
+
+    assert not any(path.suffix == ".tmp" for path in tmp_path.iterdir())
+
+
+@pytest.mark.model
+@pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch is required.")
+def test_checkpoint_verification_rejects_malformed_sidecars(tmp_path):
+    """Checksum sidecars should identify both a digest and matching filename."""
+    path = tmp_path / "snapshot.ckpt"
+    path.write_bytes(b"checkpoint")
+    sidecar = tmp_path / "snapshot.ckpt.sha256"
+    sidecar.write_text("bad", encoding="utf-8")
+    with pytest.raises(ValueError, match="Malformed"):
+        verify_checkpoint(path)
+
+    sidecar.write_text(f"{'0' * 64}  another.ckpt\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="another.ckpt"):
+        verify_checkpoint(path)
+
+
+@pytest.mark.model
+@pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch is required.")
+def test_checkpoint_save_cleans_temporary_files_on_failures(tmp_path, monkeypatch):
+    """Failed serialization and sidecar publication should remove temporaries."""
+    path = tmp_path / "snapshot.ckpt"
+    real_save = checkpoint_mod.torch.save
+    monkeypatch.setattr(
+        checkpoint_mod.torch,
+        "save",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("save failed")),
+    )
+    with pytest.raises(OSError, match="save failed"):
+        checkpoint_mod.save_checkpoint({}, path)
+    assert not list(tmp_path.glob("*.tmp"))
+
+    monkeypatch.setattr(checkpoint_mod.torch, "save", real_save)
+    real_replace = checkpoint_mod.os.replace
+    replace_calls = 0
+
+    def replace(source, destination):
+        nonlocal replace_calls
+        replace_calls += 1
+        if replace_calls == 2:
+            raise OSError("sidecar failed")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(checkpoint_mod.os, "replace", replace)
+    with pytest.raises(OSError, match="sidecar failed"):
+        checkpoint_mod.save_checkpoint({}, path)
+    assert path.exists()
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_checkpoint_helpers_require_torch(monkeypatch, tmp_path):
+    """Artifact serialization and inspection should fail clearly without Torch."""
+    monkeypatch.setattr(checkpoint_mod, "TORCH_AVAILABLE", False)
+    with pytest.raises(ImportError, match="save"):
+        checkpoint_mod.save_checkpoint({}, tmp_path / "snapshot.ckpt")
+    with pytest.raises(ImportError, match="inspect"):
+        inspect_checkpoint(tmp_path / "snapshot.ckpt")
+
+
+@pytest.mark.model
+@pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch is required.")
+def test_checkpoint_inspection_supports_legacy_torch_api(monkeypatch, tmp_path):
+    """Inspection should retry Torch versions predating ``weights_only``."""
+    path = tmp_path / "legacy.ckpt"
+    path.touch()
+    calls = []
+
+    def load(_path, **kwargs):
+        calls.append(kwargs)
+        if "weights_only" in kwargs:
+            raise TypeError("unexpected keyword argument 'weights_only'")
+        return {"state_dict": {}, "global_step": 1}
+
+    monkeypatch.setattr(checkpoint_mod.torch, "load", load)
+    assert inspect_checkpoint(path)["global_step"] == 1
+    assert len(calls) == 2
+
+    monkeypatch.setattr(
+        checkpoint_mod.torch,
+        "load",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(TypeError("unrelated")),
+    )
+    with pytest.raises(TypeError, match="unrelated"):
+        inspect_checkpoint(path)

--- a/test/test_model/test_manager.py
+++ b/test/test_model/test_manager.py
@@ -252,23 +252,116 @@ def test_initialize_train_validates_save_cadence(monkeypatch, tmp_path):
             optimizer={"name": "Adam"},
             save_epoch=1.0,
         )
+    with pytest.raises(TypeError, match="resume.*boolean"):
+        manager.initialize_train(optimizer={"name": "Adam"}, resume="yes")
+    with pytest.raises(ValueError, match="restore_optimizer"):
+        manager.initialize_train(
+            optimizer={"name": "Adam"},
+            restore_optimizer=True,
+            resume=False,
+        )
 
     scheduler = object()
+    scheduler_cfg = []
     monkeypatch.setattr("spine.model.manager.optim_factory", lambda *_args: object())
     monkeypatch.setattr(
         "spine.model.manager.lr_sched_factory",
-        lambda *_args: scheduler,
+        lambda cfg, _optimizer: scheduler_cfg.append(cfg) or scheduler,
     )
     manager.initialize_train(
         optimizer={"name": "Adam"},
         weight_prefix=str(tmp_path / "weights" / "snapshot"),
         save_epoch=0.5,
         iter_per_epoch=10,
-        lr_scheduler={"name": "StepLR"},
+        lr_scheduler={
+            "name": "ReduceLROnPlateau",
+            "interval": "checkpoint",
+            "monitor": "loss",
+        },
     )
     assert manager.save_step == 5
     assert manager.lr_scheduler is scheduler
+    assert manager.lr_scheduler_interval == "checkpoint"
+    assert manager.lr_scheduler_monitor == "loss"
+    assert scheduler_cfg == [{"name": "ReduceLROnPlateau"}]
+    assert not manager.resume_training
     assert (tmp_path / "weights").is_dir()
+
+
+def test_initialize_train_selects_resume_mode_from_weight_path():
+    """A single training checkpoint should enable non-strict automatic resume."""
+    manager = make_bare_manager(
+        net=torch.nn.Linear(1, 1),
+        configured_weight_path="snapshot.ckpt",
+    )
+
+    manager.initialize_train(optimizer={"name": "Adam"})
+
+    assert manager.resume_training
+    assert manager.restore_optimizer
+    assert not manager.strict_resume
+    assert manager.load_training_progress
+
+
+def test_initialize_train_requires_checkpoint_for_explicit_resume():
+    """Strict resume should require one global checkpoint path."""
+    manager = make_bare_manager(
+        net=torch.nn.Linear(1, 1),
+        configured_weight_path=None,
+    )
+
+    with pytest.raises(ValueError, match="requires a global `weight_path`"):
+        manager.initialize_train(optimizer={"name": "Adam"}, resume=True)
+
+
+@pytest.mark.parametrize(
+    ("scheduler", "error", "message"),
+    [
+        ("StepLR", TypeError, "must be a mapping"),
+        ({"name": "StepLR", "interval": "epoch"}, ValueError, "interval"),
+        (
+            {"name": "StepLR", "monitor": "loss"},
+            ValueError,
+            "interval: checkpoint",
+        ),
+    ],
+)
+def test_initialize_train_validates_scheduler_policy(
+    monkeypatch, scheduler, error, message
+):
+    """Manager-owned scheduler trigger options should fail during setup."""
+    manager = make_bare_manager(net=torch.nn.Linear(1, 1))
+    monkeypatch.setattr("spine.model.manager.optim_factory", lambda *_args: object())
+
+    with pytest.raises(error, match=message):
+        manager.initialize_train(
+            optimizer={"name": "Adam"},
+            lr_scheduler=scheduler,
+        )
+
+
+def test_training_rejects_weight_list(monkeypatch, tmp_path):
+    """Checkpoint collections have no defined training-resume semantics."""
+
+    class Network(torch.nn.Module):
+        pass
+
+    monkeypatch.setattr(
+        "spine.model.manager.model_factory",
+        lambda _name: (Network, Network),
+    )
+    weight_list = tmp_path / "weights.txt"
+    weight_list.write_text("snapshot.ckpt\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="only supported for inference"):
+        ModelManager(
+            name="test",
+            modules={},
+            network_input={},
+            loss_input={"target": "target"},
+            weight_list=str(weight_list),
+            train={"optimizer": {"name": "Adam"}},
+        )
 
 
 def test_prepare_data_converts_batches_and_validates_required_keys():
@@ -358,6 +451,36 @@ def test_backward_steps_optimizer_scheduler_and_model_buffers():
 
     assert scheduler.steps == 1
     assert net.buffer_updates == 1
+
+
+def test_checkpoint_scheduler_steps_with_optional_validation_metric():
+    """Checkpoint schedulers should support ordinary and monitored policies."""
+
+    class Scheduler:
+        def __init__(self):
+            self.values = []
+
+        def step(self, *values):
+            self.values.append(values)
+
+    scheduler = Scheduler()
+    manager = make_bare_manager(
+        lr_scheduler=scheduler,
+        lr_scheduler_interval="checkpoint",
+        lr_scheduler_monitor=None,
+    )
+    manager.step_checkpoint_scheduler()
+    assert scheduler.values == [()]
+
+    manager.lr_scheduler_monitor = "loss"
+    manager.step_checkpoint_scheduler({"loss": 0.25})
+    assert scheduler.values[-1] == (0.25,)
+    with pytest.raises(KeyError, match="metric `loss`"):
+        manager.step_checkpoint_scheduler({"accuracy": 1.0})
+
+    manager.lr_scheduler_interval = "step"
+    manager.step_checkpoint_scheduler({"loss": 0.1})
+    assert len(scheduler.values) == 2
 
 
 def test_training_rejects_fully_frozen_network():
@@ -472,13 +595,19 @@ def test_cast_to_numpy_handles_structured_cluster_labels():
     assert result["label"].is_numpy
 
 
-def test_save_state_writes_checkpoint_and_requires_prefix(tmp_path):
-    """Checkpoint serialization records model, optimizer, step, and epoch."""
+def test_save_state_writes_rich_checkpoint_and_requires_prefix(tmp_path, monkeypatch):
+    """Checkpoint serialization should record state, provenance and checksum."""
     net = torch.nn.Linear(1, 1)
     optimizer = torch.optim.SGD(net.parameters(), lr=0.1)
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=2)
+    monkeypatch.setattr(
+        "spine.model.checkpoint._discover_git_state",
+        lambda: ("abc123", False),
+    )
     manager = make_bare_manager(
         net=net,
         optimizer=optimizer,
+        lr_scheduler=scheduler,
         distributed=False,
         weight_prefix=None,
     )
@@ -486,11 +615,31 @@ def test_save_state_writes_checkpoint_and_requires_prefix(tmp_path):
         manager.save_state(1, 0.5)
 
     manager.weight_prefix = str(tmp_path / "snapshot")
-    manager.save_state(3, 1.5, {"metrics": {"loss": 0.25}})
+    checkpoint_path = manager.save_state(
+        3,
+        1.5,
+        {"metrics": {"loss": 0.25}},
+        config={"model": {"name": "test"}},
+        datasets={"train": {"files": ["train.root"]}},
+        runtime_state={"world_size": 1, "ranks": []},
+    )
     checkpoint = torch.load(tmp_path / "snapshot-3.ckpt", weights_only=True)
+    assert checkpoint["format_version"] == 2
+    assert checkpoint["manifest"]["git_revision"] == "abc123"
+    assert "runtime_state" in checkpoint["manifest"]["contents"]
+    assert checkpoint["config"]["model"]["name"] == "test"
+    assert checkpoint["datasets"]["train"]["files"] == ["train.root"]
     assert checkpoint["global_step"] == 3
     assert checkpoint["global_epoch"] == 1.5
+    assert checkpoint["lr_scheduler"] == scheduler.state_dict()
+    assert checkpoint["runtime_state"] == {"world_size": 1, "ranks": []}
     assert checkpoint["validation"] == {"metrics": {"loss": 0.25}}
+    assert (tmp_path / "snapshot-3.ckpt.sha256").exists()
+    assert checkpoint_path == str(tmp_path / "snapshot-3.ckpt")
+
+    best_path = manager.save_best_state(checkpoint_path)
+    assert best_path == str(tmp_path / "snapshot-best.ckpt")
+    assert (tmp_path / "snapshot-best.ckpt.sha256").exists()
 
 
 def test_evaluate_restores_training_state_without_gradients():
@@ -709,6 +858,10 @@ def test_manager_exposes_configured_checkpoint_boundaries():
     assert manager.should_save(2)
     assert not manager.should_save(1)
 
+    manager.start_iteration = 10
+    assert manager.should_save(12)
+    assert not manager.should_save(11)
+
 
 def test_module_weight_path_must_exist(tmp_path):
     """Nested pretrained-module paths are validated before deserialization."""
@@ -759,12 +912,158 @@ def test_load_weights_supports_legacy_torch_and_restores_optimizer(
         optimizer=optimizer,
     )
     monkeypatch.setattr(torch, "load", load)
-    manager.load_weights(None)
+    with pytest.warns(RuntimeWarning) as records:
+        manager.load_weights(None)
 
     assert len(calls) == 3
     assert calls[-1] == {"optimizer": checkpoint["optimizer"]}
+    assert len(records) == 2
+    assert "global epoch" in str(records[0].message)
+    assert "RNG" in str(records[1].message)
     assert manager.start_iteration == 7
     assert manager.checkpoint_validation == checkpoint["validation"]
+
+
+def test_load_weights_restores_complete_available_training_state(monkeypatch, tmp_path):
+    """Resume mode should restore scheduler and expose runtime provenance."""
+    path = tmp_path / "resume.ckpt"
+    path.touch()
+    net = torch.nn.Linear(1, 1)
+    checkpoint = {
+        "format_version": 2,
+        "manifest": {"spine_version": "test"},
+        "config": {"train": {"resume": True}},
+        "datasets": {"train": {"files": ["train.root"]}},
+        "state_dict": net.state_dict(),
+        "optimizer": {"state": "optimizer"},
+        "lr_scheduler": {"state": "scheduler"},
+        "runtime_state": {"world_size": 1, "ranks": []},
+        "global_step": 6,
+        "global_epoch": 3.5,
+    }
+    calls = []
+    optimizer = SimpleNamespace(
+        load_state_dict=lambda state: calls.append(("optimizer", state))
+    )
+    scheduler = SimpleNamespace(
+        load_state_dict=lambda state: calls.append(("scheduler", state))
+    )
+    manager = make_bare_manager(
+        model_name="test",
+        model_cfg={"test": {"weight_path": str(path), "model_name": "test"}},
+        net=net,
+        train=True,
+        restore_optimizer=True,
+        resume_training=True,
+        optimizer=optimizer,
+        lr_scheduler=scheduler,
+    )
+    monkeypatch.setattr(torch, "load", lambda *_args, **_kwargs: checkpoint)
+
+    manager.load_weights(None)
+
+    assert calls == [
+        ("optimizer", checkpoint["optimizer"]),
+        ("scheduler", checkpoint["lr_scheduler"]),
+    ]
+    assert manager.start_iteration == 7
+    assert manager.start_epoch == 3.5
+    assert manager.checkpoint_manifest == checkpoint["manifest"]
+    assert manager.checkpoint_config == checkpoint["config"]
+    assert manager.checkpoint_datasets == checkpoint["datasets"]
+    assert manager.checkpoint_runtime_state == checkpoint["runtime_state"]
+
+
+def test_resume_legacy_checkpoint_reports_missing_training_state(monkeypatch, tmp_path):
+    """Resume should reject missing optimizer state and warn for later additions."""
+    path = tmp_path / "legacy.ckpt"
+    path.touch()
+    net = torch.nn.Linear(1, 1)
+    checkpoint = {"state_dict": net.state_dict(), "global_step": 2}
+    manager = make_bare_manager(
+        model_name="test",
+        model_cfg={"test": {"weight_path": str(path), "model_name": "test"}},
+        net=net,
+        train=True,
+        restore_optimizer=True,
+        resume_training=True,
+        optimizer=SimpleNamespace(load_state_dict=lambda _state: None),
+        lr_scheduler=SimpleNamespace(load_state_dict=lambda _state: None),
+    )
+    monkeypatch.setattr(torch, "load", lambda *_args, **_kwargs: checkpoint)
+
+    with pytest.raises(KeyError, match="optimizer state"):
+        manager.load_weights(None)
+
+    checkpoint["optimizer"] = {}
+    with pytest.warns(RuntimeWarning) as records:
+        manager.load_weights(None)
+
+    assert len(records) == 3
+    assert "scheduler" in str(records[0].message)
+    assert "global epoch" in str(records[1].message)
+    assert "RNG" in str(records[2].message)
+
+
+def test_automatic_resume_allows_legacy_checkpoint_without_optimizer(
+    monkeypatch, tmp_path
+):
+    """Automatic resume should preserve legacy progress and restart its optimizer."""
+    path = tmp_path / "legacy.ckpt"
+    path.touch()
+    net = torch.nn.Linear(1, 1)
+    checkpoint = {"state_dict": net.state_dict(), "global_step": 2}
+    optimizer_calls = []
+    manager = make_bare_manager(
+        model_name="test",
+        model_cfg={"test": {"weight_path": str(path), "model_name": "test"}},
+        net=net,
+        train=True,
+        restore_optimizer=True,
+        resume_training=True,
+        strict_resume=False,
+        load_training_progress=True,
+        optimizer=SimpleNamespace(
+            load_state_dict=lambda state: optimizer_calls.append(state)
+        ),
+    )
+    monkeypatch.setattr(torch, "load", lambda *_args, **_kwargs: checkpoint)
+
+    with pytest.warns(RuntimeWarning) as records:
+        manager.load_weights(None)
+
+    assert manager.start_iteration == 3
+    assert not optimizer_calls
+    assert any("optimizer state" in str(record.message) for record in records)
+
+
+def test_explicit_non_resume_loads_weights_without_progress(monkeypatch, tmp_path):
+    """Explicit ``resume: false`` should begin new training from loaded weights."""
+    path = tmp_path / "pretrained.ckpt"
+    path.touch()
+    net = torch.nn.Linear(1, 1)
+    checkpoint = {
+        "state_dict": net.state_dict(),
+        "global_step": 9,
+        "validation": {"metrics": {"loss": 0.5}},
+        "manifest": {"spine_version": "test"},
+    }
+    manager = make_bare_manager(
+        model_name="test",
+        model_cfg={"test": {"weight_path": str(path), "model_name": "test"}},
+        net=net,
+        train=True,
+        restore_optimizer=False,
+        resume_training=False,
+        load_training_progress=False,
+    )
+    monkeypatch.setattr(torch, "load", lambda *_args, **_kwargs: checkpoint)
+
+    manager.load_weights(None)
+
+    assert manager.start_iteration == 0
+    assert manager.checkpoint_validation is None
+    assert manager.checkpoint_manifest == checkpoint["manifest"]
 
 
 def test_load_weights_targets_unwrapped_ddp_network(tmp_path):

--- a/test/test_model/test_validation.py
+++ b/test/test_model/test_validation.py
@@ -9,7 +9,7 @@ import pytest
 
 import spine.model.validation as validation_mod
 from spine.model import ValidationManager
-from spine.model.validation import EarlyStopping
+from spine.model.validation import BestCheckpoint, EarlyStopping
 from spine.utils.conditional import TORCH_AVAILABLE
 
 
@@ -186,6 +186,42 @@ def test_early_stopping_validates_policy(kwargs, message):
         stopping.restore(state)
 
 
+def test_best_checkpoint_tracks_and_restores_progress():
+    """Best-checkpoint selection should promote only meaningful improvements."""
+    policy = BestCheckpoint(
+        monitor="accuracy",
+        mode="max",
+        min_delta=0.05,
+        path="weights/best.ckpt",
+    )
+
+    assert policy.update({"accuracy": 0.5})
+    assert not policy.update({"accuracy": 0.54})
+    assert policy.update({"accuracy": 0.6})
+    assert policy.path == "weights/best.ckpt"
+
+    restored = BestCheckpoint(
+        monitor="accuracy",
+        mode="max",
+        state=policy.state_dict(),
+    )
+    assert restored.best == pytest.approx(0.6)
+
+    incompatible = policy.state_dict()
+    incompatible["mode"] = "min"
+    with pytest.raises(ValueError, match="does not match"):
+        restored.restore(incompatible)
+    with pytest.raises(KeyError, match="accuracy"):
+        restored.update({"loss": 1.0})
+
+    with pytest.raises(ValueError, match="mode"):
+        BestCheckpoint(mode="sideways")
+    with pytest.raises(ValueError, match="min_delta"):
+        BestCheckpoint(min_delta=-1.0)
+    with pytest.raises(TypeError, match="path"):
+        BestCheckpoint(path=1)
+
+
 def test_validation_manager_runs_fraction_and_updates_stopping(monkeypatch):
     """Validation should average scalar outputs over the deterministic fraction."""
 
@@ -227,6 +263,7 @@ def test_validation_manager_runs_fraction_and_updates_stopping(monkeypatch):
             "file_keys": "validation.root",
             "fraction": 0.5,
             "early_stopping": {"monitor": "loss", "patience": 1},
+            "best_checkpoint": True,
         },
         ordinary_loader(),
         FakeModel(),
@@ -239,8 +276,12 @@ def test_validation_manager_runs_fraction_and_updates_stopping(monkeypatch):
 
     metrics = manager.run(iteration=2)
     assert metrics == {"loss": 4.0}
+    assert manager.update_best_checkpoint(metrics)
+    assert not manager.update_best_checkpoint(metrics)
     assert not manager.update_early_stopping(metrics)
-    assert manager.checkpoint_state(metrics)["metrics"] == metrics
+    state = manager.checkpoint_state(metrics)
+    assert state["metrics"] == metrics
+    assert state["best_checkpoint"]["best"] == 4.0
     manager.close()
     assert manager.io.closed
 
@@ -268,11 +309,17 @@ def test_validation_manager_validates_runtime_options(monkeypatch):
         "seed": 1,
     }
 
+    with pytest.raises(TypeError, match="fraction"):
+        ValidationManager({"file_keys": "val.root", "fraction": "half"}, **kwargs)
     with pytest.raises(ValueError, match="fraction"):
         ValidationManager({"file_keys": "val.root", "fraction": 0.0}, **kwargs)
     with pytest.raises(TypeError, match="early_stopping"):
         ValidationManager(
             {"file_keys": "val.root", "early_stopping": "invalid"}, **kwargs
+        )
+    with pytest.raises(TypeError, match="best_checkpoint"):
+        ValidationManager(
+            {"file_keys": "val.root", "best_checkpoint": "invalid"}, **kwargs
         )
 
 
@@ -368,5 +415,7 @@ def test_validation_run_reduces_distributed_scalar_metrics(monkeypatch):
         manager.run(3)
 
     manager.early_stopping = None
+    manager.best_checkpoint = None
     assert not manager.update_early_stopping({"loss": 1.0})
+    assert not manager.update_best_checkpoint({"loss": 1.0})
     assert manager.checkpoint_state({"loss": 1.0}) == {"metrics": {"loss": 1.0}}

--- a/test/test_utils/test_torch_runtime.py
+++ b/test/test_utils/test_torch_runtime.py
@@ -1,0 +1,27 @@
+"""Tests for optional PyTorch runtime state helpers."""
+
+import random
+
+import numpy as np
+
+from spine.utils.conditional import TORCH_AVAILABLE, torch
+from spine.utils.torch import runtime
+
+
+def test_rng_state_round_trip_restores_python_and_numpy():
+    """Runtime state should reproduce process-local stochastic streams."""
+    random.seed(13)
+    np.random.seed(13)
+    state = runtime.capture_rng_state()
+    expected = [random.random(), np.random.random()]
+    if TORCH_AVAILABLE:
+        expected.append(torch.rand(1).item())
+
+    random.seed(99)
+    np.random.seed(99)
+    runtime.restore_rng_state(state)
+
+    result = [random.random(), np.random.random()]
+    if TORCH_AVAILABLE:
+        result.append(torch.rand(1).item())
+    assert result == expected


### PR DESCRIPTION
## Summary

- Enrich checkpoints with a versioned manifest, normalized configuration, dataset provenance, checksums, scheduler state, and per-rank RNG/loader continuation state.
- Add backward-compatible resume controls, including CLI overrides and epoch-preserving continuation when the batch size changes.
- Add best-checkpoint promotion, checkpoint-bound scheduler policies, distributed scalar reduction, and rank-zero TensorBoard logging.
- Make loader and sampler progress checkpointable, including deterministic default sampling for joint datasets.

## Motivation

Training checkpoints should be self-describing artifacts and carry enough state for reliable continuation. Validation-driven training also needs a stable best checkpoint and scheduler/metric behavior that remains consistent under DDP.

## Compatibility

Legacy checkpoints remain loadable. Missing continuation state produces explicit warnings, while strict resume validates required optimizer state. Existing training configuration remains supported.

## Validation

- Full repository test suite passed in the project Docker image.
- Focused training, checkpoint, and validation suite: 177 passed.
- Model manager suite: 45 passed with a clean warning summary.
- Validation manager suite: 15 passed.
- Pre-commit passed, including Black, isort, flake8, and repository hygiene hooks.
