### PR TITLE
Add cluster-quality cuts for model supervision

### DIFF
--- a/config/full_chain/full_chain_regression.yaml
+++ b/config/full_chain/full_chain_regression.yaml
@@ -426,13 +426,15 @@ model:
           target: pid
           loss: ce
           balance_loss: true
+          min_iou: 0.5
+          match_target: group
         primary:
           name: class
           target: inter_primary
           loss: ce
           balance_loss: true
-          use_closest: true
-          secondary_label: 0
+          min_iou: 0.5
+          match_target: group
         orient:
           name: orient
           loss: ce

--- a/src/spine/cluster/__init__.py
+++ b/src/spine/cluster/__init__.py
@@ -7,7 +7,7 @@ array-only numerical primitives remain under :mod:`spine.math`.
 # Explicit public re-exports intentionally mirror submodule ``__all__`` lists.
 # pylint: disable=duplicate-code
 
-from . import direction, features, formation, graph, label, topology
+from . import direction, features, formation, graph, label, quality, topology
 from .direction import (
     cluster_dedx,
     cluster_dedx_dir,
@@ -36,9 +36,11 @@ from .label import (
     get_cluster_points_label_batch,
     get_cluster_primary_label_batch,
 )
+from .quality import ClusterOverlapBatch, get_cluster_overlap_batch
 
 __all__ = [
     "break_clusters",
+    "ClusterOverlapBatch",
     "cluster_dedx",
     "cluster_dedx_dir",
     "cluster_direction",
@@ -64,8 +66,10 @@ __all__ = [
     "get_cluster_points_label",
     "get_cluster_points_label_batch",
     "get_cluster_primary_label_batch",
+    "get_cluster_overlap_batch",
     "get_cluster_sizes",
     "graph",
     "label",
+    "quality",
     "topology",
 ]

--- a/src/spine/cluster/quality.py
+++ b/src/spine/cluster/quality.py
@@ -1,0 +1,219 @@
+"""Cluster-to-truth overlap quality measurements.
+
+The routines in this module assign each predicted cluster to its majority
+truth instance and report the quality of that single assignment. They provide
+the common geometric input used by model losses to reject ambiguous targets.
+"""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple, cast
+
+import numpy as np
+from numba.typed import List as NumbaList  # pylint: disable=no-name-in-module
+
+from spine.data import ClusterLabelBatch, IndexBatch, TensorBatch
+from spine.math.match import overlap_metrics
+
+from .formation import form_clusters
+
+__all__ = ["ClusterOverlapBatch", "get_cluster_overlap_batch"]
+
+
+class ClusterOverlapBatch(NamedTuple):
+    """Best truth-instance overlap measurements for predicted clusters.
+
+    Attributes
+    ----------
+    match_ids : TensorBatch
+        Truth-instance identifier matched to each predicted cluster.
+    intersections : TensorBatch
+        Number of shared voxels with the matched truth instance.
+    purities : TensorBatch
+        Fraction of each predicted cluster owned by its truth match.
+    efficiencies : TensorBatch
+        Fraction of each truth match recovered by the predicted cluster.
+    ious : TensorBatch
+        Intersection over union with the matched truth instance.
+    """
+
+    match_ids: TensorBatch
+    intersections: TensorBatch
+    purities: TensorBatch
+    efficiencies: TensorBatch
+    ious: TensorBatch
+
+
+class _ClusterOverlap(NamedTuple):
+    """Unbatched overlap arrays used internally by this module.
+
+    The five arrays have one entry per predicted cluster and preserve predicted
+    cluster order throughout event-local and batched calculations.
+    """
+
+    match_ids: np.ndarray
+    intersections: np.ndarray
+    purities: np.ndarray
+    efficiencies: np.ndarray
+    ious: np.ndarray
+
+
+def get_cluster_overlap_batch(
+    data: ClusterLabelBatch,
+    clusts: IndexBatch,
+    column: str = "group",
+) -> ClusterOverlapBatch:
+    """Measure each predicted cluster against its majority truth instance.
+
+    The best truth match is the instance sharing the largest number of voxels
+    with a predicted cluster. Purity, efficiency and IoU are all read from
+    that same match, preserving a single and consistent instance assignment.
+    Matches are performed independently in each batch entry, so truth IDs may
+    safely repeat between events.
+
+    Parameters
+    ----------
+    data : ClusterLabelBatch
+        Structured voxel labels aligned with the cluster index space.
+    clusts : IndexBatch
+        (C) Predicted cluster indexes grouped by batch entry.
+    column : str, default 'group'
+        Integer-valued field used to form truth instances. Negative IDs are
+        ignored and therefore cannot be selected as matches.
+
+    Returns
+    -------
+    ClusterOverlapBatch
+        Best match and overlap quality for every predicted cluster. Unmatched
+        clusters receive match ID ``-1`` and zero-valued measurements.
+
+    Raises
+    ------
+    ValueError
+        If cluster and label batch spans are not aligned.
+    """
+    truth_ids = data.voxel_field(column).to_numpy()
+    clusts_np = clusts.to_numpy()
+    if not np.array_equal(clusts_np.spans, truth_ids.counts):
+        raise ValueError("Cluster indexes and labels must share batch spans.")
+
+    # Allocate flat outputs in predicted-cluster order
+    num_clusts = len(clusts_np.index_list)
+    output = _empty_cluster_overlap(num_clusts)
+    truth_id_array = truth_ids.numpy_tensor().astype(np.int64, copy=False)
+
+    # Match within each event so repeated truth identifiers remain independent.
+    for batch_id in range(truth_ids.batch_size):
+        lower, upper = clusts_np.edges[batch_id : batch_id + 2]
+        if lower == upper:
+            continue
+
+        event_overlap = _get_batch_entry_overlap(
+            truth_ids,
+            clusts_np,
+            truth_id_array,
+            batch_id,
+        )
+
+        # Copy the event-local results into the flat batch arrays
+        for output_values, event_values in zip(output, event_overlap, strict=True):
+            output_values[lower:upper] = event_values
+
+    counts = clusts_np.counts
+    return ClusterOverlapBatch(
+        TensorBatch(output.match_ids, counts),
+        TensorBatch(output.intersections, counts),
+        TensorBatch(output.purities, counts),
+        TensorBatch(output.efficiencies, counts),
+        TensorBatch(output.ious, counts),
+    )
+
+
+def _empty_cluster_overlap(num_clusts: int) -> _ClusterOverlap:
+    """Initialize unmatched overlap results for predicted clusters.
+
+    Parameters
+    ----------
+    num_clusts : int
+        Number of predicted clusters represented by the output.
+
+    Returns
+    -------
+    _ClusterOverlap
+        Match IDs initialized to ``-1`` and zero-valued overlap metrics.
+    """
+    return _ClusterOverlap(
+        np.full(num_clusts, -1, dtype=np.int64),
+        np.zeros(num_clusts, dtype=np.int64),
+        np.zeros(num_clusts, dtype=np.float32),
+        np.zeros(num_clusts, dtype=np.float32),
+        np.zeros(num_clusts, dtype=np.float32),
+    )
+
+
+def _get_batch_entry_overlap(
+    truth_id_batch: TensorBatch,
+    clusts: IndexBatch,
+    truth_ids: np.ndarray,
+    batch_id: int,
+) -> _ClusterOverlap:
+    """Measure one entry from aligned label and cluster batches.
+
+    Global voxel indexes are translated to event-local indexes before invoking
+    the unbatched overlap kernel.
+    """
+    lower, upper = clusts.edges[batch_id : batch_id + 2]
+    voxel_lower, voxel_upper = truth_id_batch.edges[batch_id : batch_id + 2]
+    truth_ids_b = truth_ids[voxel_lower:voxel_upper]
+    predicted = [
+        np.asarray(index - voxel_lower, dtype=np.int64)
+        for index in clusts.index_list[lower:upper]
+    ]
+    return _get_cluster_overlap(truth_ids_b, predicted)
+
+
+def _get_cluster_overlap(
+    truth_ids: np.ndarray,
+    predicted: list[np.ndarray],
+) -> _ClusterOverlap:
+    """Measure one event's predicted clusters against its truth instances.
+
+    Parameters
+    ----------
+    truth_ids : np.ndarray
+        Truth-instance ID for every voxel in the event.
+    predicted : list[np.ndarray]
+        Sorted event-local voxel indexes for each predicted cluster.
+
+    Returns
+    -------
+    _ClusterOverlap
+        Majority match and corresponding qualities for each prediction.
+    """
+    output = _empty_cluster_overlap(len(predicted))
+    unique_truth = np.unique(truth_ids[truth_ids >= 0])
+    if len(unique_truth) == 0:
+        return output
+
+    # Group the truth indexes with one stable sort. Predicted indexes are
+    # already sorted by their builders, as required by the linear kernel.
+    truth, _ = form_clusters(truth_ids)
+    counts, purities, efficiencies, ious = overlap_metrics(
+        cast(Any, NumbaList)(predicted),
+        cast(Any, NumbaList)(truth),
+    )
+
+    # Select the majority truth instance once, then gather every metric at that
+    # same matrix entry to preserve a coherent object-to-truth assignment.
+    best = np.argmax(counts, axis=1)
+    rows = np.arange(len(predicted))
+    best_counts = counts[rows, best]
+    matched = best_counts > 0
+    matched_rows = rows[matched]
+    matched_truth = best[matched]
+    output.match_ids[matched_rows] = unique_truth[matched_truth]
+    output.intersections[matched_rows] = best_counts[matched]
+    output.purities[matched_rows] = purities[matched_rows, matched_truth]
+    output.efficiencies[matched_rows] = efficiencies[matched_rows, matched_truth]
+    output.ious[matched_rows] = ious[matched_rows, matched_truth]
+    return output

--- a/src/spine/math/match.py
+++ b/src/spine/math/match.py
@@ -1,5 +1,7 @@
 """Functions to find the best overlaps between point sets."""
 
+from collections.abc import Sequence
+
 import numba as nb
 import numpy as np
 
@@ -7,6 +9,7 @@ from spine.math.distance import cdist
 
 __all__ = [
     "overlap_count",
+    "overlap_metrics",
     "overlap_iou",
     "overlap_weighted_iou",
     "overlap_dice",
@@ -16,7 +19,7 @@ __all__ = [
 
 
 @nb.njit(cache=True)
-def intersection_size_sorted(x: nb.int64[:], y: nb.int64[:]) -> nb.int64:
+def intersection_size_sorted(x: np.ndarray, y: np.ndarray) -> int:
     """Compute the size of the intersection of two sorted unique arrays."""
     i = j = count = 0
     while i < len(x) and j < len(y):
@@ -34,24 +37,24 @@ def intersection_size_sorted(x: nb.int64[:], y: nb.int64[:]) -> nb.int64:
 
 @nb.njit(cache=True, parallel=True)
 def overlap_count(
-    index_x: nb.types.List(nb.int64[:]), index_y: nb.types.List(nb.int64[:])
-) -> nb.int64[:, :]:
+    index_x: Sequence[np.ndarray], index_y: Sequence[np.ndarray]
+) -> np.ndarray:
     """Computes a set overlap matrix by overlap count.
 
     Parameters
     ----------
-    index_x: nb.types.List[np.ndarray]
-        (N) nb.types.List of tensor index, one per object to match
-    index_y: nb.types.List[np.ndarray]
-        (M) nb.types.List of tensor index, one per object to be matched to
+    index_x : Sequence[np.ndarray]
+        (N) Sorted unique voxel indexes, one per object to match.
+    index_y : Sequence[np.ndarray]
+        (M) Sorted unique voxel indexes, one per object to be matched to.
 
     Returns
     -------
     np.ndarray
-        (M, N) Overlap count matrix
+        (N, M) Overlap count matrix.
     """
     overlap_matrix = np.zeros((len(index_x), len(index_y)), dtype=np.int64)
-    for i in nb.prange(len(index_x)):
+    for i in nb.prange(len(index_x)):  # pylint: disable=not-an-iterable
         px = index_x[i]
         if len(px):
             for j, py in enumerate(index_y):
@@ -64,27 +67,92 @@ def overlap_count(
 
 
 @nb.njit(cache=True, parallel=True)
+def overlap_metrics(
+    index_x: Sequence[np.ndarray], index_y: Sequence[np.ndarray]
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Compute count, purity, efficiency and IoU overlap matrices.
+
+    The direction of the asymmetric metrics is explicit: ``index_x`` is the
+    predicted collection and ``index_y`` is the truth collection. Purity is
+    therefore the fraction of a predicted instance owned by a truth instance,
+    while efficiency is the fraction of that truth instance recovered by the
+    prediction. All metrics are evaluated from a single intersection pass.
+
+    Parameters
+    ----------
+    index_x : Sequence[np.ndarray]
+        (N) Sorted unique voxel indexes, one per predicted instance.
+    index_y : Sequence[np.ndarray]
+        (M) Sorted unique voxel indexes, one per truth instance.
+
+    Returns
+    -------
+    np.ndarray
+        (N, M) Intersection count matrix.
+    np.ndarray
+        (N, M) Predicted-instance purity matrix.
+    np.ndarray
+        (N, M) Truth-instance efficiency matrix.
+    np.ndarray
+        (N, M) Intersection-over-union matrix.
+
+    Notes
+    -----
+    Empty or disjoint pairs receive zero for every metric. Input index arrays
+    must be sorted and unique for the linear intersection kernel to be valid.
+    A caller can identify the majority truth match for prediction ``i`` with
+    ``np.argmax(counts[i])`` and read all three qualities at that matrix entry.
+    """
+    shape = (len(index_x), len(index_y))
+    counts = np.zeros(shape, dtype=np.int64)
+    purities = np.zeros(shape, dtype=np.float32)
+    efficiencies = np.zeros(shape, dtype=np.float32)
+    ious = np.zeros(shape, dtype=np.float32)
+
+    # Traverse each pair once, sharing its intersection across all metrics.
+    indexes = np.arange(len(index_x), dtype=np.int64)
+    for k in nb.prange(len(index_x)):  # pylint: disable=not-an-iterable
+        i = indexes[k]
+        px = index_x[i]
+        if len(px):
+            for j, py in enumerate(index_y):
+                if len(py):
+                    # Sorted bounds cheaply reject the common disjoint case.
+                    if px[-1] < py[0] or py[-1] < px[0]:
+                        continue
+
+                    cap = intersection_size_sorted(px, py)
+                    if cap > 0:
+                        counts[i, j] = cap
+                        purities[i, j] = cap / len(px)
+                        efficiencies[i, j] = cap / len(py)
+                        ious[i, j] = cap / (len(px) + len(py) - cap)
+
+    return counts, purities, efficiencies, ious
+
+
+@nb.njit(cache=True, parallel=True)
 def overlap_iou(
-    index_x: nb.types.List(nb.int64[:]), index_y: nb.types.List(nb.int64[:])
-) -> nb.float32[:, :]:
+    index_x: Sequence[np.ndarray], index_y: Sequence[np.ndarray]
+) -> np.ndarray:
     """Computes a set overlap matrix by IoU.
 
     IoU stands for Intersection-over-Union.
 
     Parameters
     ----------
-    index_x: nb.types.List[np.ndarray]
-        (N) nb.types.List of tensor index, one per object to match
-    index_y: nb.types.List[np.ndarray]
-        (M) nb.types.List of tensor index, one per object to be matched to
+    index_x : Sequence[np.ndarray]
+        (N) Sorted unique voxel indexes, one per object to match.
+    index_y : Sequence[np.ndarray]
+        (M) Sorted unique voxel indexes, one per object to be matched to.
 
     Returns
     -------
     np.ndarray
-        (M, N) Overlap IoU matrix
+        (N, M) Overlap IoU matrix.
     """
     overlap_matrix = np.zeros((len(index_x), len(index_y)), dtype=np.float32)
-    for i in nb.prange(len(index_x)):
+    for i in nb.prange(len(index_x)):  # pylint: disable=not-an-iterable
         px = index_x[i]
         if len(px):
             for j, py in enumerate(index_y):
@@ -101,8 +169,8 @@ def overlap_iou(
 
 @nb.njit(cache=True, parallel=True)
 def overlap_weighted_iou(
-    index_x: nb.types.List(nb.int64[:]), index_y: nb.types.List(nb.int64[:])
-) -> nb.float32[:, :]:
+    index_x: Sequence[np.ndarray], index_y: Sequence[np.ndarray]
+) -> np.ndarray:
     """Computes a set overlap matrix by IoU, weighted by the set sizes.
 
     IoU stands for Intersection-over-Union. The weighting scheme is as follows:
@@ -110,18 +178,18 @@ def overlap_weighted_iou(
 
     Parameters
     ----------
-    index_x: nb.types.List[np.ndarray]
-        (N) nb.types.List of tensor index, one per object to match
-    index_y: nb.types.List[np.ndarray]
-        (M) nb.types.List of tensor index, one per object to be matched to
+    index_x : Sequence[np.ndarray]
+        (N) Sorted unique voxel indexes, one per object to match.
+    index_y : Sequence[np.ndarray]
+        (M) Sorted unique voxel indexes, one per object to be matched to.
 
     Returns
     -------
     np.ndarray
-        (M, N) Overlap weighted IoU matrix
+        (N, M) Weighted IoU matrix.
     """
     overlap_matrix = np.zeros((len(index_x), len(index_y)), dtype=np.float32)
-    for i in nb.prange(len(index_x)):
+    for i in nb.prange(len(index_x)):  # pylint: disable=not-an-iterable
         px = index_x[i]
         if len(px):
             for j, py in enumerate(index_y):
@@ -139,8 +207,8 @@ def overlap_weighted_iou(
 
 @nb.njit(cache=True, parallel=True)
 def overlap_dice(
-    index_x: nb.types.List(nb.int64[:]), index_y: nb.types.List(nb.int64[:])
-) -> nb.float32[:, :]:
+    index_x: Sequence[np.ndarray], index_y: Sequence[np.ndarray]
+) -> np.ndarray:
     """Computes a set overlap matrix by Dice coefficient.
 
     The Dice coefficient corresponds to the 2 times the intersection of two
@@ -148,18 +216,18 @@ def overlap_dice(
 
     Parameters
     ----------
-    index_x: nb.types.List[np.ndarray]
-        (N) nb.types.List of tensor index, one per object to match
-    index_y: nb.types.List[np.ndarray]
-        (M) nb.types.List of tensor index, one per object to be matched to
+    index_x : Sequence[np.ndarray]
+        (N) Sorted unique voxel indexes, one per object to match.
+    index_y : Sequence[np.ndarray]
+        (M) Sorted unique voxel indexes, one per object to be matched to.
 
     Returns
     -------
     np.ndarray
-        (M, N) Overlap weighted IoU matrix
+        (N, M) Dice coefficient matrix.
     """
     overlap_matrix = np.zeros((len(index_x), len(index_y)), dtype=np.float32)
-    for i in nb.prange(len(index_x)):
+    for i in nb.prange(len(index_x)):  # pylint: disable=not-an-iterable
         px = index_x[i]
         if len(px):
             for j, py in enumerate(index_y):
@@ -176,8 +244,8 @@ def overlap_dice(
 
 @nb.njit(cache=True, parallel=True)
 def overlap_weighted_dice(
-    index_x: nb.types.List(nb.int64[:]), index_y: nb.types.List(nb.int64[:])
-) -> nb.float32[:, :]:
+    index_x: Sequence[np.ndarray], index_y: Sequence[np.ndarray]
+) -> np.ndarray:
     """Computes a set overlap matrix by Dice coefficient, weighted by the
     set sizes.
 
@@ -187,18 +255,18 @@ def overlap_weighted_dice(
 
     Parameters
     ----------
-    index_x: nb.types.List[np.ndarray]
-        (N) nb.types.List of tensor index, one per object to match
-    index_y: nb.types.List[np.ndarray]
-        (M) nb.types.List of tensor index, one per object to be matched to
+    index_x : Sequence[np.ndarray]
+        (N) Sorted unique voxel indexes, one per object to match.
+    index_y : Sequence[np.ndarray]
+        (M) Sorted unique voxel indexes, one per object to be matched to.
 
     Returns
     -------
     np.ndarray
-        (M, N) Overlap weighted IoU matrix
+        (N, M) Weighted Dice coefficient matrix.
     """
     overlap_matrix = np.zeros((len(index_x), len(index_y)), dtype=np.float32)
-    for i in nb.prange(len(index_x)):
+    for i in nb.prange(len(index_x)):  # pylint: disable=not-an-iterable
         px = index_x[i]
         if len(px):
             for j, py in enumerate(index_y):
@@ -217,8 +285,8 @@ def overlap_weighted_dice(
 
 @nb.njit(cache=True, parallel=True)
 def overlap_chamfer(
-    points_x: nb.types.List(nb.int64[:]), points_y: nb.types.List(nb.int64[:])
-) -> nb.float32[:, :]:
+    points_x: Sequence[np.ndarray], points_y: Sequence[np.ndarray]
+) -> np.ndarray:
     """Computes a set overlap matrix by Chamfer distance.
 
     This function can match two arbitrary points clouds, hence there is no need
@@ -226,22 +294,22 @@ def overlap_chamfer(
 
     Parameters
     ----------
-    points_x: nb.types.List[np.ndarray]
-        (N, 3) nb.types.List of coordinates, one per object to match
-    points_y: nb.types.List[np.ndarray]
-        (M, 3) nb.types.List of coordinates, one per object to be matched to
+    points_x : Sequence[np.ndarray]
+        (N) Point clouds of shape ``(P_i, 3)``, one per object to match.
+    points_y : Sequence[np.ndarray]
+        (M) Point clouds of shape ``(P_j, 3)``, one per object to match against.
 
     Returns
     -------
     np.ndarray
-        (M, N) Chamfer distance matrix
+        (N, M) Chamfer distance matrix.
 
     Notes
     -----
     Unlike the overlap metrics, this metric should be minimized.
     """
     overlap_matrix = np.full((len(points_x), len(points_y)), np.inf, dtype=np.float32)
-    for i in nb.prange(len(points_x)):
+    for i in nb.prange(len(points_x)):  # pylint: disable=not-an-iterable
         px = points_x[i]
         if len(px):
             for j, py in enumerate(points_y):
@@ -249,10 +317,17 @@ def overlap_chamfer(
                     # Compute the voxel pairwise distances
                     dist = cdist(px, py)
 
-                    # Compute the average chamfer distance
-                    loss_x = np.min(dist, axis=1)
-                    loss_y = np.min(dist, axis=0)
-                    loss = loss_x.sum() / len(loss_x) + loss_y.sum() / len(loss_y)
+                    # Reduce each point-cloud direction explicitly because
+                    # Numba does not support the ``axis`` argument to min.
+                    loss_x = 0.0
+                    for k in range(len(px)):
+                        loss_x += np.min(dist[k])
+
+                    loss_y = 0.0
+                    for k in range(len(py)):
+                        loss_y += np.min(dist[:, k])
+
+                    loss = loss_x / len(px) + loss_y / len(py)
 
                     overlap_matrix[i, j] = loss
 

--- a/src/spine/model/common/quality.py
+++ b/src/spine/model/common/quality.py
@@ -1,0 +1,441 @@
+"""Shared truth-overlap quality requirements for model objectives.
+
+This module separates the policy used to accept a reconstructed object from
+the loss which consumes that object. It also provides a small, forward-local
+cache so several GrapPA objectives can reuse the same cluster-to-truth match.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import cast
+
+import numpy as np
+
+from spine.cluster.quality import ClusterOverlapBatch, get_cluster_overlap_batch
+from spine.data import ClusterLabelBatch, EdgeIndexBatch, IndexBatch
+
+__all__ = [
+    "ClusterOverlapCache",
+    "ClusterQualityFilter",
+    "OverlapThresholds",
+]
+
+ClusterOverlapCache = dict[str, ClusterOverlapBatch]
+"""Overlap measurements keyed by the truth-instance field used for matching."""
+
+
+class ClusterQualityFilter:
+    """Apply reusable overlap-quality requirements to reconstructed objects.
+
+    A reconstructed cluster is first matched to the truth instance with which
+    it shares the most voxels. It is accepted only when that match satisfies
+    every configured IoU, purity and efficiency requirement. Thresholds may be
+    global scalars or arrays indexed by the target class of an object.
+
+    The filter owns both threshold validation and the truth-instance field used
+    for matching. A caller-provided :class:`ClusterOverlapCache` allows several
+    objectives acting on the same clusters during one forward pass to share the
+    comparatively expensive geometrical overlap calculation.
+
+    Notes
+    -----
+    With no configured thresholds, every object passes and no truth matching is
+    performed. Once filtering is active, clusters without a truth match fail
+    the policy regardless of the numerical threshold values.
+    """
+
+    def __init__(
+        self,
+        min_iou: float | Sequence[float] | None = None,
+        min_purity: float | Sequence[float] | None = None,
+        min_efficiency: float | Sequence[float] | None = None,
+        *,
+        match_target: str = "group",
+        num_classes: int | None = None,
+        require_num_classes: bool = False,
+    ) -> None:
+        """Initialize the cluster-quality filter.
+
+        Parameters
+        ----------
+        min_iou : float or sequence of float, optional
+            Minimum intersection over union. A sequence supplies one value per
+            target class.
+        min_purity : float or sequence of float, optional
+            Minimum fraction of a prediction owned by its truth match. A
+            sequence supplies one value per target class.
+        min_efficiency : float or sequence of float, optional
+            Minimum fraction of the truth match recovered by a prediction. A
+            sequence supplies one value per target class.
+        match_target : str, default 'group'
+            Field in ``data`` used to form truth instances, e.g. ``group`` or
+            ``particle``.
+        num_classes : int, optional
+            Expected number of target classes and, consequently, the required
+            length of class-dependent threshold sequences.
+        require_num_classes : bool, default False
+            Require ``num_classes`` during initialization whenever a sequence
+            is configured. This is useful for regression objectives whose
+            output width does not imply the number of quality classes.
+        """
+        self.match_target = match_target
+        self.thresholds = OverlapThresholds(
+            min_iou,
+            min_purity,
+            min_efficiency,
+            num_classes=num_classes,
+            require_num_classes=require_num_classes,
+        )
+
+    @property
+    def active(self) -> bool:
+        """Whether the filter has at least one overlap requirement."""
+        return self.thresholds.active
+
+    @property
+    def class_dependent(self) -> bool:
+        """Whether at least one requirement varies by target class."""
+        return self.thresholds.class_dependent
+
+    def validate_num_classes(self, num_classes: int) -> None:
+        """Validate threshold-array lengths against a prediction width.
+
+        Parameters
+        ----------
+        num_classes : int
+            Number of classes represented by the prediction tensor.
+
+        Raises
+        ------
+        ValueError
+            If the class count is invalid or a threshold sequence has a
+            different length.
+        """
+        self.thresholds.validate_num_classes(num_classes)
+
+    def node_mask(
+        self,
+        data: ClusterLabelBatch,
+        clusts: IndexBatch,
+        classes: np.ndarray | None = None,
+        cache: ClusterOverlapCache | None = None,
+    ) -> np.ndarray:
+        """Return the reconstructed objects satisfying the quality policy.
+
+        Parameters
+        ----------
+        data : ClusterLabelBatch
+            Structured voxel labels aligned with the cluster index space.
+        clusts : IndexBatch
+            Predicted cluster indexes grouped by batch entry.
+        classes : np.ndarray, optional
+            One target class per predicted cluster. Required only for
+            class-dependent thresholds.
+        cache : ClusterOverlapCache, optional
+            Overlap results shared within one model forward pass.
+
+        Returns
+        -------
+        np.ndarray
+            Boolean validity mask with one entry per predicted cluster.
+
+        Raises
+        ------
+        ValueError
+            If class-dependent thresholds are configured but the class labels
+            are missing, misaligned or outside the configured class range.
+        """
+        if not self.active:
+            return np.ones(len(clusts.index_list), dtype=bool)
+
+        # Cache only the geometrical overlap; each objective still applies its
+        # own thresholds and, when requested, its own class-dependent values.
+        overlap = self._get_overlap(data, clusts, cache)
+        return self.thresholds.mask(overlap, classes)
+
+    def edge_mask(
+        self,
+        data: ClusterLabelBatch,
+        clusts: IndexBatch,
+        edge_index: EdgeIndexBatch,
+        classes: np.ndarray | None = None,
+        cache: ClusterOverlapCache | None = None,
+    ) -> np.ndarray:
+        """Return edges whose two endpoints satisfy the quality policy.
+
+        Parameters
+        ----------
+        data : ClusterLabelBatch
+            Structured voxel labels aligned with the cluster index space.
+        clusts : IndexBatch
+            Predicted cluster indexes grouped by batch entry.
+        edge_index : EdgeIndexBatch
+            Batched edge endpoints indexing ``clusts``.
+        classes : np.ndarray, optional
+            One target class per edge. For class-dependent thresholds, the edge
+            class selects the policy applied to both endpoint clusters.
+        cache : ClusterOverlapCache, optional
+            Overlap results shared within one model forward pass.
+
+        Returns
+        -------
+        np.ndarray
+            Boolean validity mask with one entry per edge.
+
+        Raises
+        ------
+        IndexError
+            If an endpoint does not index a predicted cluster.
+        ValueError
+            If class-dependent thresholds are configured but the edge classes
+            are missing or do not align with the edge list.
+        """
+        # Validate endpoints even when filtering is inactive. An invalid graph
+        # otherwise produces a deceptively well-formed all-true mask.
+        edge_index_np = edge_index.to_numpy().index
+        num_nodes = len(clusts.index_list)
+        if np.any((edge_index_np < 0) | (edge_index_np >= num_nodes)):
+            raise IndexError("Edge endpoints must index the node-quality mask.")
+        if not self.active:
+            return np.ones(edge_index_np.shape[1], dtype=bool)
+
+        # Scalar requirements can be evaluated once per node and gathered at
+        # the two endpoints of every edge.
+        overlap = self._get_overlap(data, clusts, cache)
+        if not self.class_dependent:
+            node_mask = self.thresholds.mask(overlap)
+            return np.all(node_mask[edge_index_np], axis=0)
+
+        if classes is None:
+            raise ValueError("Class-dependent edge thresholds require edge labels.")
+        if len(classes) != edge_index_np.shape[1]:
+            raise ValueError("Overlap threshold classes must align with edges.")
+
+        # An edge class selects one policy, which must be satisfied by both of
+        # that edge's endpoints. Nodes may therefore be treated differently in
+        # distinct incident edges without recomputing geometrical overlaps.
+        valid = np.zeros(len(classes), dtype=bool)
+        for class_id in np.unique(classes):
+            edge_selection = classes == class_id
+            node_classes = np.full(num_nodes, class_id, dtype=np.int64)
+            node_mask = self.thresholds.mask(overlap, node_classes)
+            endpoints = edge_index_np[:, edge_selection]
+            valid[edge_selection] = np.all(node_mask[endpoints], axis=0)
+
+        return valid
+
+    def _get_overlap(
+        self,
+        data: ClusterLabelBatch,
+        clusts: IndexBatch,
+        cache: ClusterOverlapCache | None,
+    ) -> ClusterOverlapBatch:
+        """Return overlap measurements, reusing a forward-local result.
+
+        The cache key is the truth-instance field because all objectives in a
+        GrapPA forward operate on the same predicted cluster collection. A
+        standalone caller may omit the cache without changing the result.
+        """
+        overlap = None if cache is None else cache.get(self.match_target)
+        if overlap is None:
+            overlap = get_cluster_overlap_batch(data, clusts, self.match_target)
+
+            # Populate only after a successful calculation, so a failed match
+            # cannot leave a partial result for a subsequent objective.
+            if cache is not None:
+                cache[self.match_target] = overlap
+
+        return overlap
+
+
+class OverlapThresholds:
+    """Validate and apply optional cluster-overlap quality thresholds.
+
+    A threshold may be a scalar shared by every target class or a sequence
+    containing one value per class. All three enabled requirements are combined
+    with a logical AND. Sequence thresholds require a known class count so
+    malformed configurations can fail during initialization.
+    """
+
+    def __init__(
+        self,
+        min_iou: float | Sequence[float] | None = None,
+        min_purity: float | Sequence[float] | None = None,
+        min_efficiency: float | Sequence[float] | None = None,
+        num_classes: int | None = None,
+        require_num_classes: bool = False,
+    ) -> None:
+        """Initialize overlap thresholds.
+
+        Parameters
+        ----------
+        min_iou : float or sequence of float, optional
+            Minimum intersection over union.
+        min_purity : float or sequence of float, optional
+            Minimum fraction of a prediction owned by its truth match.
+        min_efficiency : float or sequence of float, optional
+            Minimum fraction of the truth match recovered by a prediction.
+        num_classes : int, optional
+            Expected threshold-sequence length. Required whenever any
+            threshold is class dependent and ``require_num_classes`` is set.
+        require_num_classes : bool, default False
+            Require the class count during initialization rather than allowing
+            a caller to validate it once the prediction width is available.
+        """
+        if num_classes is not None and num_classes < 1:
+            raise ValueError("Overlap threshold class count must be positive.")
+
+        self.min_iou: float | np.ndarray | None = self._normalize(
+            min_iou, "min_iou", num_classes, require_num_classes
+        )
+        self.min_purity: float | np.ndarray | None = self._normalize(
+            min_purity, "min_purity", num_classes, require_num_classes
+        )
+        self.min_efficiency: float | np.ndarray | None = self._normalize(
+            min_efficiency,
+            "min_efficiency",
+            num_classes,
+            require_num_classes,
+        )
+
+    @property
+    def active(self) -> bool:
+        """Whether at least one overlap threshold is configured."""
+        return any(
+            threshold is not None
+            for threshold in (self.min_iou, self.min_purity, self.min_efficiency)
+        )
+
+    @property
+    def class_dependent(self) -> bool:
+        """Whether any configured threshold varies by target class."""
+        return any(
+            isinstance(threshold, np.ndarray)
+            for threshold in (self.min_iou, self.min_purity, self.min_efficiency)
+        )
+
+    def mask(
+        self,
+        overlap: ClusterOverlapBatch,
+        classes: np.ndarray | None = None,
+    ) -> np.ndarray:
+        """Return the objects satisfying every configured threshold.
+
+        Parameters
+        ----------
+        overlap : ClusterOverlapBatch
+            Best truth match and associated qualities for each predicted
+            object.
+        classes : np.ndarray, optional
+            One target class per predicted object. Required when at least one
+            threshold is class dependent.
+
+        Returns
+        -------
+        np.ndarray
+            Boolean validity mask with one entry per predicted object.
+
+        Raises
+        ------
+        ValueError
+            If class-dependent thresholds receive missing or invalid classes.
+        """
+        num_objects = len(overlap.match_ids.data)
+
+        # An object without any truth intersection never defines a reliable
+        # target, including when the numerical threshold itself is zero.
+        valid = overlap.match_ids.data >= 0
+        for values, threshold in (
+            (overlap.ious.data, self.min_iou),
+            (overlap.purities.data, self.min_purity),
+            (overlap.efficiencies.data, self.min_efficiency),
+        ):
+            if threshold is None:
+                continue
+
+            if isinstance(threshold, np.ndarray):
+                threshold_array = cast(np.ndarray, threshold)
+                if classes is None:
+                    raise ValueError(
+                        "Class-dependent overlap thresholds require class labels."
+                    )
+                if len(classes) != num_objects:
+                    raise ValueError(
+                        "Overlap threshold classes must align with predicted objects."
+                    )
+                # Invalid or ignored classes fail the mask instead of indexing
+                # from the end of the threshold array through NumPy semantics.
+                class_valid = (classes >= 0) & (classes < len(threshold_array))
+                valid &= class_valid
+                selected = np.ones(num_objects, dtype=np.float32)
+                selected[class_valid] = threshold_array[
+                    classes[class_valid].astype(int)
+                ]
+                valid &= values >= selected
+            else:
+                valid &= values >= threshold
+
+        return valid
+
+    def validate_num_classes(self, num_classes: int) -> None:
+        """Check all class-dependent thresholds against a class count.
+
+        Parameters
+        ----------
+        num_classes : int
+            Expected number of target classes.
+
+        Raises
+        ------
+        ValueError
+            If ``num_classes`` is not positive or a threshold sequence has a
+            different length.
+        """
+        if num_classes < 1:
+            raise ValueError("Overlap threshold class count must be positive.")
+        for name, threshold in (
+            ("min_iou", self.min_iou),
+            ("min_purity", self.min_purity),
+            ("min_efficiency", self.min_efficiency),
+        ):
+            if isinstance(threshold, np.ndarray):
+                threshold_array = cast(np.ndarray, threshold)
+                if len(threshold_array) != num_classes:
+                    raise ValueError(
+                        f"`{name}` must contain exactly {num_classes} values."
+                    )
+
+    @staticmethod
+    def _normalize(
+        threshold: float | Sequence[float] | None,
+        name: str,
+        num_classes: int | None,
+        require_num_classes: bool,
+    ) -> float | np.ndarray | None:
+        """Normalize and validate one overlap threshold.
+
+        Scalars remain scalars, while sequences become one-dimensional
+        ``float32`` arrays. Every value must be finite and lie in ``[0, 1]``.
+        """
+        if threshold is None:
+            return None
+        if isinstance(threshold, (str, bytes)):
+            raise TypeError(f"`{name}` must be numeric.")
+
+        if np.isscalar(threshold):
+            values = np.asarray([threshold], dtype=np.float32)
+            normalized: float | np.ndarray = float(values[0])
+        else:
+            values = np.asarray(threshold, dtype=np.float32)
+            if values.ndim != 1:
+                raise ValueError(f"`{name}` must be a scalar or one-dimensional.")
+            if num_classes is None and require_num_classes:
+                raise ValueError(f"Class-dependent `{name}` requires `num_classes`.")
+            if num_classes is not None and len(values) != num_classes:
+                raise ValueError(f"`{name}` must contain exactly {num_classes} values.")
+            normalized = values
+
+        if not np.all(np.isfinite(values)) or np.any((values < 0) | (values > 1)):
+            raise ValueError(f"`{name}` values must lie in [0, 1].")
+        return normalized

--- a/src/spine/model/grappa/loss/edge_channel.py
+++ b/src/spine/model/grappa/loss/edge_channel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
@@ -10,6 +11,10 @@ import torch
 from spine.cluster.label import get_cluster_label_batch
 from spine.data import ClusterLabelBatch, EdgeIndexBatch, IndexBatch, TensorBatch
 from spine.model.common.factories import loss_fn_factory
+from spine.model.common.quality import (
+    ClusterOverlapCache,
+    ClusterQualityFilter,
+)
 from spine.model.common.weighting import get_class_weights
 from spine.model.grappa.evaluation import (
     edge_assignment_batch,
@@ -52,6 +57,11 @@ class EdgeChannelLoss(torch.nn.Module):
         loss: str | dict[str, Any] = "ce",
         balance_loss: bool = False,
         high_purity: bool = False,
+        *,
+        min_iou: float | Sequence[float] | None = None,
+        min_purity: float | Sequence[float] | None = None,
+        min_efficiency: float | Sequence[float] | None = None,
+        match_target: str | None = None,
     ) -> None:
         """Initialize the primary identification loss function.
 
@@ -74,6 +84,18 @@ class EdgeChannelLoss(torch.nn.Module):
         high_purity : bool, default False
             Only apply loss to nodes which belong to a sensible group, i.e.
             one with exactly one shower primary in it (not 0, not > 1)
+        min_iou : float or sequence of float, optional
+            Minimum IoU required of both endpoint clusters. A sequence provides
+            separate requirements for OFF and ON edges, in that order.
+        min_purity : float or sequence of float, optional
+            Minimum purity required of both endpoint clusters, shared or
+            specified for the OFF and ON edge classes.
+        min_efficiency : float or sequence of float, optional
+            Minimum efficiency required of both endpoint clusters, shared or
+            specified for the OFF and ON edge classes.
+        match_target : str, optional
+            Truth-instance field used to evaluate endpoint quality. Defaults
+            to the edge aggregation ``target``.
         """
         # Initialize the parent class
         super().__init__()
@@ -86,9 +108,23 @@ class EdgeChannelLoss(torch.nn.Module):
         self.balance_loss = balance_loss
         self.high_purity = high_purity
 
+        # Apply the same overlap policy to both endpoints of a supervised edge
+        self.quality_filter = ClusterQualityFilter(
+            min_iou,
+            min_purity,
+            min_efficiency,
+            match_target=match_target or target,
+            num_classes=2,
+        )
+
         if self.high_purity and self.target != "group":
             raise ValueError(
                 "The `high_purity` flag is only valid when building shower groups."
+            )
+        if self.mode == "forest" and self.quality_filter.class_dependent:
+            raise ValueError(
+                "Forest edge losses require scalar overlap thresholds because "
+                "the edge classes are defined by the target spanning tree."
             )
 
         # Set the loss
@@ -101,6 +137,7 @@ class EdgeChannelLoss(torch.nn.Module):
         edge_index: EdgeIndexBatch,
         edge_pred: TensorBatch,
         true_edge_index: EdgeIndexBatch | None = None,
+        overlap_cache: ClusterOverlapCache | None = None,
         **kwargs: object,
     ) -> dict[str, torch.Tensor | float | int]:
         """Applies the edge channel loss to a batch of data.
@@ -117,6 +154,8 @@ class EdgeChannelLoss(torch.nn.Module):
             (E, 2) Edge prediction logits (binary output)
         true_edge_index : EdgeIndexBatch
             (2, E') True reference sparse incidence matrix
+        overlap_cache : ClusterOverlapCache, optional
+            Cluster overlaps shared by the objectives in one GrapPA forward.
         **kwargs : dict, optional
             Other labels/outputs of the model which are not relevant here
 
@@ -128,6 +167,10 @@ class EdgeChannelLoss(torch.nn.Module):
             Value of the edge-wise classification accuracy
         count : int
             Number of edges the loss was applied to
+        count_rejected : int, optional
+            Number of otherwise valid edges removed because at least one
+            endpoint failed overlap quality. Only returned when thresholds are
+            configured.
         """
         # Start to build a mask of valid edges. Check that the group ID
         # of both clusters edge joins has a valid group ID
@@ -154,8 +197,26 @@ class EdgeChannelLoss(torch.nn.Module):
             # For each group, find the most likely spanning tree, label the
             # edges in the tree as 1. For all other edges, apply loss only if
             # in separate groups. If undirected, also assign symmetric path
+            forest_group_ids = group_ids
+            if self.quality_filter.active:
+                # Give each rejected node a unique group before constructing
+                # the forest. This prevents a valid target path from using an
+                # endpoint that will subsequently be removed from the loss.
+                node_quality_mask = self.quality_filter.node_mask(
+                    clust_label,
+                    clusts,
+                    cache=overlap_cache,
+                )
+                forest_ids = group_ids.numpy_tensor().copy()
+                invalid_index = np.where(~node_quality_mask)[0]
+                next_id = int(np.max(forest_ids, initial=-1)) + 1
+                forest_ids[invalid_index] = next_id + np.arange(len(invalid_index))
+                forest_group_ids = TensorBatch(forest_ids, group_ids.counts)
+
             edge_assn, valid_mask_mst = edge_assignment_forest_batch(
-                edge_index, edge_pred.to_numpy(), group_ids
+                edge_index,
+                edge_pred.to_numpy(),
+                forest_group_ids,
             )
             valid_mask &= valid_mask_mst.numpy_tensor()
 
@@ -174,6 +235,20 @@ class EdgeChannelLoss(torch.nn.Module):
 
         else:
             raise ValueError(f"Loss mode not recognized: {self.mode}")
+
+        # An edge is trustworthy only when both endpoint clusters satisfy the
+        # requested policy. Class-dependent thresholds use the ON/OFF target.
+        count_rejected = 0
+        if self.quality_filter.active:
+            edge_quality_mask = self.quality_filter.edge_mask(
+                clust_label,
+                clusts,
+                edge_index,
+                edge_assn.numpy_tensor(),
+                overlap_cache,
+            )
+            count_rejected = int(np.count_nonzero(valid_mask & ~edge_quality_mask))
+            valid_mask &= edge_quality_mask
 
         # Apply the mask and convert the labels to a torch.Tensor
         valid_index = np.where(valid_mask)[0]
@@ -203,4 +278,8 @@ class EdgeChannelLoss(torch.nn.Module):
             )
             acc /= len(valid_index)
 
-        return {"accuracy": acc, "loss": loss, "count": len(valid_index)}
+        result = {"accuracy": acc, "loss": loss, "count": len(valid_index)}
+        if self.quality_filter.active:
+            result["count_rejected"] = count_rejected
+
+        return result

--- a/src/spine/model/grappa/loss/node_class.py
+++ b/src/spine/model/grappa/loss/node_class.py
@@ -15,6 +15,10 @@ from spine.cluster.label import (
 )
 from spine.data import ClusterLabelBatch, IndexBatch, TensorBatch
 from spine.model.common.factories import loss_fn_factory
+from spine.model.common.quality import (
+    ClusterOverlapCache,
+    ClusterQualityFilter,
+)
 from spine.model.common.weighting import get_class_weights
 
 __all__ = ["NodeClassLoss"]
@@ -56,6 +60,11 @@ class NodeClassLoss(torch.nn.Module):
         weights: Sequence[float] | None = None,
         use_closest: bool = False,
         secondary_label: int | Sequence[int] = -1,
+        *,
+        min_iou: float | Sequence[float] | None = None,
+        min_purity: float | Sequence[float] | None = None,
+        min_efficiency: float | Sequence[float] | None = None,
+        match_target: str = "group",
     ) -> None:
         """Initialize the node classification loss function.
 
@@ -76,6 +85,17 @@ class NodeClassLoss(torch.nn.Module):
             When using `use_closest=True`, this label is assigned to nodes which
             are not the closest to a the start point of a particle group. These
             numbers can be different for each class if specified as a list
+        min_iou : float or sequence of float, optional
+            Minimum truth-instance IoU. A sequence supplies one requirement per
+            classification target.
+        min_purity : float or sequence of float, optional
+            Minimum fraction of the cluster owned by its majority truth match,
+            shared or specified per classification target.
+        min_efficiency : float or sequence of float, optional
+            Minimum fraction of the matched truth instance recovered by the
+            cluster, shared or specified per classification target.
+        match_target : str, default 'group'
+            Truth-instance field used to evaluate overlap quality.
         """
         # Initialize the parent class
         super().__init__()
@@ -88,6 +108,14 @@ class NodeClassLoss(torch.nn.Module):
         self.weights = weights
         self.use_closest = use_closest
         self.secondary_label = secondary_label
+
+        # Keep target-quality policy independent of the classification loss
+        self.quality_filter = ClusterQualityFilter(
+            min_iou,
+            min_purity,
+            min_efficiency,
+            match_target=match_target,
+        )
 
         # Sanity check
         if weights is not None and balance_loss:
@@ -104,6 +132,8 @@ class NodeClassLoss(torch.nn.Module):
         clusts: IndexBatch,
         node_pred: TensorBatch,
         coord_label: TensorBatch | None = None,
+        node_quality_mask: np.ndarray | None = None,
+        overlap_cache: ClusterOverlapCache | None = None,
         **kwargs: object,
     ) -> dict[str, torch.Tensor | float | int]:
         """Applies the node classification loss to a batch of data.
@@ -118,6 +148,12 @@ class NodeClassLoss(torch.nn.Module):
             (C, 2) Node prediction logits (binary output)
         coord_label : TensorBatch, optional
             (P, 1 + D + 8) Label start, end, time and shape for each point
+        node_quality_mask : np.ndarray, optional
+            External cluster mask combined with this loss's own overlap policy.
+            This allows compound objectives, such as vertex prediction, to use
+            one validity decision for all of their output components.
+        overlap_cache : ClusterOverlapCache, optional
+            Cluster overlaps shared by the objectives in one GrapPA forward.
         **kwargs : dict, optional
             Other labels/outputs of the model which are not relevant here
 
@@ -129,6 +165,9 @@ class NodeClassLoss(torch.nn.Module):
             Value of the node-wise classification accuracy
         count : int
             Number of nodes the loss was applied to
+        count_rejected : int, optional
+            Number of otherwise valid nodes removed by overlap-quality
+            filtering. Only returned when a quality mask is applied.
         """
         # Get the class labels
         node_assn = get_cluster_label_batch(clust_label, clusts, column=self.target)
@@ -136,6 +175,7 @@ class NodeClassLoss(torch.nn.Module):
         # If requested, adjust the class labeling of particle groups by picking
         # the node closest to the creation point as the reference target
         num_classes = node_pred.shape[1]
+        self.quality_filter.validate_num_classes(num_classes)
         if self.use_closest:
             # Make sure that the start point labeling is provided
             if coord_label is None:
@@ -160,11 +200,8 @@ class NodeClassLoss(torch.nn.Module):
                 clust_label, coord_label, clusts, node_assn, default
             )
 
-        # Create a mask for valid nodes (-1 indicates an invalid class ID)
-        node_assn_array = node_assn.numpy_tensor()
-        valid_mask = node_assn_array > -1
-
         # Check that the labels and the output tensor size are compatible
+        node_assn_array = node_assn.numpy_tensor()
         class_mask = node_assn_array < num_classes
         if np.any(~class_mask):
             warn(
@@ -173,8 +210,39 @@ class NodeClassLoss(torch.nn.Module):
                 RuntimeWarning,
             )
 
-        valid_mask &= class_mask
+        # Record ordinary task eligibility before applying overlap quality.
+        base_valid_mask = (node_assn_array > -1) & class_mask
+        valid_mask = base_valid_mask.copy()
+        apply_quality = self.quality_filter.active or node_quality_mask is not None
+        count_rejected = 0
 
+        # Reject targets whose matched truth instance is insufficiently pure,
+        # efficient or complete under the configured quality policy.
+        if apply_quality:
+            quality_mask = self.quality_filter.node_mask(
+                clust_label,
+                clusts,
+                node_assn_array,
+                overlap_cache,
+            )
+            if node_quality_mask is not None:
+                if len(node_quality_mask) != len(quality_mask):
+                    raise ValueError(
+                        "External node-quality mask must align with clusters."
+                    )
+                # Compound objectives may impose an additional shared mask.
+                quality_mask &= node_quality_mask
+
+            count_rejected = int(np.count_nonzero(base_valid_mask & ~quality_mask))
+            valid_mask &= quality_mask
+
+            # Convert rejected objects to the standard ignored target so all
+            # later masking and metric code follows the ordinary loss path.
+            node_assn_array = node_assn_array.copy()
+            node_assn_array[~quality_mask] = -1
+            node_assn = TensorBatch(node_assn_array, node_assn.counts)
+
+        # Create a mask for valid nodes (-1 indicates an invalid class ID)
         # Apply the valid mask and convert the labels to a torch.Tensor
         valid_index = np.where(valid_mask)[0]
         node_assn = node_assn.to_tensor(dtype=torch.long, device=node_pred.device)
@@ -217,6 +285,8 @@ class NodeClassLoss(torch.nn.Module):
 
         # Prepare and return result
         result = {"loss": loss, "accuracy": acc, "count": len(valid_index)}
+        if apply_quality:
+            result["count_rejected"] = count_rejected
 
         for class_id in range(num_classes):
             result[f"accuracy_class_{class_id}"] = acc_class[class_id]

--- a/src/spine/model/grappa/loss/node_orient.py
+++ b/src/spine/model/grappa/loss/node_orient.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
@@ -11,6 +12,10 @@ from spine.cluster.label import get_cluster_label_batch
 from spine.constants import TRACK_SHP
 from spine.data import ClusterLabelBatch, IndexBatch, TensorBatch
 from spine.model.common.factories import loss_fn_factory
+from spine.model.common.quality import (
+    ClusterOverlapCache,
+    ClusterQualityFilter,
+)
 
 __all__ = ["NodeOrientLoss"]
 
@@ -43,16 +48,44 @@ class NodeOrientLoss(torch.nn.Module):
     # Alternative allowed names of the loss
     aliases = ("orientation",)
 
-    def __init__(self, loss: str | dict[str, Any] = "ce") -> None:
+    def __init__(
+        self,
+        loss: str | dict[str, Any] = "ce",
+        *,
+        min_iou: float | Sequence[float] | None = None,
+        min_purity: float | Sequence[float] | None = None,
+        min_efficiency: float | Sequence[float] | None = None,
+        match_target: str = "particle",
+    ) -> None:
         """Initialize the node orientation loss function.
 
         Parameters
         ----------
         loss : str, default 'ce'
             Name of the loss function to apply
+        min_iou : float or sequence of float, optional
+            Minimum truth-particle IoU, shared or specified for the backward
+            and forward orientation targets.
+        min_purity : float or sequence of float, optional
+            Minimum predicted-cluster purity, shared or specified for the two
+            orientation targets.
+        min_efficiency : float or sequence of float, optional
+            Minimum truth-particle efficiency, shared or specified for the two
+            orientation targets.
+        match_target : str, default 'particle'
+            Truth-instance field used to evaluate overlap quality.
         """
         # Initialize the parent class
         super().__init__()
+
+        # Configure optional cluster-quality filtering
+        self.quality_filter = ClusterQualityFilter(
+            min_iou,
+            min_purity,
+            min_efficiency,
+            match_target=match_target,
+            num_classes=2,
+        )
 
         # Set the loss
         self.loss_fn = loss_fn_factory(loss, functional=True)
@@ -65,6 +98,7 @@ class NodeOrientLoss(torch.nn.Module):
         node_pred: TensorBatch,
         start_points: TensorBatch,
         end_points: TensorBatch,
+        overlap_cache: ClusterOverlapCache | None = None,
         **kwargs: object,
     ) -> dict[str, torch.Tensor | float | int]:
         """Applies the node orientation loss to a batch of data.
@@ -84,6 +118,8 @@ class NodeOrientLoss(torch.nn.Module):
             (C, 3) Start point features associated with each node
         end_points : TensorBatch
             (C, 3) End point features associated with each node
+        overlap_cache : ClusterOverlapCache, optional
+            Cluster overlaps shared by the objectives in one GrapPA forward.
         **kwargs : dict, optional
             Other labels/outputs of the model which are not relevant here
 
@@ -95,6 +131,9 @@ class NodeOrientLoss(torch.nn.Module):
             Value of the node-wise orientation accuracy
         count : int
             Number of nodes the loss was applied to
+        count_rejected : int, optional
+            Number of otherwise valid track nodes removed by overlap quality.
+            Only returned when thresholds are configured.
         """
         # Fetch the true particle associations and the shape
         part_ids = get_cluster_label_batch(clust_label, clusts, column="particle")
@@ -130,6 +169,28 @@ class NodeOrientLoss(torch.nn.Module):
         node_assn = torch.sign(torch.sum(true_dirs * feat_dirs, dim=1)).long()
         node_assn = (node_assn + 1) // 2
 
+        # Class-dependent thresholds refer to the resulting orientation label.
+        count_rejected = 0
+        if self.quality_filter.active:
+            # The orientation label exists only for valid track nodes. Expand
+            # it to cluster order before applying a class-dependent policy.
+            classes = np.full(len(clusts.index_list), -1, dtype=np.int64)
+            classes[valid_index] = node_assn.detach().cpu().numpy()
+            quality_mask = self.quality_filter.node_mask(
+                clust_label,
+                clusts,
+                classes,
+                overlap_cache,
+            )
+
+            # Filter the NumPy indexes and their aligned Torch targets together.
+            keep = quality_mask[valid_index]
+            count_rejected = int(np.count_nonzero(~keep))
+            valid_index = valid_index[keep]
+            node_assn = node_assn[
+                torch.as_tensor(keep, dtype=torch.bool, device=node_assn.device)
+            ]
+
         # Compute the loss
         node_pred_tensor = node_pred.torch_tensor()[valid_index]
         loss = self.loss_fn(node_pred_tensor, node_assn, reduction="sum")
@@ -142,4 +203,8 @@ class NodeOrientLoss(torch.nn.Module):
             acc = float(torch.sum(torch.argmax(node_pred_tensor, dim=1) == node_assn))
             acc /= len(valid_index)
 
-        return {"accuracy": acc, "loss": loss, "count": len(valid_index)}
+        result = {"accuracy": acc, "loss": loss, "count": len(valid_index)}
+        if self.quality_filter.active:
+            result["count_rejected"] = count_rejected
+
+        return result

--- a/src/spine/model/grappa/loss/node_reg.py
+++ b/src/spine/model/grappa/loss/node_reg.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
@@ -10,6 +11,10 @@ import torch
 from spine.cluster.label import get_cluster_label_batch
 from spine.data import ClusterLabelBatch, IndexBatch, TensorBatch
 from spine.model.common.factories import loss_fn_factory
+from spine.model.common.quality import (
+    ClusterOverlapCache,
+    ClusterQualityFilter,
+)
 
 __all__ = ["NodeRegressionLoss"]
 
@@ -46,6 +51,13 @@ class NodeRegressionLoss(torch.nn.Module):
         self,
         target: str,
         loss: str | dict[str, Any] = "mse",
+        *,
+        min_iou: float | Sequence[float] | None = None,
+        min_purity: float | Sequence[float] | None = None,
+        min_efficiency: float | Sequence[float] | None = None,
+        match_target: str = "group",
+        quality_target: str = "pid",
+        quality_num_classes: int | None = None,
     ) -> None:
         """Initialize the node regression loss function.
 
@@ -55,12 +67,40 @@ class NodeRegressionLoss(torch.nn.Module):
             Column(s) in the label tensor specifying the regression target(s)
         loss : str, default 'mse'
             Name of the loss function to apply
+        min_iou : float or sequence of float, optional
+            Minimum truth-instance IoU, shared or selected from the class given
+            by ``quality_target``.
+        min_purity : float or sequence of float, optional
+            Minimum predicted-cluster purity, shared or selected from the class
+            given by ``quality_target``.
+        min_efficiency : float or sequence of float, optional
+            Minimum truth-instance efficiency, shared or selected from the
+            class given by ``quality_target``.
+        match_target : str, default 'group'
+            Truth-instance field used to evaluate overlap quality.
+        quality_target : str, default 'pid'
+            Categorical field used to select class-dependent thresholds.
+        quality_num_classes : int, optional
+            Number of values represented by ``quality_target``. Required when
+            any quality threshold is a sequence.
         """
         # Initialize the parent class
         super().__init__()
 
         # Parse the regression target
         self.target = target
+        self.quality_target = quality_target
+
+        # Regression width is unrelated to the categorical quality policy, so
+        # class-dependent thresholds use an explicit target and class count.
+        self.quality_filter = ClusterQualityFilter(
+            min_iou,
+            min_purity,
+            min_efficiency,
+            match_target=match_target,
+            num_classes=quality_num_classes,
+            require_num_classes=True,
+        )
 
         # Set the loss
         self.loss_fn = loss_fn_factory(loss, reduction="sum")
@@ -70,6 +110,7 @@ class NodeRegressionLoss(torch.nn.Module):
         clust_label: ClusterLabelBatch,
         clusts: IndexBatch,
         node_pred: TensorBatch,
+        overlap_cache: ClusterOverlapCache | None = None,
         **kwargs: object,
     ) -> dict[str, torch.Tensor | float | int]:
         """Applies the node regression loss to a batch of data.
@@ -82,6 +123,8 @@ class NodeRegressionLoss(torch.nn.Module):
             (C) Index which maps each cluster to a list of voxel IDs
         node_pred : TensorBatch
             (C, N_d) Node prediction
+        overlap_cache : ClusterOverlapCache, optional
+            Cluster overlaps shared by the objectives in one GrapPA forward.
         **kwargs : dict, optional
             Other labels/outputs of the model which are not relevant here
 
@@ -93,13 +136,47 @@ class NodeRegressionLoss(torch.nn.Module):
             Value of the node-wise classification accuracy
         count : int
             Number of nodes the loss was applied to
+        count_rejected : int, optional
+            Number of otherwise valid nodes removed by overlap-quality
+            filtering. Only returned when thresholds are configured.
         """
         # Get the regression labels
         node_assn = get_cluster_label_batch(clust_label, clusts, column=self.target)
 
-        # Create a mask for valid nodes (-1 indicates an invalid label)
-        valid_mask = node_assn.numpy_tensor() > -1
+        # Vector targets are eligible only when every component is available.
+        node_assn_array = node_assn.numpy_tensor()
+        base_valid_mask = node_assn_array > -1
+        if base_valid_mask.ndim > 1:
+            base_valid_mask = np.all(base_valid_mask, axis=1)
+        valid_mask = base_valid_mask.copy()
+        count_rejected = 0
 
+        # Reject regression targets attached to poor truth-instance matches.
+        if self.quality_filter.active:
+            classes = None
+            if self.quality_filter.class_dependent:
+                # Reduce the categorical quality field on the same clusters as
+                # the continuous regression target.
+                classes = get_cluster_label_batch(
+                    clust_label,
+                    clusts,
+                    column=self.quality_target,
+                ).numpy_tensor()
+            quality_mask = self.quality_filter.node_mask(
+                clust_label,
+                clusts,
+                classes,
+                overlap_cache,
+            )
+            count_rejected = int(np.count_nonzero(base_valid_mask & ~quality_mask))
+            valid_mask &= quality_mask
+
+            # Mark rejected targets with the ordinary invalid-label sentinel.
+            node_assn_array = node_assn.numpy_tensor().copy()
+            node_assn_array[~quality_mask] = -1
+            node_assn = TensorBatch(node_assn_array, node_assn.counts)
+
+        # Combine ordinary target validity with the optional quality policy.
         # Apply the valid mask and convert the labels to a torch.Tensor
         valid_index = np.where(valid_mask)[0]
         node_assn = node_assn.to_tensor(device=node_pred.device)
@@ -134,4 +211,8 @@ class NodeRegressionLoss(torch.nn.Module):
             ) / denominator
             acc = float(torch.std(rel_res, correction=0))
 
-        return {"accuracy": acc, "loss": loss, "count": len(valid_index)}
+        result = {"accuracy": acc, "loss": loss, "count": len(valid_index)}
+        if self.quality_filter.active:
+            result["count_rejected"] = count_rejected
+
+        return result

--- a/src/spine/model/grappa/loss/node_shower_primary.py
+++ b/src/spine/model/grappa/loss/node_shower_primary.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
@@ -13,6 +14,10 @@ from spine.cluster.label import (
 )
 from spine.data import ClusterLabelBatch, IndexBatch, TensorBatch
 from spine.model.common.factories import loss_fn_factory
+from spine.model.common.quality import (
+    ClusterOverlapCache,
+    ClusterQualityFilter,
+)
 from spine.model.common.weighting import get_class_weights
 from spine.model.grappa.evaluation import node_purity_mask_batch
 
@@ -52,6 +57,11 @@ class NodeShowerPrimaryLoss(torch.nn.Module):
         high_purity: bool = False,
         use_closest: bool = False,
         use_group_pred: bool = False,
+        *,
+        min_iou: float | Sequence[float] | None = None,
+        min_purity: float | Sequence[float] | None = None,
+        min_efficiency: float | Sequence[float] | None = None,
+        match_target: str = "group",
     ) -> None:
         """Initialize the EM shower primary identification loss function.
 
@@ -69,6 +79,17 @@ class NodeShowerPrimaryLoss(torch.nn.Module):
             point of the shower as the primary (more robust to fragment breaks)
         use_group_pred : bool, default False
             Use predicted group to check for high purity
+        min_iou : float or sequence of float, optional
+            Minimum truth-instance IoU, shared or specified for secondary and
+            primary shower fragments.
+        min_purity : float or sequence of float, optional
+            Minimum predicted-cluster purity, shared or specified for secondary
+            and primary shower fragments.
+        min_efficiency : float or sequence of float, optional
+            Minimum truth-instance efficiency, shared or specified for
+            secondary and primary shower fragments.
+        match_target : str, default 'group'
+            Truth-instance field used to evaluate overlap quality.
         """
         # Initialize the parent class
         super().__init__()
@@ -78,6 +99,15 @@ class NodeShowerPrimaryLoss(torch.nn.Module):
         self.high_purity = high_purity
         self.use_closest = use_closest
         self.use_group_pred = use_group_pred
+
+        # The binary quality classes follow the secondary/primary target IDs
+        self.quality_filter = ClusterQualityFilter(
+            min_iou,
+            min_purity,
+            min_efficiency,
+            match_target=match_target,
+            num_classes=2,
+        )
 
         # Set the loss
         self.loss_fn = loss_fn_factory(loss, functional=True)
@@ -89,6 +119,7 @@ class NodeShowerPrimaryLoss(torch.nn.Module):
         node_pred: TensorBatch,
         coord_label: TensorBatch | None = None,
         group_pred: TensorBatch | None = None,
+        overlap_cache: ClusterOverlapCache | None = None,
         **kwargs: object,
     ) -> dict[str, torch.Tensor | float | int]:
         """Applies the shower primary loss to a batch of data.
@@ -105,6 +136,8 @@ class NodeShowerPrimaryLoss(torch.nn.Module):
             (P, 1 + D + 8) Label start, end, time and shape for each point
         group_pred : TensorBatch, optional
             (C) Predicted group to which each node belongs to
+        overlap_cache : ClusterOverlapCache, optional
+            Cluster overlaps shared by the objectives in one GrapPA forward.
         **kwargs : dict, optional
             Other labels/outputs of the model which are not relevant here
 
@@ -116,6 +149,9 @@ class NodeShowerPrimaryLoss(torch.nn.Module):
             Value of the node-wise classification accuracy
         count : int
             Number of nodes the loss was applied to
+        count_rejected : int, optional
+            Number of otherwise valid shower fragments removed by overlap
+            quality. Only returned when thresholds are configured.
         """
         # Create a mask for valid nodes (-1 indicates an invalid primary ID)
         primary_ids = get_cluster_label_batch(
@@ -138,6 +174,9 @@ class NodeShowerPrimaryLoss(torch.nn.Module):
                 clust_label, coord_label, clusts, primary_ids
             )
 
+            # A group without a usable reference point has no primary target.
+            valid_mask &= primary_ids.numpy_tensor() > -1
+
         # If requested, remove groups that do not contain exactly one primary
         if self.high_purity:
             # Fetch the group IDs
@@ -149,6 +188,19 @@ class NodeShowerPrimaryLoss(torch.nn.Module):
                 group_ids = get_cluster_label_batch(clust_label, clusts, column="group")
 
             valid_mask &= node_purity_mask_batch(group_ids, primary_ids)
+
+        # Exclude fragments whose truth-instance match is not sufficiently
+        # pure, efficient or complete for a stable primary target.
+        count_rejected = 0
+        if self.quality_filter.active:
+            quality_mask = self.quality_filter.node_mask(
+                clust_label,
+                clusts,
+                primary_ids.numpy_tensor(),
+                overlap_cache,
+            )
+            count_rejected = int(np.count_nonzero(valid_mask & ~quality_mask))
+            valid_mask &= quality_mask
 
         # Apply the valid mask and convert the labels to a torch.Tensor
         valid_index = np.where(valid_mask)[0]
@@ -178,4 +230,8 @@ class NodeShowerPrimaryLoss(torch.nn.Module):
             )
             acc /= len(valid_index)
 
-        return {"accuracy": acc, "loss": loss, "count": len(valid_index)}
+        result = {"accuracy": acc, "loss": loss, "count": len(valid_index)}
+        if self.quality_filter.active:
+            result["count_rejected"] = count_rejected
+
+        return result

--- a/src/spine/model/grappa/loss/node_vertex.py
+++ b/src/spine/model/grappa/loss/node_vertex.py
@@ -12,6 +12,10 @@ from spine.cluster.label import get_cluster_label_batch
 from spine.data import ClusterLabelBatch, IndexBatch, Meta, TensorBatch
 from spine.geo import GeoManager
 from spine.model.common.factories import loss_fn_factory
+from spine.model.common.quality import (
+    ClusterOverlapCache,
+    ClusterQualityFilter,
+)
 from spine.model.grappa.vertex import (
     decode_vertex_positions,
     vertex_position_scales,
@@ -63,6 +67,11 @@ class NodeVertexLoss(torch.nn.Module):
         normalize_positions: bool = False,
         use_anchor_points: bool = False,
         return_vertex_labels: bool = False,
+        *,
+        min_iou: float | Sequence[float] | None = None,
+        min_purity: float | Sequence[float] | None = None,
+        min_efficiency: float | Sequence[float] | None = None,
+        match_target: str = "group",
     ) -> None:
         """Initialize the vertex regression loss function.
 
@@ -82,6 +91,17 @@ class NodeVertexLoss(torch.nn.Module):
             Predict positions w.r.t. to the particle end points
         return_vertex_labels : bool, default `False`
             If `True`, return the list vertex labels (one per particle)
+        min_iou : float or sequence of float, optional
+            Minimum truth-instance IoU, shared or specified for secondary and
+            primary node targets.
+        min_purity : float or sequence of float, optional
+            Minimum predicted-cluster purity, shared or specified for secondary
+            and primary node targets.
+        min_efficiency : float or sequence of float, optional
+            Minimum truth-instance efficiency, shared or specified for
+            secondary and primary node targets.
+        match_target : str, default 'group'
+            Truth-instance field used to evaluate overlap quality.
         """
         # Initialize the parent class
         super().__init__()
@@ -92,6 +112,15 @@ class NodeVertexLoss(torch.nn.Module):
         self.normalize_positions = normalize_positions
         self.use_anchor_points = use_anchor_points
         self.return_vertex_labels = return_vertex_labels
+
+        # One policy governs both outputs of this compound objective
+        self.quality_filter = ClusterQualityFilter(
+            min_iou,
+            min_purity,
+            min_efficiency,
+            match_target=match_target,
+            num_classes=2,
+        )
 
         # Initialize the primary identification loss
         self.primary_loss = NodeClassLoss(
@@ -117,6 +146,7 @@ class NodeVertexLoss(torch.nn.Module):
         meta: Sequence[Meta] | None = None,
         start_points: TensorBatch | None = None,
         end_points: TensorBatch | None = None,
+        overlap_cache: ClusterOverlapCache | None = None,
         **kwargs: object,
     ) -> dict[str, torch.Tensor | TensorBatch | float | int]:
         """Applies the node type loss to a batch of data.
@@ -135,6 +165,8 @@ class NodeVertexLoss(torch.nn.Module):
             (C, 3) Node start positions
         end_points : TensorBatch, optional
             (C, 3) Node end positions
+        overlap_cache : ClusterOverlapCache, optional
+            Cluster overlaps shared by the objectives in one GrapPA forward.
         **kwargs : dict, optional
             Other labels/outputs of the model which are not relevant here
 
@@ -154,6 +186,13 @@ class NodeVertexLoss(torch.nn.Module):
             Value of the vertex regression loss
         reg_accuracy : float
             Value of the vertex regression accuracy
+        primary_count_rejected : int, optional
+            Number of otherwise valid primary-classification targets removed
+            by overlap quality.
+        reg_count_rejected : int, optional
+            Number of otherwise valid primary vertex targets removed by overlap
+            quality. Rejection counts are returned only when thresholds are
+            configured.
         """
         # Ensure that the predictions are of the expected shape, split them
         if node_pred.shape[1] != 5:
@@ -171,9 +210,6 @@ class NodeVertexLoss(torch.nn.Module):
         primary_pred = TensorBatch(primary_pred, node_pred.counts)
         vertex_pred = TensorBatch(vertex_pred, node_pred.counts)
 
-        # Compute the primary identification loss
-        result_primary = self.primary_loss(clust_label, clusts, primary_pred)
-
         # If containment or normalization are requested, ensure meta is provided
         if self.only_contained or self.normalize_positions:
             if meta is None:
@@ -187,6 +223,22 @@ class NodeVertexLoss(torch.nn.Module):
             clust_label, clusts, column="interaction_primary"
         )
         vertex_labels = get_cluster_label_batch(clust_label, clusts, column="vertex")
+
+        # Use one cluster-quality decision for both primary classification and
+        # the vertex regression attached to primary nodes.
+        quality_mask = self.quality_filter.node_mask(
+            clust_label,
+            clusts,
+            primary_ids.numpy_tensor(),
+            overlap_cache,
+        )
+        result_primary = self.primary_loss(
+            clust_label,
+            clusts,
+            primary_pred,
+            node_quality_mask=(quality_mask if self.quality_filter.active else None),
+            overlap_cache=overlap_cache,
+        )
 
         # Create a mask for valid nodes (-1 indicates invalid labels,
         # 0 indicates a secondary)
@@ -207,6 +259,13 @@ class NodeVertexLoss(torch.nn.Module):
                 )
 
             valid_mask &= contain_mask
+
+        # Count only primary vertices which pass every ordinary task-specific
+        # requirement but fail the shared overlap-quality policy.
+        count_rejected = 0
+        if self.quality_filter.active:
+            count_rejected = int(np.count_nonzero(valid_mask & ~quality_mask))
+            valid_mask &= quality_mask
 
         # If requested, normalize the target positions to the detector size
         position_scales = None
@@ -258,6 +317,8 @@ class NodeVertexLoss(torch.nn.Module):
             "reg_count": len(valid_index),
             **{f"primary_{key}": value for key, value in result_primary.items()},
         }
+        if self.quality_filter.active:
+            result["reg_count_rejected"] = count_rejected
 
         if self.return_vertex_labels:
             result["labels"] = vertex_labels

--- a/src/spine/model/grappa/model.py
+++ b/src/spine/model/grappa/model.py
@@ -26,6 +26,7 @@ from spine.constants.factory import enum_factory
 from spine.data import ClusterLabelBatch, EdgeIndexBatch, IndexBatch, TensorBatch
 from spine.model.common.dbscan import DBSCAN
 from spine.model.common.factories import final_factory
+from spine.model.common.quality import ClusterOverlapCache
 from spine.model.grappa.evaluation import (
     node_assignment_batch,
     node_assignment_score_batch,
@@ -620,8 +621,9 @@ class GrapPA(torch.nn.Module):
 
         Parameters
         ----------
-        data : ClusterLabelBatch
-            Structured labels used to build clusters on the fly
+        data : ClusterLabelBatch or TensorBatch
+            Structured labels used to build clusters, or a plain tensor batch
+            when each selected voxel is represented as an individual node.
         coord_label : TensorBatch, optional
             (P, 1 + 2*D + 2) Tensor of label points
 
@@ -629,6 +631,12 @@ class GrapPA(torch.nn.Module):
         -------
         clusts : IndexBatch
             (C, N_c, N_{c,i}) Cluster indexes
+
+        Raises
+        ------
+        TypeError
+            If cluster or DBSCAN fragmentation is requested with a plain
+            ``TensorBatch``, which does not carry semantic or instance labels.
         """
         if self.node_source == "voxel":
             # Represent each selected voxel as a singleton graph node. With
@@ -660,14 +668,18 @@ class GrapPA(torch.nn.Module):
                 default=np.empty(0, dtype=np.int64),
             )
 
+        # All non-voxel fragmentation paths require the named semantic and
+        # instance fields provided by structured cluster labels. Besides making
+        # that runtime contract explicit, this narrows the type below.
+        if not isinstance(data, ClusterLabelBatch):
+            raise TypeError("Label clustering requires structured labels.")
+
         if self.dbscan is not None:
             # Use the DBSCAN fragmenter to build the clusters
             seg_label = data.shapes
             clusts, _ = self.dbscan(data.to_tensor_batch(), seg_label, coord_label)
         else:
             # Use the label tensor to build the clusters
-            if not isinstance(data, ClusterLabelBatch):  # pragma: no cover
-                raise TypeError("Label clustering requires structured labels.")
             clusts = form_clusters_batch(
                 data.to_numpy(),
                 self.node_min_size,
@@ -997,6 +1009,10 @@ class GrapPALoss(torch.nn.Module):
         """
         # Loop and apply the losses
         result: dict[str, Any] = {}
+
+        # Objectives often match the same clusters to the same truth field.
+        # Cache those geometrical overlaps for the duration of this forward.
+        overlap_cache: ClusterOverlapCache = {}
         num_losses = 0
         total_loss: torch.Tensor | None = None
         total_accuracy = 0.0
@@ -1022,6 +1038,7 @@ class GrapPALoss(torch.nn.Module):
                     coord_label=coord_label,
                     true_edge_index=graph_label,
                     iteration=iteration,
+                    overlap_cache=overlap_cache,
                     **output,
                     **extra,
                 )

--- a/src/spine/model/image/loss.py
+++ b/src/spine/model/image/loss.py
@@ -12,6 +12,7 @@ from spine.constants import PID_MASSES
 from spine.data import ClusterLabelBatch, IndexBatch, TensorBatch
 
 from ..common.factories import loss_fn_factory
+from ..common.quality import ClusterQualityFilter
 
 __all__ = [
     "ImageTaskLoss",
@@ -72,6 +73,8 @@ def _object_targets(
     if isinstance(labels, ClusterLabelBatch):
         if target is None:
             raise ValueError("Structured cluster labels require a named target.")
+        if not isinstance(target, str):
+            raise TypeError("Structured cluster-label targets must be named fields.")
         kinetic_energy = target == "kinetic_energy"
         if target_reduction == "ancestor":
             if not kinetic_energy and target != "pid":
@@ -160,6 +163,11 @@ class ImageClassificationLoss(ImageTaskLoss):
         balance_loss: bool = False,
         class_weights: Sequence[float] | None = None,
         ignore_index: int = -1,
+        *,
+        min_iou: float | Sequence[float] | None = None,
+        min_purity: float | Sequence[float] | None = None,
+        min_efficiency: float | Sequence[float] | None = None,
+        match_target: str | None = None,
     ) -> None:
         """Initialize a classification objective.
 
@@ -182,6 +190,15 @@ class ImageClassificationLoss(ImageTaskLoss):
             Fixed class weights.
         ignore_index : int, default -1
             Label value excluded from supervision and metrics.
+        min_iou : float or sequence of float, optional
+            Minimum truth-instance IoU, shared or specified per target class.
+        min_purity : float or sequence of float, optional
+            Minimum predicted-instance purity, shared or specified per class.
+        min_efficiency : float or sequence of float, optional
+            Minimum truth-instance efficiency, shared or specified per class.
+        match_target : str, optional
+            Truth-instance field used to evaluate overlap quality. Defaults to
+            ``ancestor`` for ancestor reduction and ``group`` otherwise.
         """
         # Initialize the parent class
         super().__init__()
@@ -203,15 +220,55 @@ class ImageClassificationLoss(ImageTaskLoss):
         self.balance_loss = balance_loss
         self.class_weights = class_weights
         self.ignore_index = ignore_index
+
+        # Ancestor-reduced objects must be compared with ancestor instances;
+        # ordinary image objects use the particle-group instance definition.
+        match_target = match_target or (
+            "ancestor" if target_reduction == "ancestor" else "group"
+        )
+        self.quality_filter = ClusterQualityFilter(
+            min_iou,
+            min_purity,
+            min_efficiency,
+            match_target=match_target,
+            num_classes=out_channels,
+        )
         self.loss_fn: Any = loss_fn_factory(loss, reduction="none")
 
     def forward(
         self,
-        labels: TensorBatch | Sequence[Any] | torch.Tensor,
+        labels: ClusterLabelBatch | TensorBatch | Sequence[Any] | torch.Tensor,
         objects: IndexBatch,
         prediction: TensorBatch,
     ) -> dict[str, Any]:
-        """Compute classification loss and classwise accuracy."""
+        """Compute the image-object classification objective.
+
+        Parameters
+        ----------
+        labels : ClusterLabelBatch, TensorBatch, sequence or torch.Tensor
+            Direct object labels or structured voxel labels from which the
+            configured target can be reduced.
+        objects : IndexBatch
+            Voxel indexes defining the image objects represented by the
+            prediction rows.
+        prediction : TensorBatch
+            Classification logits with shape ``(N, C)``.
+
+        Returns
+        -------
+        dict
+            Mean loss, global accuracy, supervised-object count and one
+            accuracy entry per target class. When quality filtering is active,
+            also includes the number of otherwise valid rejected objects.
+
+        Raises
+        ------
+        TypeError
+            If overlap filtering is requested without structured voxel labels.
+        ValueError
+            If target labels are not scalar class IDs or fall outside the
+            configured output range.
+        """
         # Normalize labels and identify valid class targets
         logits = prediction.torch_tensor()
         targets = _object_targets(
@@ -226,12 +283,39 @@ class ImageClassificationLoss(ImageTaskLoss):
                 raise ValueError("Classification targets must be scalar class IDs.")
             targets = targets.flatten()
         targets = targets.long()
+
+        # Validate ordinary classification eligibility before overlap quality.
         valid = targets != self.ignore_index
         invalid = valid & ((targets < 0) | (targets >= self.num_classes))
         if torch.any(invalid).item():
             raise ValueError(
                 f"Classification labels must lie in [0, {self.num_classes})."
             )
+
+        # Overlap thresholds require voxel-level truth and reconstructed object
+        # indexes; direct image labels do not define an instance match.
+        count_rejected = 0
+        if self.quality_filter.active:
+            if not isinstance(labels, ClusterLabelBatch):
+                raise TypeError(
+                    "Image overlap thresholds require `ClusterLabelBatch` labels."
+                )
+            classes = targets.detach().cpu().numpy()
+            quality_mask = self.quality_filter.node_mask(labels, objects, classes)
+            quality_mask_tensor = torch.as_tensor(
+                quality_mask,
+                dtype=torch.bool,
+                device=targets.device,
+            )
+            count_rejected = int(
+                torch.count_nonzero(valid & ~quality_mask_tensor).item()
+            )
+
+            # Reuse the configured ignore index so quality rejection follows
+            # precisely the same downstream path as an absent target.
+            targets = targets.clone()
+            targets[~quality_mask_tensor] = self.ignore_index
+            valid &= quality_mask_tensor
 
         # Return a differentiable zero when no supervised object is available
         valid_index = torch.nonzero(valid).flatten()
@@ -241,6 +325,8 @@ class ImageClassificationLoss(ImageTaskLoss):
                 "accuracy": 1.0,
                 "count": 0,
             }
+            if self.quality_filter.active:
+                result["count_rejected"] = count_rejected
             for class_id in range(self.num_classes):
                 result[f"accuracy_class_{class_id}"] = 1.0
             return result
@@ -284,6 +370,8 @@ class ImageClassificationLoss(ImageTaskLoss):
             "accuracy": accuracy,
             "count": len(valid_index),
         }
+        if self.quality_filter.active:
+            result["count_rejected"] = count_rejected
         for class_id in range(self.num_classes):
             class_mask = targets == class_id
             result[f"accuracy_class_{class_id}"] = (
@@ -308,6 +396,13 @@ class ImageRegressionLoss(ImageTaskLoss):
         target_reduction: str = "mode",
         loss: str | dict[str, Any] = "mse",
         ignore_value: float | None = -1.0,
+        *,
+        min_iou: float | Sequence[float] | None = None,
+        min_purity: float | Sequence[float] | None = None,
+        min_efficiency: float | Sequence[float] | None = None,
+        match_target: str | None = None,
+        quality_target: str = "pid",
+        quality_num_classes: int | None = None,
     ) -> None:
         """Initialize a regression objective.
 
@@ -329,6 +424,19 @@ class ImageRegressionLoss(ImageTaskLoss):
         ignore_value : float, optional
             Target value excluded from supervision. Set to ``null`` to retain
             every finite target.
+        min_iou : float or sequence of float, optional
+            Minimum truth-instance IoU, shared or specified per quality class.
+        min_purity : float or sequence of float, optional
+            Minimum predicted-instance purity, shared or specified per class.
+        min_efficiency : float or sequence of float, optional
+            Minimum truth-instance efficiency, shared or specified per class.
+        match_target : str, optional
+            Truth-instance field used to evaluate overlap quality. Defaults to
+            ``ancestor`` for ancestor reduction and ``group`` otherwise.
+        quality_target : str, default 'pid'
+            Categorical field used to select class-dependent thresholds.
+        quality_num_classes : int, optional
+            Number of quality classes. Required for threshold sequences.
         """
         # Initialize the parent class
         super().__init__()
@@ -343,15 +451,58 @@ class ImageRegressionLoss(ImageTaskLoss):
         self.target = target
         self.target_reduction = target_reduction
         self.ignore_value = ignore_value
+        self.quality_target = quality_target
+
+        # Match against the same instance definition used to construct the
+        # image objects unless the caller explicitly selects another field.
+        match_target = match_target or (
+            "ancestor" if target_reduction == "ancestor" else "group"
+        )
+        self.quality_filter = ClusterQualityFilter(
+            min_iou,
+            min_purity,
+            min_efficiency,
+            match_target=match_target,
+            num_classes=quality_num_classes,
+            require_num_classes=True,
+        )
         self.loss_fn: Any = loss_fn_factory(loss, reduction="none")
 
     def forward(
         self,
-        labels: TensorBatch | Sequence[Any] | torch.Tensor,
+        labels: ClusterLabelBatch | TensorBatch | Sequence[Any] | torch.Tensor,
         objects: IndexBatch,
         prediction: TensorBatch,
     ) -> dict[str, Any]:
-        """Compute regression loss, bias, MAE, and RMSE."""
+        """Compute the image-object regression objective and residual metrics.
+
+        Parameters
+        ----------
+        labels : ClusterLabelBatch, TensorBatch, sequence or torch.Tensor
+            Direct object targets or structured voxel labels from which the
+            configured regression target can be reduced.
+        objects : IndexBatch
+            Voxel indexes defining the image objects represented by the
+            prediction rows.
+        prediction : TensorBatch
+            Scalar or vector predictions with shape ``(N, out_channels)``.
+
+        Returns
+        -------
+        dict
+            Mean loss, residual bias, mean absolute error, root mean squared
+            error and the number of supervised objects. When quality filtering
+            is active, also includes the number of otherwise valid rejected
+            objects.
+
+        Raises
+        ------
+        TypeError
+            If overlap filtering is requested without structured voxel labels.
+        ValueError
+            If prediction and target shapes differ, or class-dependent quality
+            thresholds cannot be reduced to scalar class IDs.
+        """
         # Normalize targets and enforce the configured output shape
         predictions = prediction.torch_tensor()
         targets = _object_targets(
@@ -374,18 +525,60 @@ class ImageRegressionLoss(ImageTaskLoss):
         valid = torch.isfinite(targets).all(dim=1)
         if self.ignore_value is not None:
             valid &= torch.all(targets != self.ignore_value, dim=1)
+
+        # Apply the same instance-quality policy used by classification heads.
+        count_rejected = 0
+        if self.quality_filter.active:
+            if not isinstance(labels, ClusterLabelBatch):
+                raise TypeError(
+                    "Image overlap thresholds require `ClusterLabelBatch` labels."
+                )
+            classes = None
+            if self.quality_filter.class_dependent:
+                # Regression targets are continuous, so obtain a separate
+                # categorical label to select class-dependent requirements.
+                quality_values = labels.voxel_field(self.quality_target).data
+                if quality_values.ndim > 1 and quality_values.shape[1] != 1:
+                    raise ValueError("Overlap quality classes must be scalar IDs.")
+                classes = _object_targets(
+                    labels,
+                    objects,
+                    self.quality_target,
+                    self.target_reduction,
+                    predictions.device,
+                )
+                classes = classes.flatten().long().detach().cpu().numpy()
+            quality_mask = self.quality_filter.node_mask(labels, objects, classes)
+            quality_mask_tensor = torch.as_tensor(
+                quality_mask,
+                dtype=torch.bool,
+                device=valid.device,
+            )
+            count_rejected = int(
+                torch.count_nonzero(valid & ~quality_mask_tensor).item()
+            )
+
+            # Keep a conventional ignored value for callers which inspect the
+            # filtered targets while excluding it from all objective metrics.
+            targets = targets.clone()
+            targets[~quality_mask_tensor] = -1
+            valid &= quality_mask_tensor
+
         valid_index = torch.nonzero(valid).flatten()
 
         # Return a differentiable zero when no supervised object is available
         if len(valid_index) == 0:
             zero = predictions.sum() * 0.0
-            return {
+            result = {
                 "loss": zero,
                 "bias": 0.0,
                 "mae": 0.0,
                 "rmse": 0.0,
                 "count": 0,
             }
+            if self.quality_filter.active:
+                result["count_rejected"] = count_rejected
+            return result
 
         # Evaluate the objective and physical residual metrics
         predictions = predictions[valid_index]
@@ -393,13 +586,17 @@ class ImageRegressionLoss(ImageTaskLoss):
         losses = self.loss_fn(predictions, targets)
         loss = losses.reshape(len(valid_index), -1).mean(dim=1).mean()
         residuals = predictions - targets
-        return {
+        result = {
             "loss": loss,
             "bias": residuals.mean().item(),
             "mae": residuals.abs().mean().item(),
             "rmse": residuals.square().mean().sqrt().item(),
             "count": len(valid_index),
         }
+        if self.quality_filter.active:
+            result["count_rejected"] = count_rejected
+
+        return result
 
 
 class ImageLoss(torch.nn.Module):

--- a/test/test_cluster/test_quality.py
+++ b/test/test_cluster/test_quality.py
@@ -1,0 +1,85 @@
+"""Tests for predicted-cluster overlap quality measurements."""
+
+import numpy as np
+
+from spine.cluster import get_cluster_overlap_batch
+from spine.data import ClusterLabelBatch, IndexBatch, TensorBatch
+
+
+def test_cluster_overlap_batch_reports_best_match_quality():
+    """Best-match metrics should preserve batch boundaries and direction."""
+    rows = np.zeros((6, 7), dtype=np.float32)
+    rows[:, 0] = (0, 0, 0, 0, 0, 1)
+    rows[:, 1] = np.arange(6)
+    rows[:, 4] = 1.0
+    rows[:, 5] = (0, 0, 0, 1, 1, 0)
+    rows[:, 6] = (0, 0, 0, 1, 1, 0)
+    particles = {
+        "group": TensorBatch(np.array([0, 1, -1]), counts=[2, 1]),
+    }
+    labels = ClusterLabelBatch(
+        TensorBatch(rows, counts=[5, 1], has_batch_col=True),
+        particles,
+    )
+    objects = IndexBatch(
+        [
+            np.array([0, 1]),
+            np.array([2, 3]),
+            np.array([4]),
+            np.array([5]),
+        ],
+        spans=[5, 1],
+        counts=[3, 1],
+        single_counts=[2, 2, 1, 1],
+    )
+
+    overlap = get_cluster_overlap_batch(labels, objects)
+
+    np.testing.assert_array_equal(overlap.match_ids.data, [0, 0, 1, -1])
+    np.testing.assert_array_equal(overlap.intersections.data, [2, 1, 1, 0])
+    np.testing.assert_allclose(overlap.purities.data, [1.0, 0.5, 1.0, 0.0])
+    np.testing.assert_allclose(
+        overlap.efficiencies.data,
+        [2 / 3, 1 / 3, 1 / 2, 0.0],
+    )
+    np.testing.assert_allclose(overlap.ious.data, [2 / 3, 1 / 4, 1 / 2, 0.0])
+
+
+def test_cluster_overlap_batch_rejects_misaligned_spans():
+    """Overlap quality requires indexes in the cluster-label voxel space."""
+    rows = np.zeros((2, 7), dtype=np.float32)
+    labels = ClusterLabelBatch(
+        TensorBatch(rows, counts=[2], has_batch_col=True),
+        {"group": TensorBatch(np.array([0]), counts=[1])},
+    )
+    objects = IndexBatch(
+        [np.array([0])],
+        spans=[1],
+        counts=[1],
+        single_counts=[1],
+    )
+
+    with np.testing.assert_raises_regex(ValueError, "share batch spans"):
+        get_cluster_overlap_batch(labels, objects)
+
+
+def test_cluster_overlap_batch_accepts_empty_event():
+    """Events without predicted clusters should preserve batch alignment."""
+    rows = np.zeros((2, 7), dtype=np.float32)
+    rows[:, 0] = (0, 1)
+    rows[:, 5] = (0, 0)
+    labels = ClusterLabelBatch(
+        TensorBatch(rows, counts=[1, 1], has_batch_col=True),
+        {"group": TensorBatch(np.array([0, 0]), counts=[1, 1])},
+    )
+    objects = IndexBatch(
+        [np.array([1])],
+        spans=[1, 1],
+        counts=[0, 1],
+        single_counts=[1],
+    )
+
+    overlap = get_cluster_overlap_batch(labels, objects)
+
+    np.testing.assert_array_equal(overlap.match_ids.data, [0])
+    np.testing.assert_allclose(overlap.ious.data, [1.0])

--- a/test/test_math/test_match.py
+++ b/test/test_math/test_match.py
@@ -8,6 +8,7 @@ from spine.math.match import (
     overlap_count,
     overlap_dice,
     overlap_iou,
+    overlap_metrics,
     overlap_weighted_dice,
     overlap_weighted_iou,
 )
@@ -43,6 +44,31 @@ def test_overlap_metrics_cover_empty_disjoint_and_overlapping_sets():
     assert overlap_dice(left, right)[1, 1] == np.float32(4 / 7)
     assert overlap_weighted_iou(left, right)[1, 1] == np.float32(1.4)
     assert overlap_weighted_dice(left, right)[1, 1] == np.float32(2.0)
+
+
+def test_combined_overlap_metrics_preserve_directionality():
+    """Combined metrics should distinguish predicted purity and efficiency."""
+    predicted = [
+        np.array([], dtype=np.int64),
+        np.array([0, 1, 2], dtype=np.int64),
+        np.array([10], dtype=np.int64),
+    ]
+    truth = [
+        np.array([], dtype=np.int64),
+        np.array([1, 2, 3, 4], dtype=np.int64),
+        np.array([20], dtype=np.int64),
+    ]
+
+    counts, purities, efficiencies, ious = overlap_metrics(predicted, truth)
+
+    assert counts.tolist() == [[0, 0, 0], [0, 2, 0], [0, 0, 0]]
+    np.testing.assert_array_equal(counts, overlap_count(predicted, truth))
+    np.testing.assert_array_equal(ious, overlap_iou(predicted, truth))
+    assert purities[1, 1] == np.float32(2 / 3)
+    assert efficiencies[1, 1] == np.float32(1 / 2)
+    assert ious[1, 1] == np.float32(2 / 5)
+    assert not np.any(purities[[0, 2]])
+    assert not np.any(efficiencies[:, [0, 2]])
 
 
 def test_chamfer_distance_handles_empty_and_nonempty_clouds():

--- a/test/test_model/test_common/test_quality.py
+++ b/test/test_model/test_common/test_quality.py
@@ -1,0 +1,190 @@
+"""Tests for shared overlap-quality threshold handling."""
+
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from spine.cluster.quality import ClusterOverlapBatch
+from spine.data import EdgeIndexBatch, IndexBatch, TensorBatch
+from spine.model.common.quality import ClusterQualityFilter, OverlapThresholds
+
+
+def _overlap() -> ClusterOverlapBatch:
+    """Build three compact best-match records for threshold tests."""
+    counts = [3]
+    return ClusterOverlapBatch(
+        TensorBatch(np.array([0, 1, -1]), counts),
+        TensorBatch(np.array([6, 7, 0]), counts),
+        TensorBatch(np.array([0.9, 0.9, 0.0]), counts),
+        TensorBatch(np.array([0.8, 0.8, 0.0]), counts),
+        TensorBatch(np.array([0.6, 0.7, 0.0]), counts),
+    )
+
+
+def test_overlap_thresholds_apply_scalar_and_class_values():
+    """All active metrics should gate the best match conjunctively."""
+    thresholds = OverlapThresholds(
+        min_iou=[0.5, 0.8],
+        min_purity=0.85,
+        min_efficiency=0.75,
+        num_classes=2,
+    )
+
+    assert thresholds.active
+    assert thresholds.class_dependent
+    np.testing.assert_array_equal(
+        thresholds.mask(_overlap(), np.array([0, 1, 0])),
+        [True, False, False],
+    )
+
+
+def test_overlap_thresholds_validate_configuration_and_classes():
+    """Malformed thresholds and missing class selectors fail explicitly."""
+    assert not OverlapThresholds().active
+    assert not OverlapThresholds().class_dependent
+
+    for value in (-0.1, 1.1, np.nan):
+        with pytest.raises(ValueError, match=r"\[0, 1\]"):
+            OverlapThresholds(min_iou=value)
+    with pytest.raises(TypeError, match="numeric"):
+        OverlapThresholds(min_iou=cast(Any, "bad"))
+    with pytest.raises(ValueError, match="one-dimensional"):
+        OverlapThresholds(min_iou=cast(Any, [[0.5]]))
+    with pytest.raises(ValueError, match="positive"):
+        OverlapThresholds(num_classes=0)
+    with pytest.raises(ValueError, match="exactly 2 values"):
+        OverlapThresholds(min_iou=[0.5], num_classes=2)
+    with pytest.raises(ValueError, match="requires `num_classes`"):
+        OverlapThresholds(min_iou=[0.5], require_num_classes=True)
+
+    thresholds = OverlapThresholds(min_iou=[0.5, 0.5])
+    with pytest.raises(ValueError, match="exactly 3 values"):
+        thresholds.validate_num_classes(3)
+    with pytest.raises(ValueError, match="positive"):
+        thresholds.validate_num_classes(0)
+    with pytest.raises(ValueError, match="require class labels"):
+        thresholds.mask(_overlap())
+    with pytest.raises(ValueError, match="align"):
+        thresholds.mask(_overlap(), np.array([0, 1]))
+
+    np.testing.assert_array_equal(
+        thresholds.mask(_overlap(), np.array([0, 4, 0])),
+        [True, False, False],
+    )
+
+
+def test_cluster_quality_filter_reuses_cached_overlap(monkeypatch):
+    """Several objectives should share one geometrical overlap calculation."""
+    calls = []
+
+    def overlap(*args):
+        calls.append(args)
+        return _overlap()
+
+    monkeypatch.setattr(
+        "spine.model.common.quality.get_cluster_overlap_batch",
+        overlap,
+    )
+    clusters = IndexBatch(
+        [np.array([0]), np.array([1]), np.array([2])],
+        spans=[3],
+        counts=[3],
+        single_counts=[1, 1, 1],
+    )
+    cache = {}
+    first = ClusterQualityFilter(min_iou=0.5)
+    second = ClusterQualityFilter(min_purity=0.8)
+
+    np.testing.assert_array_equal(
+        first.node_mask(cast(Any, object()), clusters, cache=cache),
+        [True, True, False],
+    )
+    np.testing.assert_array_equal(
+        second.node_mask(cast(Any, object()), clusters, cache=cache),
+        [True, True, False],
+    )
+    assert len(calls) == 1
+
+
+def test_cluster_quality_filter_projects_class_dependent_edge_policy(monkeypatch):
+    """An edge-class policy must be satisfied independently by both endpoints."""
+    monkeypatch.setattr(
+        "spine.model.common.quality.get_cluster_overlap_batch",
+        lambda *args: _overlap(),
+    )
+    clusters = IndexBatch(
+        [np.array([0]), np.array([1]), np.array([2])],
+        spans=[3],
+        counts=[3],
+        single_counts=[1, 1, 1],
+    )
+    edges = EdgeIndexBatch(
+        np.array([[0, 1], [1, 2]]),
+        counts=[2],
+        spans=[3],
+        directed=True,
+    )
+    quality_filter = ClusterQualityFilter(
+        min_iou=[0.5, 0.8],
+        num_classes=2,
+    )
+
+    np.testing.assert_array_equal(
+        quality_filter.edge_mask(
+            cast(Any, object()),
+            clusters,
+            edges,
+            np.array([0, 1]),
+        ),
+        [True, False],
+    )
+    with pytest.raises(ValueError, match="require edge labels"):
+        quality_filter.edge_mask(cast(Any, object()), clusters, edges)
+    with pytest.raises(ValueError, match="align with edges"):
+        quality_filter.edge_mask(
+            cast(Any, object()),
+            clusters,
+            edges,
+            np.array([0]),
+        )
+
+    bad_edges = EdgeIndexBatch(
+        np.array([[0], [4]]),
+        counts=[1],
+        spans=[3],
+        directed=True,
+    )
+    with pytest.raises(IndexError, match="index the node-quality mask"):
+        quality_filter.edge_mask(
+            cast(Any, object()),
+            clusters,
+            bad_edges,
+            np.array([0]),
+        )
+
+
+def test_inactive_cluster_quality_filter_accepts_all_objects():
+    """An unconfigured filter should avoid overlap work and retain all items."""
+    clusters = IndexBatch(
+        [np.array([0]), np.array([1])],
+        spans=[2],
+        counts=[2],
+        single_counts=[1, 1],
+    )
+    edges = EdgeIndexBatch(
+        np.array([[0], [1]]),
+        counts=[1],
+        spans=[2],
+        directed=True,
+    )
+    quality_filter = ClusterQualityFilter()
+
+    np.testing.assert_array_equal(
+        quality_filter.node_mask(cast(Any, object()), clusters),
+        [True, True],
+    )
+    np.testing.assert_array_equal(
+        quality_filter.edge_mask(cast(Any, object()), clusters, edges),
+        [True],
+    )

--- a/test/test_model/test_full_chain/test_regression.py
+++ b/test/test_model/test_full_chain/test_regression.py
@@ -16,11 +16,25 @@ from spine.utils.conditional import TORCH_AVAILABLE
 from ..cases import FULL_CHAIN_REGRESSION_CONFIG
 
 FULL_CHAIN_REFERENCE = (
-    (4.777881622314453, 0.9742614181115755),
-    (2.7037878036499023, 0.9495003823904554),
-    (3.4835681915283203, 0.9762163855539899),
+    (4.770995140075684, 0.9757392506238908),
+    (2.667616844177246, 0.9509786432600207),
+    (3.3565175533294678, 0.9776052744428787),
 )
 FULL_CHAIN_REFERENCE_ATOL = 1.0e-5
+
+
+def test_full_chain_particle_target_quality_policy() -> None:
+    """Apply IoU rejection only to predicted full-chain particle targets."""
+    cfg = load_config_file(str(FULL_CHAIN_REGRESSION_CONFIG), download=False)
+    loss_cfg = cfg["model"]["modules"]["grappa_inter_loss"]["node_loss"]
+
+    for task in ("type", "primary"):
+        assert loss_cfg[task]["min_iou"] == 0.5
+        assert loss_cfg[task]["match_target"] == "group"
+
+    # IoU now owns ambiguous-fragment rejection for particle primary targets.
+    assert "use_closest" not in loss_cfg["primary"]
+    assert "secondary_label" not in loss_cfg["primary"]
 
 
 @pytest.fixture(name="cuda_available")

--- a/test/test_model/test_grappa/conftest.py
+++ b/test/test_model/test_grappa/conftest.py
@@ -49,6 +49,14 @@ def graph_labels(graph_data):
         coord_cols=np.arange(1, 4),
     )
     particles = {
+        "group": TensorBatch(
+            np.array([0, 1, 0], dtype=np.int64),
+            counts=np.array([2, 1], dtype=np.int64),
+        ),
+        "pid": TensorBatch(
+            np.array([0, 1, 0], dtype=np.int64),
+            counts=np.array([2, 1], dtype=np.int64),
+        ),
         "shape": TensorBatch(
             np.array([0, 1, 1], dtype=np.int64),
             counts=np.array([2, 1], dtype=np.int64),

--- a/test/test_model/test_grappa/test_loss/test_loss.py
+++ b/test/test_model/test_grappa/test_loss/test_loss.py
@@ -10,11 +10,13 @@ from spine.data import (
     IndexBatch,
     Meta,
     TensorBatch,
+    TensorSchema,
 )
 from spine.model.grappa.evaluation import edge_assignment_forest_batch
 from spine.model.grappa.loss import (
     EdgeChannelLoss,
     NodeClassLoss,
+    NodeOrientLoss,
     NodeRegressionLoss,
     NodeShowerPrimaryLoss,
     NodeVertexLoss,
@@ -155,6 +157,20 @@ def test_node_regression_loss_masks_invalid_targets(graph_labels, graph_clusters
         )
 
 
+def test_node_regression_loss_supports_vector_targets(graph_labels, graph_clusters):
+    """Vector regression applies one validity decision to each node."""
+    prediction = TensorBatch(torch.zeros((3, 3)), graph_clusters.counts)
+
+    result = NodeRegressionLoss(target="vertex")(
+        graph_labels,
+        graph_clusters,
+        prediction,
+    )
+
+    assert result["count"] == 3
+    torch.testing.assert_close(result["loss"], torch.tensor(95.0))
+
+
 def test_node_regression_loss_handles_no_valid_targets(graph_labels, graph_clusters):
     """An entirely unavailable regression target yields a neutral result."""
     graph_labels.particles["energy"].data.fill(-1.0)
@@ -169,6 +185,49 @@ def test_node_regression_loss_handles_no_valid_targets(graph_labels, graph_clust
     assert result["count"] == 0
     assert result["accuracy"] == 1.0
     torch.testing.assert_close(result["loss"], torch.tensor(0.0))
+
+
+def test_node_losses_filter_low_quality_clusters(graph_labels):
+    """Node classification and regression share overlap-quality filtering."""
+    objects = _mixed_graph_clusters()
+    class_prediction = TensorBatch(torch.zeros((3, 2)), objects.counts)
+    class_result = NodeClassLoss(
+        target="pid",
+        min_purity=[0.75, 0.75],
+    )(graph_labels, objects, class_prediction)
+    assert class_result["count"] == 1
+    assert class_result["count_rejected"] == 2
+
+    graph_labels.particles["energy"].data[1] = 6.0
+    reg_prediction = TensorBatch(torch.zeros((3, 1)), objects.counts)
+    reg_result = NodeRegressionLoss(
+        target="energy",
+        min_purity=[0.75, 0.75],
+        quality_num_classes=2,
+    )(graph_labels, objects, reg_prediction)
+    assert reg_result["count"] == 1
+    assert reg_result["count_rejected"] == 2
+
+
+def test_node_overlap_thresholds_validate_class_counts(graph_labels, graph_clusters):
+    """Node threshold vectors must match the classification domain."""
+    with pytest.raises(ValueError, match="requires `num_classes`"):
+        NodeRegressionLoss(target="energy", min_iou=[0.5])
+
+    prediction = TensorBatch(torch.zeros((3, 2)), graph_clusters.counts)
+    with pytest.raises(ValueError, match="exactly 2 values"):
+        NodeClassLoss(target="pid", min_iou=[0.5])(
+            graph_labels,
+            graph_clusters,
+            prediction,
+        )
+    with pytest.raises(ValueError, match="align with clusters"):
+        NodeClassLoss(target="pid")(
+            graph_labels,
+            graph_clusters,
+            prediction,
+            node_quality_mask=np.array([True]),
+        )
 
 
 def test_vertex_loss_validates_inputs(graph_labels, graph_clusters):
@@ -266,6 +325,20 @@ def _edge_inputs():
     )
 
     return edge_index, edge_pred
+
+
+def _mixed_graph_clusters():
+    """Return two impure clusters and one pure cluster."""
+    return IndexBatch(
+        [
+            np.array([0, 2], dtype=np.int64),
+            np.array([1, 3], dtype=np.int64),
+            np.array([4, 5], dtype=np.int64),
+        ],
+        spans=[4, 2],
+        counts=[2, 1],
+        single_counts=[2, 2, 2],
+    )
 
 
 def _add_particle_fields(graph_labels, **fields):
@@ -548,6 +621,60 @@ def test_shower_primary_truth_group_purity(
     assert result["count"] == 3
 
 
+def test_shower_primary_filters_low_quality_fragments(graph_labels):
+    """Specialized shower-primary targets use the shared overlap policy."""
+    _add_particle_fields(
+        graph_labels,
+        group=[0, 1, 0],
+        group_primary=[1, 0, 1],
+    )
+    objects = _mixed_graph_clusters()
+    prediction = TensorBatch(torch.zeros((3, 2)), objects.counts)
+
+    result = NodeShowerPrimaryLoss(min_purity=[0.75, 0.75])(
+        graph_labels,
+        objects,
+        prediction,
+    )
+
+    assert result["count"] == 1
+    assert result["count_rejected"] == 2
+
+
+def test_node_orientation_filters_low_quality_tracks(graph_labels):
+    """Track orientation retains only clusters with trustworthy associations."""
+    _add_particle_fields(
+        graph_labels,
+        particle=[0, 1, 0],
+        shape=[1, 1, 1],
+    )
+    objects = _mixed_graph_clusters()
+    prediction = TensorBatch(torch.tensor([[0.0, 1.0]] * 3), objects.counts)
+    starts = TensorBatch(torch.zeros((3, 3)), objects.counts)
+    ends = TensorBatch(torch.tensor([[1.0, 0.0, 0.0]] * 3), objects.counts)
+    coord_label = TensorBatch(
+        torch.tensor([[0.0, 0.0, 0.0, 1.0, 0.0, 0.0]] * 3),
+        counts=[2, 1],
+        coord_cols=np.arange(6),
+        schema=TensorSchema(
+            coordinate_groups={"start": (0, 1, 2), "end": (3, 4, 5)},
+        ),
+    )
+
+    result = NodeOrientLoss(min_purity=[0.75, 0.75])(
+        graph_labels,
+        coord_label,
+        objects,
+        prediction,
+        starts,
+        ends,
+    )
+
+    assert result["count"] == 1
+    assert result["count_rejected"] == 2
+    assert result["accuracy"] == 1.0
+
+
 def test_vertex_loss_checks_containment_per_event(
     graph_labels,
     graph_clusters,
@@ -625,3 +752,48 @@ def test_vertex_loss_normalizes_anchor_points(graph_labels, graph_clusters):
     )
 
     assert torch.isfinite(result["loss"])
+
+
+def test_vertex_loss_shares_quality_mask_across_both_tasks(graph_labels):
+    """Primary classification and vertex regression reject the same fragments."""
+    objects = _mixed_graph_clusters()
+    prediction = TensorBatch(torch.zeros((3, 5)), objects.counts)
+
+    result = NodeVertexLoss(
+        only_contained=False,
+        min_purity=[0.75, 0.75],
+    )(graph_labels, objects, prediction)
+
+    assert result["primary_count"] == 1
+    assert result["primary_count_rejected"] == 2
+    assert result["reg_count"] == 1
+    assert result["reg_count_rejected"] == 0
+
+
+def test_edge_channel_filters_low_quality_endpoints(graph_labels):
+    """Edge supervision requires both endpoint clusters to pass quality gates."""
+    _add_particle_fields(graph_labels, group=[0, 1, 0])
+    objects = _mixed_graph_clusters()
+    edge_index, edge_pred = _edge_inputs()
+
+    result = EdgeChannelLoss(
+        target="group",
+        min_purity=[0.75, 0.75],
+    )(graph_labels, objects, edge_index, edge_pred)
+    assert result["count"] == 0
+    assert result["count_rejected"] == 2
+
+    result = EdgeChannelLoss(
+        target="group",
+        mode="forest",
+        min_purity=0.75,
+    )(graph_labels, objects, edge_index, edge_pred)
+    assert result["count"] == 0
+    assert result["count_rejected"] == 2
+
+    with pytest.raises(ValueError, match="require scalar"):
+        EdgeChannelLoss(
+            target="group",
+            mode="forest",
+            min_purity=[0.75, 0.75],
+        )

--- a/test/test_model/test_grappa/test_model.py
+++ b/test/test_model/test_grappa/test_model.py
@@ -137,6 +137,42 @@ def test_grappa_loss_routes_graph_truth_to_edge_objective():
     assert result["accuracy"] == 1.0
 
 
+def test_grappa_loss_shares_one_overlap_cache_across_objectives(graph_labels):
+    """Every objective in one forward pass should receive the same cache."""
+
+    class CaptureLoss(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.cache = None
+
+        def forward(self, overlap_cache=None, **kwargs):
+            self.cache = overlap_cache
+            return {"loss": torch.tensor(0.0), "accuracy": 1.0}
+
+    loss = GrapPALoss(
+        {
+            "node_loss": {
+                "first": {"name": "class", "target": "shape"},
+                "second": {"name": "class", "target": "shape"},
+            }
+        }
+    )
+    first = CaptureLoss()
+    second = CaptureLoss()
+    loss.node_first_loss = first
+    loss.node_second_loss = second
+    prediction = TensorBatch(torch.zeros((3, 2)), counts=[2, 1])
+
+    loss(
+        graph_labels,
+        node_first_pred=prediction,
+        node_second_pred=prediction,
+    )
+
+    assert first.cache is second.cache
+    assert first.cache == {}
+
+
 def test_grappa_validates_node_graph_and_grouping_configuration():
     """GrapPA rejects ambiguous node construction and grouping settings."""
     cfg = shower_model_config()
@@ -311,6 +347,9 @@ def test_grappa_dbscan_cluster_path_and_shape_contract(
 
     model.dbscan = FakeDBSCAN()
     assert model._make_clusters(graph_labels) is graph_clusters
+
+    with pytest.raises(TypeError, match="structured labels"):
+        model._make_clusters(graph_data.to_tensor())
 
     model.graph_constructor.max_length = np.ones((5, 5))
     with pytest.raises(TypeError, match="structured cluster labels"):

--- a/test/test_model/test_image/test_loss.py
+++ b/test/test_model/test_image/test_loss.py
@@ -2,6 +2,7 @@
 
 import math
 
+import numpy as np
 import pytest
 
 torch = pytest.importorskip("torch")
@@ -47,6 +48,7 @@ def test_classification_loss_reports_classwise_metrics(image_data):
 
     assert result["accuracy"] == 1.0
     assert result["pid_count"] == 2
+    assert "pid_count_rejected" not in result
     assert torch.isfinite(result["loss"])
     result["loss"].backward()
 
@@ -103,6 +105,119 @@ def test_voxel_labels_are_reduced_over_cluster_objects(image_data):
 
     assert result["pid_count"] == 4
     assert torch.isfinite(result["loss"])
+
+
+def test_image_losses_filter_low_quality_objects(image_data):
+    """Image classification and regression use identical overlap gates."""
+    objects = ImageObjectBuilder(source="cluster")(
+        image_data,
+        object_data=image_data,
+    )
+    logits = TensorBatch(torch.zeros((4, 5)), counts=objects.counts)
+    class_result = ImageClassificationLoss(
+        5,
+        target="pid",
+        min_efficiency=0.75,
+    )(image_data, objects, logits)
+    assert class_result["count"] == 2
+    assert class_result["count_rejected"] == 2
+
+    predictions = TensorBatch(torch.zeros((4, 1)), counts=objects.counts)
+    reg_result = ImageRegressionLoss(
+        1,
+        target="momentum",
+        min_efficiency=0.75,
+    )(image_data, objects, predictions)
+    assert reg_result["count"] == 2
+    assert reg_result["count_rejected"] == 2
+
+
+def test_image_losses_report_when_quality_rejects_every_object(
+    image_data,
+    monkeypatch,
+):
+    """Zero-count objectives should retain their quality rejection count."""
+    objects = ImageObjectBuilder(source="cluster")(
+        image_data,
+        object_data=image_data,
+    )
+
+    class_loss = ImageClassificationLoss(5, target="pid", min_iou=0.0)
+    monkeypatch.setattr(
+        class_loss.quality_filter,
+        "node_mask",
+        lambda *args: np.zeros(len(objects.index_list), dtype=bool),
+    )
+    logits = TensorBatch(torch.zeros((4, 5)), counts=objects.counts)
+    class_result = class_loss(image_data, objects, logits)
+    assert class_result["count"] == 0
+    assert class_result["count_rejected"] == 4
+
+    reg_loss = ImageRegressionLoss(1, target="momentum", min_iou=0.0)
+    monkeypatch.setattr(
+        reg_loss.quality_filter,
+        "node_mask",
+        lambda *args: np.zeros(len(objects.index_list), dtype=bool),
+    )
+    predictions = TensorBatch(torch.zeros((4, 1)), counts=objects.counts)
+    reg_result = reg_loss(image_data, objects, predictions)
+    assert reg_result["count"] == 0
+    assert reg_result["count_rejected"] == 4
+
+
+def test_image_overlap_thresholds_validate_inputs(image_data):
+    """Image overlap gates require structured labels and valid class widths."""
+    with pytest.raises(ValueError, match="exactly 3 values"):
+        ImageClassificationLoss(3, min_iou=[0.5, 0.5])
+    with pytest.raises(ValueError, match="requires `num_classes`"):
+        ImageRegressionLoss(1, min_iou=[0.5])
+
+    objects = ImageObjectBuilder()(image_data)
+    prediction = TensorBatch(torch.zeros((2, 3)), counts=objects.counts)
+    with pytest.raises(TypeError, match="ClusterLabelBatch"):
+        ImageClassificationLoss(3, min_iou=0.5)([0, 1], objects, prediction)
+
+    regression = TensorBatch(torch.zeros((2, 1)), counts=objects.counts)
+    with pytest.raises(TypeError, match="ClusterLabelBatch"):
+        ImageRegressionLoss(1, min_iou=0.5)([0.0, 1.0], objects, regression)
+
+
+def test_image_regression_supports_class_dependent_overlap_thresholds(image_data):
+    """Regression gates may vary by a separate categorical truth field."""
+    objects = ImageObjectBuilder(source="cluster")(
+        image_data,
+        object_data=image_data,
+    )
+    predictions = TensorBatch(torch.zeros((4, 1)), counts=objects.counts)
+    thresholds = [0.0, 0.0, 0.75, 0.75, 0.0]
+
+    result = ImageRegressionLoss(
+        1,
+        target="momentum",
+        min_efficiency=thresholds,
+        quality_num_classes=5,
+    )(image_data, objects, predictions)
+
+    assert result["count"] == 2
+
+
+def test_image_overlap_quality_classes_must_be_scalar(image_data):
+    """Vector-valued fields cannot index class-dependent thresholds."""
+    objects = ImageObjectBuilder(source="cluster")(
+        image_data,
+        object_data=image_data,
+    )
+    predictions = TensorBatch(torch.zeros((4, 1)), counts=objects.counts)
+    loss = ImageRegressionLoss(
+        1,
+        target="momentum",
+        min_iou=[0.0, 0.0, 0.0],
+        quality_target="vertex",
+        quality_num_classes=3,
+    )
+
+    with pytest.raises(ValueError, match="scalar IDs"):
+        loss(image_data, objects, predictions)
 
 
 def test_ancestor_targets_use_root_particle_pid(image_data):
@@ -254,6 +369,8 @@ def test_structured_and_batched_targets_validate_required_shape(image_data):
 
     with pytest.raises(ValueError, match="named target"):
         ImageClassificationLoss(3)(image_data, objects, prediction)
+    with pytest.raises(TypeError, match="must be named fields"):
+        ImageClassificationLoss(3, target=0)(image_data, objects, prediction)
     with pytest.raises(ValueError, match="one row per image object"):
         ImageClassificationLoss(3)(
             TensorBatch(torch.tensor([0]), counts=[1]),


### PR DESCRIPTION
## Summary

- add maximum-intersection cluster matching with IoU, purity, and efficiency measurements
- add reusable scalar or class-dependent overlap policies and a forward-local GrapPA cache
- apply quality filtering to generic and specialized GrapPA node/edge losses and image classification/regression losses
- report count_rejected for otherwise valid targets removed specifically by quality filtering
- set the full-chain particle PID and primary policy to group IoU >= 0.5, replacing closest-fragment relabeling for particle-primary supervision
- leave standalone GrapPA and shower-fragment primary policies unchanged

## Policy

Training targets retain majority-vote semantics: the truth instance is selected by maximum voxel intersection, and all quality metrics are evaluated against that same match. Objects which fail an enabled quality requirement receive the ordinary ignored target.

## Full-chain profile

The six-event regression sample produced 79 reconstructed particles, including 76 with valid particle targets. Retention among valid targets was 89.5% at IoU 0.5, 78.9% at 0.8, 71.1% at 0.85, and 68.4% at 0.9. We selected 0.5 as a conservative initial default pending larger-scale studies.

## Validation

- full coverage suite: 3379 passed, 3 skipped; 32385 statements, 100% coverage
- updated full-chain repeatability and configuration contracts: 106 passed, 1 CUDA-only skip
- focused GrapPA/image quality tests: 55 passed
- Black, isort, flake8, YAML validation, pre-commit hooks, and diff checks pass